### PR TITLE
fix: recover simulation workflow snapshots in editor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -269,3 +269,20 @@ Ask these questions in order:
 
 If the answer is still unclear, prefer the stricter boundary and document the
 decision in the change.
+
+## Release Process
+
+**Every PR that changes behavior must bump the version** in the root `pyproject.toml`.
+
+The `version` field in `pyproject.toml` (repo root) is the **single source of truth**. When a PR merges to main and the version has changed, CI automatically:
+1. Publishes both `runsight` and `runsight-core` to PyPI
+2. Builds and pushes Docker image to GHCR
+3. Creates a git tag `v{version}`
+
+Do NOT create git tags manually. Do NOT modify version fields in `apps/api/pyproject.toml` or `packages/core/pyproject.toml` — CI handles those.
+
+## Key Rules
+
+- Never run full test suites (pytest or vitest) — they consume ~4GB each and hang the machine. Target specific files only.
+- Styling: CVA + Tailwind + @theme tokens. No BEM, no mixing approaches.
+- Main branch = production. Simulation branches for testing uncommitted changes.

--- a/README.md
+++ b/README.md
@@ -203,6 +203,16 @@ uv run python -m pytest packages/core/tests/test_specific_file.py -v
 pnpm run lint
 ```
 
+## Releasing
+
+Version is controlled by a single field: `version` in the root `pyproject.toml`. To publish a new release:
+
+1. Bump `version` in `pyproject.toml` (e.g., `0.1.7` → `0.1.8`)
+2. Merge to main
+3. CI detects the version change → publishes PyPI + Docker → creates git tag `v0.1.8`
+
+No manual tagging needed. Every PR that changes behavior should include a version bump.
+
 ## License
 
 Apache 2.0 — see [LICENSE](LICENSE).

--- a/apps/gui/src/features/canvas/WorkflowSurface.tsx
+++ b/apps/gui/src/features/canvas/WorkflowSurface.tsx
@@ -14,13 +14,26 @@ import { EmptyState } from "@runsight/ui/empty-state";
 import { LayoutGrid } from "lucide-react";
 import { useCanvasStore } from "@/store/canvas";
 import { useWorkflow } from "@/queries/workflows";
+import { gitApi } from "@/api/git";
+
+function getOverlayRefFromLocation(): string | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  const overlayRef = new URLSearchParams(window.location.search).get("overlayRef");
+  return overlayRef && overlayRef.trim().length > 0 ? overlayRef : null;
+}
 
 export function WorkflowSurface({ mode: initialMode, workflowId: initialWorkflowId = "", runId: initialRunId }: WorkflowSurfaceProps) {
   const [mode, setMode] = useState<WorkflowSurfaceMode>(initialMode);
   const [workflowId, setWorkflowId] = useState(initialWorkflowId);
   const [activeRunId, setRunId] = useState(initialRunId);
   const [apiKeyModalOpen, setApiKeyModalOpen] = useState(false);
+  const [overlayYaml, setOverlayYaml] = useState<string | null>(null);
+  const [isOverlayLoading, setIsOverlayLoading] = useState(false);
   const queryClient = useQueryClient();
+  const overlayRef = getOverlayRefFromLocation();
 
   const handleForkTransition = useCallback((newWorkflowId: string) => {
     setMode("edit");
@@ -73,7 +86,44 @@ export function WorkflowSurface({ mode: initialMode, workflowId: initialWorkflow
   }, [toggleVisibility.yaml]);
 
   useEffect(() => {
+    let cancelled = false;
+
+    if (!workflowId || !overlayRef) {
+      setOverlayYaml(null);
+      setIsOverlayLoading(false);
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    setIsOverlayLoading(true);
+    gitApi
+      .getGitFile(overlayRef, `custom/workflows/${workflowId}.yaml`)
+      .then(({ content }) => {
+        if (cancelled) return;
+        setOverlayYaml(content);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setOverlayYaml(null);
+      })
+      .finally(() => {
+        if (cancelled) return;
+        setIsOverlayLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [overlayRef, workflowId]);
+
+  useEffect(() => {
     if (!workflowId || !workflow?.yaml) {
+      return;
+    }
+
+    if (overlayRef && overlayYaml !== null) {
+      setYamlContent(overlayYaml);
       return;
     }
 
@@ -97,6 +147,8 @@ export function WorkflowSurface({ mode: initialMode, workflowId: initialWorkflow
     workflow?.canvas_state,
     workflow?.yaml,
     workflowId,
+    overlayRef,
+    overlayYaml,
   ]);
 
   // Palette + inspector hidden — canvas coming soon
@@ -175,11 +227,18 @@ export function WorkflowSurface({ mode: initialMode, workflowId: initialWorkflow
             />
           </div>
         ) : activeTab === "yaml" ? (
-          <YamlEditor
-            workflowId={workflowId}
-            readOnly={!editable}
-            onDirtyChange={(dirty: boolean) => setIsDirty(dirty)}
-          />
+          isOverlayLoading ? (
+            <div className="flex h-full items-center justify-center text-muted">
+              Loading workflow snapshot...
+            </div>
+          ) : (
+            <YamlEditor
+              workflowId={workflowId}
+              yaml={overlayYaml ?? undefined}
+              readOnly={!editable}
+              onDirtyChange={(dirty: boolean) => setIsDirty(dirty)}
+            />
+          )
         ) : null}
       </div>
 

--- a/apps/gui/src/features/canvas/YamlEditor.tsx
+++ b/apps/gui/src/features/canvas/YamlEditor.tsx
@@ -16,25 +16,26 @@ interface YamlEditorProps {
 export function YamlEditor({ workflowId, yaml: yamlProp, readOnly = false, onDirtyChange, onValidation }: YamlEditorProps) {
   const { data: workflow } = useWorkflow(workflowId ?? "");
   const resolvedYaml = yamlProp ?? workflow?.yaml ?? "";
+  const [editorYaml, setEditorYaml] = useState(resolvedYaml);
   const [isDirty, setIsDirty] = useState(false);
   const contentRef = useRef(resolvedYaml);
   const { validate, setEditorRefs } = useYamlValidation(onValidation);
 
   useEffect(() => {
+    setEditorYaml(resolvedYaml);
+    contentRef.current = resolvedYaml;
+    setIsDirty(false);
+
     if (yamlProp != null) {
-      contentRef.current = yamlProp;
-      setIsDirty(false);
       useCanvasStore.getState().setYamlContent(yamlProp);
       useCanvasStore.getState().markSaved();
       return;
     }
     if (workflow?.yaml != null) {
-      contentRef.current = workflow.yaml;
-      setIsDirty(false);
       useCanvasStore.getState().setYamlContent(workflow.yaml);
       useCanvasStore.getState().markSaved();
     }
-  }, [yamlProp, workflow?.yaml]);
+  }, [resolvedYaml, yamlProp, workflow?.yaml]);
 
   useEffect(() => {
     onDirtyChange?.(isDirty);
@@ -49,7 +50,9 @@ export function YamlEditor({ workflowId, yaml: yamlProp, readOnly = false, onDir
   }
 
   function onChange(value: string | undefined) {
-    contentRef.current = value ?? "";
+    const nextValue = value ?? "";
+    contentRef.current = nextValue;
+    setEditorYaml(nextValue);
     setIsDirty(true);
     validate(contentRef.current);
     useCanvasStore.getState().setYamlContent(contentRef.current);
@@ -60,7 +63,7 @@ export function YamlEditor({ workflowId, yaml: yamlProp, readOnly = false, onDir
       <LazyMonacoEditor
         language="yaml"
         theme="runsight-yaml"
-        value={resolvedYaml}
+        value={editorYaml}
         height="100%"
         onChange={onChange}
         onMount={onMount}

--- a/apps/gui/src/features/canvas/__tests__/run812SimulationOverlayOpenWorkflow.test.ts
+++ b/apps/gui/src/features/canvas/__tests__/run812SimulationOverlayOpenWorkflow.test.ts
@@ -1,0 +1,132 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+
+const mocks = vi.hoisted(() => {
+  const store = {
+    nodes: [] as unknown[],
+    edges: [] as unknown[],
+    blockCount: 0,
+    edgeCount: 0,
+    yamlContent: "",
+    setYamlContent: vi.fn(),
+    hydrateFromPersisted: vi.fn(),
+  };
+
+  const useCanvasStore = ((selector: (state: typeof store) => unknown) =>
+    selector(store)) as {
+    (selector: (state: typeof store) => unknown): unknown;
+    getState: () => typeof store;
+  };
+  useCanvasStore.getState = () => store;
+
+  return {
+    getGitFile: vi.fn(),
+    yamlEditorProps: [] as Array<Record<string, unknown>>,
+    store,
+    useCanvasStore,
+  };
+});
+
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+
+vi.mock("@/queries/workflows", () => ({
+  useWorkflow: () => ({
+    data: {
+      id: "wf_test",
+      name: "Test Flow",
+      yaml: "workflow:\n  name: Live Flow\n",
+      canvas_state: null,
+      commit_sha: "live_sha",
+    },
+    isError: false,
+  }),
+}));
+
+vi.mock("@/api/git", () => ({
+  gitApi: {
+    getGitFile: mocks.getGitFile,
+  },
+}));
+
+vi.mock("@/store/canvas", () => ({
+  useCanvasStore: mocks.useCanvasStore,
+}));
+
+vi.mock("../CanvasTopbar", () => ({
+  CanvasTopbar: () => React.createElement("div", null, "topbar"),
+}));
+
+vi.mock("../YamlEditor", () => ({
+  YamlEditor: (props: Record<string, unknown>) => {
+    mocks.yamlEditorProps.push(props);
+    return React.createElement("div", null, "yaml-editor");
+  },
+}));
+
+vi.mock("../CanvasBottomPanel", () => ({
+  CanvasBottomPanel: () => React.createElement("div", null, "bottom-panel"),
+}));
+
+vi.mock("../CanvasStatusBar", () => ({
+  CanvasStatusBar: () => React.createElement("div", null, "status-bar"),
+}));
+
+vi.mock("@/components/provider/ProviderModal", () => ({
+  ProviderModal: () => React.createElement("div", null, "provider-modal"),
+}));
+
+vi.mock("@/features/git/CommitDialog", () => ({
+  CommitDialog: () => React.createElement("div", null, "commit-dialog"),
+}));
+
+vi.mock("@runsight/ui/empty-state", () => ({
+  EmptyState: () => React.createElement("div", null, "empty-state"),
+}));
+
+vi.mock("lucide-react", () => ({
+  LayoutGrid: () => React.createElement("div", null, "layout-grid"),
+}));
+
+import { WorkflowSurface } from "../WorkflowSurface";
+
+describe("WorkflowSurface simulation overlay recovery", () => {
+  beforeEach(() => {
+    mocks.getGitFile.mockReset();
+    mocks.getGitFile.mockResolvedValue({
+      content: "workflow:\n  name: Snapshot Flow\n",
+    });
+    mocks.yamlEditorProps.length = 0;
+    mocks.store.setYamlContent.mockReset();
+    mocks.store.hydrateFromPersisted.mockReset();
+    window.history.pushState({}, "", "/workflows/wf_test/edit?overlayRef=sim_sha&overlaySource=simulation");
+  });
+
+  afterEach(() => {
+    cleanup();
+    window.history.pushState({}, "", "/");
+  });
+
+  it("loads workflow YAML from the simulation snapshot into the existing editor route", async () => {
+    render(
+      React.createElement(
+        MemoryRouter,
+        undefined,
+        React.createElement(WorkflowSurface, { mode: "edit", workflowId: "wf_test" }),
+      ),
+    );
+
+    await waitFor(() => {
+      expect(mocks.getGitFile).toHaveBeenCalledWith("sim_sha", "custom/workflows/wf_test.yaml");
+    });
+
+    await waitFor(() => {
+      expect(mocks.yamlEditorProps.at(-1)?.yaml).toBe("workflow:\n  name: Snapshot Flow\n");
+    });
+  });
+});

--- a/apps/gui/src/features/runs/RunDetailHeader.tsx
+++ b/apps/gui/src/features/runs/RunDetailHeader.tsx
@@ -74,9 +74,18 @@ export function RunDetailHeader({
 
   const handleOpenWorkflow = useCallback(() => {
     if (run.workflow_id) {
+      if (run.source === "simulation" && run.commit_sha) {
+        const params = new URLSearchParams({
+          overlayRef: run.commit_sha,
+          overlaySource: "simulation",
+        });
+        navigate(`/workflows/${run.workflow_id}/edit?${params.toString()}`);
+        return;
+      }
+
       navigate(`/workflows/${run.workflow_id}/edit`);
     }
-  }, [navigate, run.workflow_id]);
+  }, [navigate, run.commit_sha, run.source, run.workflow_id]);
 
   const handleFork = useCallback(() => {
     if (forkDisabled || isForking) return;
@@ -143,7 +152,7 @@ export function RunDetailHeader({
               Cancel
             </Button>
           ) : null}
-          {run.workflow_id && !isActive ? (
+          {run.workflow_id ? (
             <Button
               variant="secondary"
               onClick={handleOpenWorkflow}

--- a/apps/gui/src/features/runs/__tests__/runDetailHeaderControls.test.ts
+++ b/apps/gui/src/features/runs/__tests__/runDetailHeaderControls.test.ts
@@ -51,22 +51,29 @@ function LocationEcho() {
 function buildRun({
   status = "completed",
   workflowId = "wf_research",
+  source = "manual",
 }: {
   status?: RunStatus;
   workflowId?: string | null;
+  source?: "manual" | "simulation";
 } = {}) {
   return {
     id: "run_123456",
     workflow_id: workflowId ?? undefined,
     workflow_name: "Research & Review",
     status,
+    source,
     commit_sha: "abc123def456",
     total_cost_usd: 0.123,
     total_tokens: 456,
   };
 }
 
-function renderHeader(options?: { status?: RunStatus; workflowId?: string | null }) {
+function renderHeader(options?: {
+  status?: RunStatus;
+  workflowId?: string | null;
+  source?: "manual" | "simulation";
+}) {
   const run = buildRun(options);
   const router = createMemoryRouter(
     [
@@ -157,15 +164,38 @@ describe("Run detail header controls (RUN-510)", () => {
   });
 
   it("shows a live cancel control for active runs and calls the cancel mutation", async () => {
-    const { user } = renderHeader({ status: "running" });
+    const { router, user } = renderHeader({ status: "running" });
 
     expect(screen.getByRole("button", { name: /cancel run/i })).toBeTruthy();
-    expect(screen.queryByRole("button", { name: /open workflow/i })).toBeNull();
+    expect(screen.getByRole("button", { name: /open workflow/i })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Fork" })).toBeTruthy();
 
     await user.click(screen.getByRole("button", { name: /cancel run/i }));
 
     expect(mocks.cancelRun).toHaveBeenCalledWith("run_123456");
+
+    await user.click(screen.getByRole("button", { name: /open workflow/i }));
+
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe("/workflows/wf_research/edit");
+      expect(router.state.location.search).toBe("");
+    });
+  });
+
+  it("opens the workflow editor with a snapshot overlay when launched from a simulation run", async () => {
+    const { router, user } = renderHeader({ status: "running", source: "simulation" });
+
+    expect(screen.getByRole("button", { name: /cancel run/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /open workflow/i })).toBeTruthy();
+
+    await user.click(screen.getByRole("button", { name: /open workflow/i }));
+
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe("/workflows/wf_research/edit");
+      expect(router.state.location.search).toContain("overlayRef=abc123def456");
+      expect(router.state.location.search).toContain("overlaySource=simulation");
+    });
+    expect(mocks.forkWorkflow).not.toHaveBeenCalled();
   });
 
   it("opens the new forked workflow editor after forking from a run", async () => {

--- a/apps/gui/src/features/setup/SetupStartPage.tsx
+++ b/apps/gui/src/features/setup/SetupStartPage.tsx
@@ -59,7 +59,7 @@ export function Component() {
             label="Start with a template"
             title="Tutorial Template"
             badge={<Badge variant="accent">Recommended</Badge>}
-            description="A 3-block workflow with 2 AI agents. Research a topic, write a summary, and quality-check the output."
+            description="A looped starter workflow with inline souls. It drafts a research brief, writes it to custom/outputs, and emits an error stub if review still fails."
             footer={
               <div className="flex items-center gap-1 font-mono text-2xs text-muted pt-3 border-t border-neutral-3">
                 <span

--- a/apps/gui/src/features/setup/__tests__/run575_templateAlignment.test.ts
+++ b/apps/gui/src/features/setup/__tests__/run575_templateAlignment.test.ts
@@ -1,65 +1,40 @@
-/**
- * RED-TEAM tests for RUN-575: Align default workflow template with library-only souls.
- *
- * After RUN-570 killed inline souls in the schema, the default template YAML
- * (TEMPLATE_YAML in features/setup/constants.ts) must be updated:
- *   - AC1: No `souls:` section in the template
- *   - AC2: `soul_ref` values still reference researcher, writer, reviewer
- *          (now resolved from custom/souls/ library files, not inline)
- *
- * All tests should FAIL until the template constant is rewritten.
- */
-
 import { describe, it, expect } from "vitest";
+import { parse } from "yaml";
 import { TEMPLATE_YAML } from "../constants";
 
-// ---------------------------------------------------------------------------
-// AC1: TEMPLATE_YAML must NOT contain a `souls:` section
-// ---------------------------------------------------------------------------
+function parseTemplate(): Record<string, any> {
+  return parse(TEMPLATE_YAML) as Record<string, any>;
+}
 
-describe("RUN-575 AC1: template has no inline souls section", () => {
-  it("does not contain a top-level souls: key", () => {
-    // A top-level `souls:` key means inline soul definitions are still present.
-    // After RUN-575, the template should have NO `souls:` section at all.
-    const hasSoulsSection = /^souls:/m.test(TEMPLATE_YAML);
-    expect(hasSoulsSection).toBe(false);
+describe("onboarding template alignment", () => {
+  it("uses inline souls instead of library soul files", () => {
+    expect(TEMPLATE_YAML).toMatch(/^souls:/m);
+    expect(TEMPLATE_YAML).toMatch(/^\s+system_prompt:/m);
+    expect(TEMPLATE_YAML).not.toMatch(/soul_ref:\s*writer/);
   });
 
-  it("does not contain any system_prompt fields (inline soul artifact)", () => {
-    // system_prompt is a field inside inline soul definitions.
-    // If the template still has system_prompt, it still has inline souls.
-    expect(TEMPLATE_YAML).not.toMatch(/system_prompt:/);
-  });
-
-  it("does not contain any role fields under a souls section", () => {
-    // role: is another inline-soul field that should disappear
-    // when the souls: section is removed. We check specifically for
-    // the pattern of `role:` indented under what would be a soul definition.
-    expect(TEMPLATE_YAML).not.toMatch(/^\s+role:\s+/m);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// AC2: TEMPLATE_YAML still uses soul_ref for researcher, writer, reviewer
-// ---------------------------------------------------------------------------
-
-describe("RUN-575 AC2: template soul_ref values point to library souls", () => {
-  it("has soul_ref: researcher in the research block", () => {
-    // The research block must still reference the researcher soul via soul_ref.
-    // After the migration, this resolves against custom/souls/researcher.yaml.
+  it("references only the inline souls used by the starter flow", () => {
     expect(TEMPLATE_YAML).toMatch(/soul_ref:\s*researcher/);
-  });
-
-  it("has soul_ref: writer in the write_summary block", () => {
-    expect(TEMPLATE_YAML).toMatch(/soul_ref:\s*writer/);
-  });
-
-  it("has soul_ref: reviewer in the quality_review block", () => {
     expect(TEMPLATE_YAML).toMatch(/soul_ref:\s*reviewer/);
+    expect(TEMPLATE_YAML).toMatch(/soul_ref:\s*error_writer/);
+    expect(TEMPLATE_YAML.match(/soul_ref:/g) ?? []).toHaveLength(3);
   });
 
-  it("contains exactly 3 soul_ref declarations", () => {
-    const soulRefMatches = TEMPLATE_YAML.match(/soul_ref:/g) ?? [];
-    expect(soulRefMatches).toHaveLength(3);
+  it("whitelists file_io on the workflow and requires it in the two writer souls", () => {
+    const parsed = parseTemplate();
+    expect(parsed.tools).toEqual(["file_io"]);
+    expect(parsed.souls?.researcher?.required_tool_calls).toEqual(["file_io"]);
+    expect(parsed.souls?.error_writer?.required_tool_calls).toEqual(["file_io"]);
+  });
+
+  it("keeps the template artifact-first by targeting custom/outputs", () => {
+    expect(TEMPLATE_YAML).toContain("custom/outputs/onboarding-research-brief.md");
+    expect(TEMPLATE_YAML).toContain("custom/outputs/onboarding-research-error.md");
+  });
+
+  it("contains loud provider/model placeholders so users know config is required", () => {
+    expect(TEMPLATE_YAML).toContain("PLACEHOLDER_PROVIDER_ID");
+    expect(TEMPLATE_YAML).toContain("PLACEHOLDER_MODEL_NAME");
+    expect(TEMPLATE_YAML).toContain("REQUIRED BEFORE RUNNING");
   });
 });

--- a/apps/gui/src/features/setup/__tests__/templateYaml.test.ts
+++ b/apps/gui/src/features/setup/__tests__/templateYaml.test.ts
@@ -1,134 +1,126 @@
-/**
- * RED-TEAM tests for RUN-353: Hello-world template "Research & Review" YAML.
- *
- * These tests verify the TEMPLATE_YAML constant exported from
- * features/setup/constants.ts. The constant should contain a valid
- * Runsight workflow YAML with:
- *   - 3 inline souls: researcher, writer, reviewer
- *   - 3 blocks: research (linear), write_summary (linear), quality_review (gate)
- *   - 2 transitions: research->write_summary, write_summary->quality_review
- *   - Gate block with eval_key pointing to writer output
- *
- * Expected failures: constants.ts does not exist yet, so the import will fail.
- */
-
 import { describe, it, expect } from "vitest";
-
-// This import will fail until the constant is implemented.
-// @ts-expect-error — module does not exist yet
+import { parse } from "yaml";
+import { parseWorkflowYamlToGraph } from "@/features/canvas/yamlParser";
 import { TEMPLATE_YAML } from "../constants";
 
-// ---------------------------------------------------------------------------
-// 1. Export and basic shape
-// ---------------------------------------------------------------------------
+function parseTemplate(): Record<string, any> {
+  return parse(TEMPLATE_YAML) as Record<string, any>;
+}
 
 describe("TEMPLATE_YAML export", () => {
-  it("is exported from features/setup/constants.ts", () => {
-    expect(TEMPLATE_YAML).toBeDefined();
-  });
-
-  it("is a non-empty string", () => {
+  it("is a non-empty workflow YAML string", () => {
     expect(typeof TEMPLATE_YAML).toBe("string");
     expect(TEMPLATE_YAML.length).toBeGreaterThan(0);
-  });
-
-  it("contains version 1.0", () => {
     expect(TEMPLATE_YAML).toMatch(/version:\s*['"]?1\.0['"]?/);
   });
 });
 
-// ---------------------------------------------------------------------------
-// 2. Soul references (library-only, no inline souls after RUN-575)
-// ---------------------------------------------------------------------------
-
-describe("TEMPLATE_YAML soul references", () => {
-  it("references researcher via soul_ref", () => {
-    expect(TEMPLATE_YAML).toMatch(/soul_ref:\s*researcher/);
+describe("TEMPLATE_YAML flow-level wiring", () => {
+  it("declares file_io once at the workflow level", () => {
+    const parsed = parseTemplate();
+    expect(parsed.tools).toEqual(["file_io"]);
   });
 
-  it("references writer via soul_ref", () => {
-    expect(TEMPLATE_YAML).toMatch(/soul_ref:\s*writer/);
+  it("defines inline souls for research, review, and fallback writing", () => {
+    const parsed = parseTemplate();
+    expect(Object.keys(parsed.souls ?? {})).toEqual([
+      "researcher",
+      "reviewer",
+      "error_writer",
+    ]);
   });
 
-  it("references reviewer via soul_ref", () => {
-    expect(TEMPLATE_YAML).toMatch(/soul_ref:\s*reviewer/);
+  it("only grants file_io to the inline souls that need to write files", () => {
+    const parsed = parseTemplate();
+    expect(parsed.souls?.researcher?.tools).toEqual(["file_io"]);
+    expect(parsed.souls?.researcher?.required_tool_calls).toEqual(["file_io"]);
+    expect(parsed.souls?.error_writer?.tools).toEqual(["file_io"]);
+    expect(parsed.souls?.error_writer?.required_tool_calls).toEqual(["file_io"]);
+    expect(parsed.souls?.reviewer?.tools).toBeUndefined();
   });
 
-  it("does not contain an inline souls section", () => {
-    expect(TEMPLATE_YAML).not.toMatch(/^souls:/m);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// 3. Block definitions
-// ---------------------------------------------------------------------------
-
-describe("TEMPLATE_YAML block definitions", () => {
-  it("defines a research block", () => {
-    expect(TEMPLATE_YAML).toMatch(/blocks:\s*\n(\s+.*\n)*?\s+research:/);
-  });
-
-  it("defines a write_summary block", () => {
-    expect(TEMPLATE_YAML).toMatch(/\bwrite_summary:/);
-  });
-
-  it("defines a quality_review block", () => {
-    expect(TEMPLATE_YAML).toMatch(/\bquality_review:/);
-  });
-
-  it("contains exactly 3 block definitions under the blocks key", () => {
-    const blocksMatch = TEMPLATE_YAML.match(
-      /^blocks:\s*\n((?:[ \t]+.*\n)*)/m,
-    );
-    expect(blocksMatch).not.toBeNull();
-    const blocksBlock = blocksMatch![1];
-    const blockKeys = blocksBlock.match(/^ {2}\w+:/gm) ?? [];
-    expect(blockKeys).toHaveLength(3);
-  });
-
-  it("quality_review block has type: gate", () => {
-    // After quality_review: there should be a type: gate within a few lines
-    expect(TEMPLATE_YAML).toMatch(/quality_review:\s*\n\s+type:\s*gate/);
-  });
-
-  it("quality_review block has eval_key: write_summary", () => {
-    expect(TEMPLATE_YAML).toMatch(/eval_key:\s*write_summary/);
-  });
-
-  it("quality_review block references reviewer soul", () => {
-    expect(TEMPLATE_YAML).toMatch(
-      /quality_review:\s*\n(?:\s+.*\n)*?\s+soul_ref:\s*reviewer/,
-    );
+  it("uses explicit provider/model placeholders instead of shipping runnable defaults", () => {
+    const parsed = parseTemplate();
+    expect(parsed.souls?.researcher?.provider).toBe("PLACEHOLDER_PROVIDER_ID");
+    expect(parsed.souls?.researcher?.model_name).toBe("PLACEHOLDER_MODEL_NAME");
+    expect(parsed.souls?.researcher?.temperature).toBe(1);
+    expect(parsed.souls?.reviewer?.provider).toBe("PLACEHOLDER_PROVIDER_ID");
+    expect(parsed.souls?.reviewer?.model_name).toBe("PLACEHOLDER_MODEL_NAME");
+    expect(parsed.souls?.reviewer?.temperature).toBe(1);
+    expect(parsed.souls?.error_writer?.provider).toBe("PLACEHOLDER_PROVIDER_ID");
+    expect(parsed.souls?.error_writer?.model_name).toBe("PLACEHOLDER_MODEL_NAME");
+    expect(parsed.souls?.error_writer?.temperature).toBe(1);
   });
 });
 
-// ---------------------------------------------------------------------------
-// 4. Workflow section
-// ---------------------------------------------------------------------------
-
-describe("TEMPLATE_YAML workflow section", () => {
-  it("has entry: research", () => {
-    expect(TEMPLATE_YAML).toMatch(/entry:\s*research/);
+describe("TEMPLATE_YAML block graph", () => {
+  it("defines the expected onboarding starter blocks", () => {
+    const parsed = parseTemplate();
+    expect(Object.keys(parsed.blocks ?? {})).toEqual([
+      "draft_report",
+      "quality_gate",
+      "review_loop",
+      "check_review_status",
+      "write_error_stub",
+      "finish",
+    ]);
   });
 
-  it("has a workflow name containing 'Research'", () => {
-    expect(TEMPLATE_YAML).toMatch(/name:.*Research/);
+  it("puts the researcher and gate inside a loop with retry semantics", () => {
+    const parsed = parseTemplate();
+    expect(parsed.blocks?.review_loop).toMatchObject({
+      type: "loop",
+      inner_block_refs: ["draft_report", "quality_gate"],
+      max_rounds: 2,
+      break_on_exit: "pass",
+      retry_on_exit: "fail",
+      error_route: "write_error_stub",
+    });
+    expect(parsed.blocks?.review_loop?.carry_context).toMatchObject({
+      enabled: true,
+      mode: "all",
+      source_blocks: ["draft_report", "quality_gate"],
+      inject_as: "previous_round_context",
+    });
   });
 
-  it("has transition from research to write_summary", () => {
-    expect(TEMPLATE_YAML).toMatch(
-      /from:\s*research\s*\n\s+to:\s*write_summary/,
-    );
+  it("branches through review status before choosing finish vs error stub", () => {
+    const parsed = parseTemplate();
+    expect(parsed.workflow).toMatchObject({
+      name: "Research & Review",
+      entry: "review_loop",
+    });
+    expect(parsed.workflow?.transitions).toEqual([
+      { from: "review_loop", to: "check_review_status" },
+      { from: "write_error_stub", to: "finish" },
+    ]);
+    expect(parsed.workflow?.conditional_transitions).toEqual([
+      {
+        from: "check_review_status",
+        pass: "finish",
+        fail: "write_error_stub",
+        default: "write_error_stub",
+      },
+    ]);
   });
 
-  it("has transition from write_summary to quality_review", () => {
-    expect(TEMPLATE_YAML).toMatch(
-      /from:\s*write_summary\s*\n\s+to:\s*quality_review/,
-    );
+  it("declares success and fallback artifact paths in the template", () => {
+    expect(TEMPLATE_YAML).toContain("custom/outputs/onboarding-research-brief.md");
+    expect(TEMPLATE_YAML).toContain("custom/outputs/onboarding-research-error.md");
   });
+});
 
-  it("has exactly 2 transitions", () => {
-    const transitionMatches = TEMPLATE_YAML.match(/- from:/g) ?? [];
-    expect(transitionMatches).toHaveLength(2);
+describe("TEMPLATE_YAML parses in the canvas graph", () => {
+  it("produces six nodes with no parser error", () => {
+    const result = parseWorkflowYamlToGraph(TEMPLATE_YAML);
+    expect(result.error).toBeUndefined();
+    expect(result.nodes.map((node) => node.id)).toEqual([
+      "draft_report",
+      "quality_gate",
+      "review_loop",
+      "check_review_status",
+      "write_error_stub",
+      "finish",
+    ]);
   });
 });

--- a/apps/gui/src/features/setup/constants.ts
+++ b/apps/gui/src/features/setup/constants.ts
@@ -1,22 +1,142 @@
 export const TEMPLATE_YAML = `\
 version: '1.0'
