### PR TITLE
fix: include frontend in PyPI wheel (no-isolation)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,14 +91,14 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
-      - run: pip install build
+      - run: pip install build hatchling setuptools
       - run: python -m build packages/core -o dist/
       - name: Build runsight wheel (with bundled frontend)
         run: |
-          python -m build --wheel apps/api -o dist/
-          python -m build --sdist apps/api -o dist/
+          python -m build --no-isolation --wheel apps/api -o dist/
+          python -m build --no-isolation --sdist apps/api -o dist/
           echo "--- Wheel contents (static check) ---"
-          python -c "import zipfile,glob; whl=glob.glob('dist/runsight-*.whl')[0]; files=[f for f in zipfile.ZipFile(whl).namelist() if 'static' in f]; print(f'{len(files)} static files in wheel'); [print(f) for f in files[:5]]"
+          python -c "import zipfile,glob; whl=glob.glob('dist/runsight-*.whl')[0]; files=[f for f in zipfile.ZipFile(whl).namelist() if 'static' in f]; print(f'{len(files)} static files in wheel'); assert len(files) > 10, 'Frontend not bundled!'"
 
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runsight-workspace"
-version = "0.1.9"
+version = "0.1.10"
 requires-python = ">=3.11"
 dependencies = []
 


### PR DESCRIPTION
## Summary
- Use `--no-isolation` flag so `python -m build` uses the working tree directly (where `cp -r` placed frontend files) instead of creating an isolated VCS copy that strips untracked files
- Pre-install `hatchling` and `setuptools` (required when skipping isolation)
- Added assertion: build fails if `< 10` static files in wheel
- Bump to 0.1.10

## Root cause
`python -m build` (even with `--wheel`) creates an isolated build environment by copying source via VCS. The frontend static files are untracked (just copied by `cp -r`), so they get stripped. Local build works because the files exist in the working tree and `--no-isolation` was implicitly the case.

## Test plan
- [ ] CI passes
- [ ] Wheel contents assertion passes (>10 static files)
- [ ] `uvx runsight` serves GUI at localhost:8000

🤖 Generated with [Claude Code](https://claude.com/claude-code)