### PR TITLE
release: 0.1.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runsight-workspace"
-version = "0.1.7"
+version = "0.1.8"
 requires-python = ">=3.11"
 dependencies = []
 


### PR DESCRIPTION
## Summary
- Bump version to 0.1.8 to trigger first publish with correct OIDC config

## Test plan
- [ ] CI passes
- [ ] After merge, publish-pypi + publish-docker succeed
- [ ] `uvx runsight` serves the GUI at localhost:8000

🤖 Generated with [Claude Code](https://claude.com/claude-code)