+tools:
+  - file_io
+# REQUIRED BEFORE RUNNING:
+# - Replace every PLACEHOLDER_PROVIDER_ID with one of your configured provider ids.
+# - Replace every PLACEHOLDER_MODEL_NAME with a model that belongs to that provider.
+# - Temperature defaults to 1 below. If your chosen model does not support temperature,
+#   remove the temperature line for that soul.
+souls:
+  researcher:
+    id: researcher
+    role: Research File Writer
+    system_prompt: >
+      You are a fast research assistant.
+      Use the user's task as the topic. If the task is blank or too generic,
+      default to "Runsight onboarding starter workflow".
+      Produce a concise markdown research note with a title, 3 to 5 concrete bullets,
+      and a short "Next steps" section.
+      If previous_round_context appears in the provided context, use it to improve the draft.
+      Before finishing, you MUST call the file_io tool to write the markdown to
+      custom/outputs/onboarding-research-brief.md.
+      After the tool call succeeds, return the same markdown.
+    tools:
+      - file_io
+    required_tool_calls:
+      - file_io
+    max_tool_iterations: 4
+    provider: PLACEHOLDER_PROVIDER_ID
+    model_name: PLACEHOLDER_MODEL_NAME
+    temperature: 1
+    avatar_color: info
+  reviewer:
+    id: reviewer
+    role: Quality Gate Reviewer
+    system_prompt: >
+      Review the draft research note.
+      Return PASS if it is specific, structured, and actionable.
+      Return FAIL: followed by one short paragraph of concrete fixes if it is too vague,
+      generic, or missing the required structure.
+    max_tool_iterations: 3
+    provider: PLACEHOLDER_PROVIDER_ID
+    model_name: PLACEHOLDER_MODEL_NAME
+    temperature: 1
+    avatar_color: accent
+  error_writer:
+    id: error_writer
+    role: Error Stub Writer
+    system_prompt: >
+      This block only runs after the review flow fails or errors.
+      Write a short markdown stub to custom/outputs/onboarding-research-error.md.
+      The stub should explain that the workflow did not produce a verified report yet
+      and that the operator should inspect the latest run details.
+      Before finishing, you MUST call the file_io tool to write the stub file.
+      After the tool call succeeds, return one sentence with the file path.
+    tools:
+      - file_io
+    required_tool_calls:
+      - file_io
+    max_tool_iterations: 3
+    provider: PLACEHOLDER_PROVIDER_ID
+    model_name: PLACEHOLDER_MODEL_NAME
+    temperature: 1
+    avatar_color: warning
 blocks:
