### PR TITLE
fix: include frontend in PyPI wheel

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -93,7 +93,12 @@ jobs:
           python-version: "3.13"
       - run: pip install build
       - run: python -m build packages/core -o dist/
-      - run: python -m build apps/api -o dist/
+      - name: Build runsight wheel (with bundled frontend)
+        run: |
+          python -m build --wheel apps/api -o dist/
+          python -m build --sdist apps/api -o dist/
+          echo "--- Wheel contents (static check) ---"
+          python -c "import zipfile,glob; whl=glob.glob('dist/runsight-*.whl')[0]; files=[f for f in zipfile.ZipFile(whl).namelist() if 'static' in f]; print(f'{len(files)} static files in wheel'); [print(f) for f in files[:5]]"
 
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runsight-workspace"
-version = "0.1.8"
+version = "0.1.9"
 requires-python = ">=3.11"
 dependencies = []
 


### PR DESCRIPTION
## Summary
- Build wheel directly from source (`--wheel`) instead of from sdist, so hatchling `artifacts` config includes `static/**`
- Previous builds produced 472KB wheels (Python only). This should produce ~5MB+ (with frontend)
- Bump to 0.1.9

## Root cause
`python -m build` defaults to: sdist → wheel-from-sdist. The sdist step strips artifact files, so the wheel built from it also lacks them. Building `--wheel` separately goes straight from source.

## Test plan
- [ ] CI passes
- [ ] Wheel contents log shows static files
- [ ] `uvx runsight` serves GUI at localhost:8000

🤖 Generated with [Claude Code](https://claude.com/claude-code)