-  research:
+  draft_report:
     type: linear
     soul_ref: researcher
-  write_summary:
-    type: linear
-    soul_ref: writer
-  quality_review:
+  quality_gate:
     type: gate
     soul_ref: reviewer
-    eval_key: write_summary
+    eval_key: draft_report
+  review_loop:
+    type: loop
+    inner_block_refs:
+      - draft_report
+      - quality_gate
+    max_rounds: 2
+    break_on_exit: pass
+    retry_on_exit: fail
+    carry_context:
+      enabled: true
+      mode: all
+      source_blocks:
+        - draft_report
+        - quality_gate
+      inject_as: previous_round_context
+    error_route: write_error_stub
+  check_review_status:
+    type: code
+    timeout_seconds: 10
+    code: |
+      def main(data):
+          loop_meta = data["shared_memory"].get("__loop__review_loop", {}) or {}
+          break_reason = str(loop_meta.get("break_reason", ""))
+          passed = "pass" in break_reason
+          return {
+              "status": "pass" if passed else "fail",
+              "break_reason": break_reason,
+              "exit_handle": "pass" if passed else "fail",
+          }
+  write_error_stub:
+    type: linear
+    soul_ref: error_writer
+  finish:
+    type: code
+    timeout_seconds: 10
+    code: |
+      import json
+
+      def _normalize(raw):
+          if isinstance(raw, dict):
+              return raw
+          if isinstance(raw, str):
+              try:
+                  return json.loads(raw)
+              except Exception:
+                  return {"raw": raw}
+          return {"raw": raw}
+
+      def main(data):
+          return {
+              "status": "completed",
+              "report_path": "custom/outputs/onboarding-research-brief.md",
+              "error_stub_path": "custom/outputs/onboarding-research-error.md",
+              "review_status": _normalize(data["results"].get("check_review_status", "")),
+              "error_stub": _normalize(data["results"].get("write_error_stub", "")),
+          }
 workflow:
   name: Research & Review
-  entry: research
+  entry: review_loop
   transitions:
-    - from: research
-      to: write_summary
-    - from: write_summary
-      to: quality_review
+    - from: review_loop
+      to: check_review_status
+    - from: write_error_stub
+      to: finish
+  conditional_transitions:
+    - from: check_review_status
+      pass: finish
+      fail: write_error_stub
+      default: write_error_stub
 `;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runsight-workspace"
-version = "0.1.7"
+version = "0.1.8"
 requires-python = ">=3.11"
 dependencies = []
 


### PR DESCRIPTION
## Summary
- make `Open Workflow` open the live editor with a git snapshot overlay for simulation runs instead of creating a new workflow file
- load simulation snapshot YAML into the workflow editor without changing the normal production-run path
- update the onboarding template to use inline placeholders with temperature set to `1`

## Verification
- pnpm -C apps/gui exec vitest run --config vitest.unit.config.ts src/features/runs/__tests__/runDetailHeaderControls.test.ts src/features/runs/__tests__/run509RunDetailWorkflowNavigation.test.ts src/features/canvas/__tests__/run812SimulationOverlayOpenWorkflow.test.ts
- pnpm -C apps/gui exec vitest run --config vitest.unit.config.ts src/features/setup/__tests__/templateYaml.test.ts src/features/setup/__tests__/run575_templateAlignment.test.ts src/features/setup/__tests__/setupStartPage.test.ts
- uv run --project packages/core python ... parse_workflow_yaml(...)