### PR TITLE
[EPIC] RUN-769 Custom assertions via YAML + Python

### DIFF
--- a/apps/api/src/runsight_api/logic/observers/eval_observer.py
+++ b/apps/api/src/runsight_api/logic/observers/eval_observer.py
@@ -3,9 +3,8 @@
 import logging
 from typing import Any, Dict, List, Optional
 
-from runsight_core.assertions.base import AssertionContext, GradingResult
-from runsight_core.assertions.registry import NOT_PREFIX, _apply_transform, _get_handler
-from runsight_core.assertions.scoring import AssertionsResult
+from runsight_core.assertions.base import AssertionContext
+from runsight_core.assertions.registry import run_assertions_sync
 from runsight_core.observer import compute_prompt_hash, compute_soul_version
 from runsight_core.primitives import Soul
 from runsight_core.state import BlockResult, WorkflowState
@@ -15,80 +14,6 @@ from runsight_api.data.repositories.run_repo import RunRepository
 from runsight_api.domain.entities.run import RunNode
 
 logger = logging.getLogger(__name__)
-
-
-def _run_assertion_sync(
-    *,
-    type: str,
-    output: str,
-    context: AssertionContext,
-    value: Any = "",
-    threshold: float | None = None,
-    weight: float = 1.0,
-    transform: str | None = None,
-) -> GradingResult:
-    """Dispatch a single assertion synchronously, forwarding all kwargs to the handler."""
-    if transform is not None:
-        transformed = _apply_transform(transform, output)
-        if isinstance(transformed, GradingResult):
-            return transformed
-        output = transformed
-
-    negated = type.startswith(NOT_PREFIX)
-    base_type = type[len(NOT_PREFIX) :] if negated else type
-
-    handler_cls = _get_handler(base_type)
-    try:
-        handler = handler_cls(value=value, threshold=threshold)
-    except TypeError:
-        try:
-            handler = handler_cls(value=value)
-        except TypeError:
-            handler = handler_cls()
-    result = handler.evaluate(output, context)
-
-    if negated:
-        return GradingResult(
-            passed=not result.passed,
-            score=1.0 - result.score,
-            reason=result.reason,
-            named_scores=result.named_scores,
-            tokens_used=result.tokens_used,
-            component_results=result.component_results,
-            assertion_type=result.assertion_type,
-            metadata=result.metadata,
-        )
-
-    return result
-
-
-def _run_assertions_sync(
-    config: List[Dict[str, Any]],
-    *,
-    output: str,
-    context: AssertionContext,
-) -> AssertionsResult:
-    """Run a list of assertion configs synchronously and return aggregated results."""
-    agg = AssertionsResult()
-    if not config:
-        return agg
-
-    for cfg in config:
-        weight = cfg.get("weight", 1.0)
-        result = _run_assertion_sync(
-            type=cfg["type"],
-            output=output,
-            context=context,
-            value=cfg.get("value", ""),
-            threshold=cfg.get("threshold"),
-            weight=weight,
-            transform=cfg.get("transform"),
-        )
-        if cfg.get("metric"):
-            result.named_scores[cfg["metric"]] = result.score
-        agg.add_result(result, weight=weight)
-
-    return agg
 
 
 class EvalObserver:
@@ -223,7 +148,7 @@ class EvalObserver:
         )
 
         # Run assertions synchronously
-        assertion_result = _run_assertions_sync(block_configs, output=output, context=context)
+        assertion_result = run_assertions_sync(block_configs, output=output, context=context)
         eval_score = assertion_result.aggregate_score
         eval_passed = assertion_result.passed()
 

--- a/apps/api/src/runsight_api/logic/services/execution_service.py
+++ b/apps/api/src/runsight_api/logic/services/execution_service.py
@@ -202,6 +202,7 @@ class ExecutionService:
                 workflow_registry=workflow_registry,
                 api_keys=api_keys,
                 runner=runner,
+                _base_dir=str(self.workflow_repo.base_path),
             )
 
             # Store branch + commit_sha on Run record

--- a/apps/api/tests/logic/test_eval_observer.py
+++ b/apps/api/tests/logic/test_eval_observer.py
@@ -13,7 +13,9 @@ Tests target the new EvalObserver that lives in the CompositeObserver chain:
 All tests should FAIL until the implementation exists.
 """
 
+import ast
 import asyncio
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -169,6 +171,27 @@ class TestEvalObserverImport:
             assertion_configs={"block_a": [{"type": "contains", "value": "x"}]},
         )
         assert obs is not None
+
+    def test_module_uses_public_registry_sync_runner(self):
+        """EvalObserver should depend on the shared registry sync runner, not local duplicates."""
+        import runsight_api.logic.observers.eval_observer as eval_observer_module
+        from runsight_core.assertions import registry as assertion_registry
+
+        source = Path(eval_observer_module.__file__).read_text()
+        tree = ast.parse(source)
+        defined_functions = {
+            node.name
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        }
+
+        assert hasattr(assertion_registry, "run_assertions_sync")
+        assert "_run_assertion_sync" not in defined_functions
+        assert "_run_assertions_sync" not in defined_functions
+        assert (
+            getattr(eval_observer_module, "run_assertions_sync")
+            is assertion_registry.run_assertions_sync
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/apps/api/tests/logic/test_run800_eval_observer_custom_assertion.py
+++ b/apps/api/tests/logic/test_run800_eval_observer_custom_assertion.py
@@ -1,0 +1,261 @@
+"""RUN-800: EvalObserver integration coverage for custom assertions with config."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from textwrap import dedent
+from typing import Any
+
+import pytest
+import runsight_core.assertions.deterministic  # noqa: F401
+import yaml
+from runsight_core.primitives import Soul
+from runsight_core.state import BlockResult, WorkflowState
+from runsight_core.yaml.discovery import AssertionScanner
+from sqlmodel import Session, SQLModel, create_engine
+
+from runsight_api.domain.entities.run import Run, RunNode, RunStatus
+from runsight_api.logic.observers.eval_observer import EvalObserver
+
+
+def _write_yaml(path: Path, data: dict[str, Any]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+    return path
+
+
+def _write_assertion(
+    base_dir: Path,
+    *,
+    stem: str,
+    returns: str,
+    code: str,
+    params: dict[str, Any] | None = None,
+) -> None:
+    assertions_dir = base_dir / "custom" / "assertions"
+    assertions_dir.mkdir(parents=True, exist_ok=True)
+    manifest = {
+        "version": "1.0",
+        "name": stem.replace("_", " ").title(),
+        "description": f"Custom assertion {stem}",
+        "returns": returns,
+        "source": f"{stem}.py",
+    }
+    if params is not None:
+        manifest["params"] = params
+    _write_yaml(assertions_dir / f"{stem}.yaml", manifest)
+    (assertions_dir / f"{stem}.py").write_text(dedent(code), encoding="utf-8")
+
+
+@pytest.fixture
+def db_engine():
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+    return engine
+
+
+@pytest.fixture
+def run_with_node(db_engine):
+    run_id = "run_800_custom_eval"
+    with Session(db_engine) as session:
+        run = Run(
+            id=run_id,
+            workflow_id="wf_custom_eval",
+            workflow_name="custom_eval_workflow",
+            status=RunStatus.pending,
+            task_json="{}",
+        )
+        node = RunNode(
+            id=f"{run_id}:analyze",
+            run_id=run_id,
+            node_id="analyze",
+            block_type="LinearBlock",
+            status="completed",
+            cost_usd=0.02,
+            tokens={"total": 128},
+            output="calm response",
+        )
+        session.add(run)
+        session.add(node)
+        session.commit()
+    return db_engine, run_id
+
+
+@pytest.fixture
+def sse_queue():
+    return asyncio.Queue()
+
+
+@pytest.fixture
+def sample_soul():
+    return Soul(
+        id="analyst_v1",
+        role="Analyst",
+        system_prompt="You are calm and precise.",
+        model_name="gpt-4o",
+    )
+
+
+@pytest.fixture
+def sample_state():
+    return WorkflowState(
+        total_cost_usd=0.02,
+        total_tokens=128,
+        results={"analyze": BlockResult(output="calm response")},
+    )
+
+
+def _register_custom_assertions(base_dir: Path):
+    from runsight_core.assertions.registry import register_custom_assertions
+
+    register_custom_assertions(AssertionScanner(base_dir).scan())
+
+
+class TestEvalObserverCustomAssertions:
+    def test_eval_observer_persists_promptfoo_custom_assertion_and_emits_sse(
+        self,
+        tmp_path: Path,
+        run_with_node,
+        sse_queue,
+        sample_state,
+        sample_soul,
+    ):
+        _write_assertion(
+            tmp_path,
+            stem="tone_check",
+            returns="grading_result",
+            code="""
+            def get_assert(output, context):
+                cfg = context.get("config", {})
+                return {
+                    "pass": output.startswith(cfg.get("prefix", "")),
+                    "score": 0.9,
+                    "reason": f"prefix={cfg.get('prefix', '')}",
+                }
+            """,
+        )
+        _register_custom_assertions(tmp_path)
+        engine, run_id = run_with_node
+        obs = EvalObserver(
+            engine=engine,
+            run_id=run_id,
+            sse_queue=sse_queue,
+            assertion_configs={
+                "analyze": [{"type": "custom:tone_check", "config": {"prefix": "calm"}}]
+            },
+        )
+
+        obs.on_block_complete(
+            "custom_eval_workflow", "analyze", "LinearBlock", 1.0, sample_state, soul=sample_soul
+        )
+
+        with Session(engine) as session:
+            node = session.get(RunNode, f"{run_id}:analyze")
+            assert node.eval_passed is True
+            assert node.eval_score == pytest.approx(0.9)
+            assert node.eval_results["assertions"][0]["type"] == "custom:tone_check"
+            assert node.eval_results["assertions"][0]["passed"] is True
+            assert node.eval_results["assertions"][0]["score"] == pytest.approx(0.9)
+
+        event = sse_queue.get_nowait()
+        assert event["event"] == "node_eval_complete"
+        assert event["data"]["node_id"] == "analyze"
+        assert event["data"]["passed"] is True
+        assert event["data"]["assertions"][0]["type"] == "custom:tone_check"
+        assert event["data"]["assertions"][0]["score"] == pytest.approx(0.9)
+
+    def test_eval_observer_supports_negated_custom_assertions_with_builtin_regression(
+        self,
+        tmp_path: Path,
+        run_with_node,
+        sse_queue,
+        sample_state,
+        sample_soul,
+    ):
+        _write_assertion(
+            tmp_path,
+            stem="blocked_word",
+            returns="bool",
+            code="""
+            def get_assert(output, context):
+                return context.get("config", {}).get("blocked") in output
+            """,
+        )
+        _register_custom_assertions(tmp_path)
+        engine, run_id = run_with_node
+        obs = EvalObserver(
+            engine=engine,
+            run_id=run_id,
+            sse_queue=sse_queue,
+            assertion_configs={
+                "analyze": [
+                    {"type": "not-custom:blocked_word", "config": {"blocked": "storm"}},
+                    {"type": "contains", "value": "calm"},
+                ]
+            },
+        )
+
+        obs.on_block_complete(
+            "custom_eval_workflow", "analyze", "LinearBlock", 1.0, sample_state, soul=sample_soul
+        )
+
+        with Session(engine) as session:
+            node = session.get(RunNode, f"{run_id}:analyze")
+            assert node.eval_passed is True
+            assert node.eval_score == pytest.approx(1.0)
+            assert len(node.eval_results["assertions"]) == 2
+            assert node.eval_results["assertions"][0]["type"] == "custom:blocked_word"
+            assert node.eval_results["assertions"][1]["passed"] is True
+
+        event = sse_queue.get_nowait()
+        assert event["data"]["passed"] is True
+        assert len(event["data"]["assertions"]) == 2
+
+    def test_eval_observer_persists_invalid_config_failure_and_emits_sse(
+        self,
+        tmp_path: Path,
+        run_with_node,
+        sse_queue,
+        sample_state,
+        sample_soul,
+    ):
+        _write_assertion(
+            tmp_path,
+            stem="budget_guard",
+            returns="bool",
+            code="""
+            def get_assert(output, context):
+                return True
+            """,
+            params={
+                "type": "object",
+                "properties": {"budget": {"type": "number"}},
+                "required": ["budget"],
+            },
+        )
+        _register_custom_assertions(tmp_path)
+        engine, run_id = run_with_node
+        obs = EvalObserver(
+            engine=engine,
+            run_id=run_id,
+            sse_queue=sse_queue,
+            assertion_configs={"analyze": [{"type": "custom:budget_guard", "config": {}}]},
+        )
+
+        obs.on_block_complete(
+            "custom_eval_workflow", "analyze", "LinearBlock", 1.0, sample_state, soul=sample_soul
+        )
+
+        with Session(engine) as session:
+            node = session.get(RunNode, f"{run_id}:analyze")
+            assert node.eval_passed is False
+            assert node.eval_score == pytest.approx(0.0)
+            assert node.eval_results["assertions"][0]["type"] == "custom:budget_guard"
+            assert node.eval_results["assertions"][0]["reason"].startswith(
+                "Config validation failed:"
+            )
+
+        event = sse_queue.get_nowait()
+        assert event["data"]["passed"] is False
+        assert event["data"]["assertions"][0]["reason"].startswith("Config validation failed:")

--- a/apps/api/tests/logic/test_run800_eval_observer_custom_assertion.py
+++ b/apps/api/tests/logic/test_run800_eval_observer_custom_assertion.py
@@ -1,37 +1,144 @@
-"""RUN-800: EvalObserver integration coverage for custom assertions with config."""
+"""RUN-800 live-path coverage through ExecutionService workflow loading."""
 
 from __future__ import annotations
 
 import asyncio
+import tempfile
 from pathlib import Path
 from textwrap import dedent
-from typing import Any
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
-import runsight_core.assertions.deterministic  # noqa: F401
 import yaml
-from runsight_core.primitives import Soul
-from runsight_core.state import BlockResult, WorkflowState
-from runsight_core.yaml.discovery import AssertionScanner
-from sqlmodel import Session, SQLModel, create_engine
+from sqlmodel import SQLModel, Session, create_engine
 
-from runsight_api.domain.entities.run import Run, RunNode, RunStatus
-from runsight_api.logic.observers.eval_observer import EvalObserver
+from runsight_api.domain.entities.run import Run, RunStatus
 
 
-def _write_yaml(path: Path, data: dict[str, Any]) -> Path:
+@pytest.fixture(autouse=True)
+def _isolate_custom_assertion_registry():
+    from runsight_core.assertions.custom import _PARAM_SCHEMAS
+    from runsight_core.assertions.registry import _REGISTRY
+
+    saved_registry = dict(_REGISTRY)
+    saved_param_schemas = dict(_PARAM_SCHEMAS)
+
+    for key in list(_REGISTRY):
+        if key.startswith("custom:"):
+            _REGISTRY.pop(key, None)
+    _PARAM_SCHEMAS.clear()
+
+    yield
+
+    _REGISTRY.clear()
+    _REGISTRY.update(saved_registry)
+    _PARAM_SCHEMAS.clear()
+    _PARAM_SCHEMAS.update(saved_param_schemas)
+
+
+_PROMPTFOO_WORKFLOW_YAML = """\
+version: "1.0"
+config:
+  model_name: gpt-4o
+souls:
+  analyst:
+    id: analyst
+    role: Analyst
+    system_prompt: You are a careful analyst.
+    provider: openai
+    model_name: gpt-4o
+blocks:
+  analyze:
+    type: linear
+    soul_ref: analyst
+    assertions:
+      - type: custom:tone_check
+        config:
+          prefix: calm
+      - type: contains
+        value: "calm"
+workflow:
+  name: run800_promptfoo_live_path
+  entry: analyze
+  transitions:
+    - from: analyze
+      to: null
+"""
+
+_NEGATED_CUSTOM_WORKFLOW_YAML = """\
+version: "1.0"
+config:
+  model_name: gpt-4o
+souls:
+  analyst:
+    id: analyst
+    role: Analyst
+    system_prompt: You are a careful analyst.
+    provider: openai
+    model_name: gpt-4o
+blocks:
+  analyze:
+    type: linear
+    soul_ref: analyst
+    assertions:
+      - type: not-custom:blocked_word
+        config:
+          blocked: storm
+      - type: contains
+        value: "calm"
+workflow:
+  name: run800_negated_custom_live_path
+  entry: analyze
+  transitions:
+    - from: analyze
+      to: null
+"""
+
+_INVALID_CONFIG_WORKFLOW_YAML = """\
+version: "1.0"
+config:
+  model_name: gpt-4o
+souls:
+  analyst:
+    id: analyst
+    role: Analyst
+    system_prompt: You are a careful analyst.
+    provider: openai
+    model_name: gpt-4o
+blocks:
+  analyze:
+    type: linear
+    soul_ref: analyst
+    assertions:
+      - type: custom:budget_guard
+        config: {}
+workflow:
+  name: run800_invalid_config_live_path
+  entry: analyze
+  transitions:
+    - from: analyze
+      to: null
+"""
+
+
+def _write_yaml(path: Path, data: dict) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
-    return path
 
 
-def _write_assertion(
+def _write_workflow_file(base_dir: Path, workflow_id: str, content: str) -> None:
+    workflows_dir = base_dir / "custom" / "workflows"
+    workflows_dir.mkdir(parents=True, exist_ok=True)
+    (workflows_dir / f"{workflow_id}.yaml").write_text(content, encoding="utf-8")
+
+
+def _write_custom_assertion(
     base_dir: Path,
     *,
     stem: str,
     returns: str,
     code: str,
-    params: dict[str, Any] | None = None,
+    params: dict | None = None,
 ) -> None:
     assertions_dir = base_dir / "custom" / "assertions"
     assertions_dir.mkdir(parents=True, exist_ok=True)
@@ -48,133 +155,62 @@ def _write_assertion(
     (assertions_dir / f"{stem}.py").write_text(dedent(code), encoding="utf-8")
 
 
+def _make_achat_response(content: str, cost_usd: float = 0.001, total_tokens: int = 100):
+    return {
+        "content": content,
+        "cost_usd": cost_usd,
+        "prompt_tokens": 50,
+        "completion_tokens": 50,
+        "total_tokens": total_tokens,
+        "tool_calls": None,
+        "finish_reason": "stop",
+        "raw_message": {"role": "assistant", "content": content},
+    }
+
+
+async def _wait_for_run_terminal(engine, run_id: str, timeout: float = 10.0):
+    terminal = {RunStatus.completed, RunStatus.failed, RunStatus.cancelled}
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        with Session(engine) as session:
+            run = session.get(Run, run_id)
+            if run and run.status in terminal:
+                return run
+        await asyncio.sleep(0.1)
+    with Session(engine) as session:
+        return session.get(Run, run_id)
+
+
 @pytest.fixture
 def db_engine():
-    engine = create_engine("sqlite:///:memory:")
-    SQLModel.metadata.create_all(engine)
-    return engine
+    eng = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    SQLModel.metadata.create_all(eng)
+    return eng
 
 
 @pytest.fixture
-def run_with_node(db_engine):
-    run_id = "run_800_custom_eval"
-    with Session(db_engine) as session:
-        run = Run(
-            id=run_id,
-            workflow_id="wf_custom_eval",
-            workflow_name="custom_eval_workflow",
-            status=RunStatus.pending,
-            task_json="{}",
-        )
-        node = RunNode(
-            id=f"{run_id}:analyze",
-            run_id=run_id,
-            node_id="analyze",
-            block_type="LinearBlock",
-            status="completed",
-            cost_usd=0.02,
-            tokens={"total": 128},
-            output="calm response",
-        )
-        session.add(run)
-        session.add(node)
-        session.commit()
-    return db_engine, run_id
-
-
-@pytest.fixture
-def sse_queue():
-    return asyncio.Queue()
-
-
-@pytest.fixture
-def sample_soul():
-    return Soul(
-        id="analyst_v1",
-        role="Analyst",
-        system_prompt="You are calm and precise.",
-        model_name="gpt-4o",
-    )
-
-
-@pytest.fixture
-def sample_state():
-    return WorkflowState(
-        total_cost_usd=0.02,
-        total_tokens=128,
-        results={"analyze": BlockResult(output="calm response")},
-    )
-
-
-def _register_custom_assertions(base_dir: Path):
-    from runsight_core.assertions.registry import register_custom_assertions
-
-    register_custom_assertions(AssertionScanner(base_dir).scan())
-
-
-class TestEvalObserverCustomAssertions:
-    def test_eval_observer_persists_promptfoo_custom_assertion_and_emits_sse(
-        self,
-        tmp_path: Path,
-        run_with_node,
-        sse_queue,
-        sample_state,
-        sample_soul,
-    ):
-        _write_assertion(
-            tmp_path,
+def base_dir():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        base = Path(tmpdir)
+        _write_workflow_file(base, "run800-promptfoo", _PROMPTFOO_WORKFLOW_YAML)
+        _write_workflow_file(base, "run800-negated-custom", _NEGATED_CUSTOM_WORKFLOW_YAML)
+        _write_workflow_file(base, "run800-invalid-config", _INVALID_CONFIG_WORKFLOW_YAML)
+        _write_custom_assertion(
+            base,
             stem="tone_check",
             returns="grading_result",
             code="""
             def get_assert(output, context):
-                cfg = context.get("config", {})
+                config = context.get("config", {})
                 return {
-                    "pass": output.startswith(cfg.get("prefix", "")),
+                    "pass": output.startswith(config.get("prefix", "")),
                     "score": 0.9,
-                    "reason": f"prefix={cfg.get('prefix', '')}",
+                    "reason": f"prefix={config.get('prefix', '')}",
                 }
             """,
         )
-        _register_custom_assertions(tmp_path)
-        engine, run_id = run_with_node
-        obs = EvalObserver(
-            engine=engine,
-            run_id=run_id,
-            sse_queue=sse_queue,
-            assertion_configs={
-                "analyze": [{"type": "custom:tone_check", "config": {"prefix": "calm"}}]
-            },
-        )
-
-        obs.on_block_complete(
-            "custom_eval_workflow", "analyze", "LinearBlock", 1.0, sample_state, soul=sample_soul
-        )
-
-        with Session(engine) as session:
-            node = session.get(RunNode, f"{run_id}:analyze")
-            assert node.eval_passed is True
-            assert node.eval_score == pytest.approx(0.9)
-            assert node.eval_results["assertions"][0]["type"] == "custom:tone_check"
-            assert node.eval_results["assertions"][0]["passed"] is True
-            assert node.eval_results["assertions"][0]["score"] == pytest.approx(0.9)
-
-        event = sse_queue.get_nowait()
-        assert event["event"] == "node_eval_complete"
-        assert event["data"]["node_id"] == "analyze"
-        assert event["data"]["passed"] is True
-        assert event["data"]["assertions"][0]["type"] == "custom:tone_check"
-        assert event["data"]["assertions"][0]["score"] == pytest.approx(0.9)
-
-    def test_eval_observer_supports_negated_custom_assertions_with_builtin_regression(
-        self,
-        tmp_path: Path,
-        run_with_node,
-        sse_queue,
-        sample_state,
-        sample_soul,
-    ):
-        _write_assertion(
-            tmp_path,
+        _write_custom_assertion(
+            base,
             stem="blocked_word",
             returns="bool",
             code="""
@@ -182,80 +218,266 @@ class TestEvalObserverCustomAssertions:
                 return context.get("config", {}).get("blocked") in output
             """,
         )
-        _register_custom_assertions(tmp_path)
-        engine, run_id = run_with_node
-        obs = EvalObserver(
-            engine=engine,
-            run_id=run_id,
-            sse_queue=sse_queue,
-            assertion_configs={
-                "analyze": [
-                    {"type": "not-custom:blocked_word", "config": {"blocked": "storm"}},
-                    {"type": "contains", "value": "calm"},
-                ]
-            },
-        )
-
-        obs.on_block_complete(
-            "custom_eval_workflow", "analyze", "LinearBlock", 1.0, sample_state, soul=sample_soul
-        )
-
-        with Session(engine) as session:
-            node = session.get(RunNode, f"{run_id}:analyze")
-            assert node.eval_passed is True
-            assert node.eval_score == pytest.approx(1.0)
-            assert len(node.eval_results["assertions"]) == 2
-            assert node.eval_results["assertions"][0]["type"] == "custom:blocked_word"
-            assert node.eval_results["assertions"][1]["passed"] is True
-
-        event = sse_queue.get_nowait()
-        assert event["data"]["passed"] is True
-        assert len(event["data"]["assertions"]) == 2
-
-    def test_eval_observer_persists_invalid_config_failure_and_emits_sse(
-        self,
-        tmp_path: Path,
-        run_with_node,
-        sse_queue,
-        sample_state,
-        sample_soul,
-    ):
-        _write_assertion(
-            tmp_path,
+        _write_custom_assertion(
+            base,
             stem="budget_guard",
             returns="bool",
-            code="""
-            def get_assert(output, context):
-                return True
-            """,
             params={
                 "type": "object",
                 "properties": {"budget": {"type": "number"}},
                 "required": ["budget"],
             },
+            code="""
+            def get_assert(output, context):
+                return True
+            """,
         )
-        _register_custom_assertions(tmp_path)
-        engine, run_id = run_with_node
-        obs = EvalObserver(
-            engine=engine,
-            run_id=run_id,
-            sse_queue=sse_queue,
-            assertion_configs={"analyze": [{"type": "custom:budget_guard", "config": {}}]},
+        yield base
+
+
+@pytest.fixture
+def app_with_real_services(db_engine, base_dir):
+    from fastapi import FastAPI
+    from sqlmodel import Session
+
+    from runsight_api.data.filesystem.provider_repo import FileSystemProviderRepo
+    from runsight_api.data.filesystem.workflow_repo import WorkflowRepository
+    from runsight_api.data.repositories.run_repo import RunRepository
+    from runsight_api.logic.services.eval_service import EvalService
+    from runsight_api.logic.services.execution_service import ExecutionService
+    from runsight_api.logic.services.run_service import RunService
+    from runsight_api.transport.deps import (
+        get_eval_service,
+        get_execution_service,
+        get_run_service,
+    )
+    from runsight_api.transport.routers import runs
+
+    app = FastAPI()
+    app.include_router(runs.router, prefix="/api")
+
+    workflow_repo = WorkflowRepository(str(base_dir))
+    provider_repo = FileSystemProviderRepo(base_path=str(base_dir))
+
+    mock_secrets = Mock()
+    mock_secrets.resolve = Mock(return_value="sk-fake-test-key-for-e2e")
+
+    execution_service = ExecutionService(
+        run_repo=None,
+        workflow_repo=workflow_repo,
+        provider_repo=provider_repo,
+        engine=db_engine,
+        secrets=mock_secrets,
+        settings_repo=None,
+    )
+    app.state.execution_service = execution_service
+
+    def _get_run_service():
+        session = Session(db_engine)
+        run_repo = RunRepository(session)
+        return RunService(run_repo, workflow_repo)
+
+    def _get_execution_service(request=None):
+        return execution_service
+
+    def _get_eval_service():
+        session = Session(db_engine)
+        run_repo = RunRepository(session)
+        return EvalService(run_repo)
+
+    app.dependency_overrides[get_run_service] = _get_run_service
+    app.dependency_overrides[get_execution_service] = _get_execution_service
+    app.dependency_overrides[get_eval_service] = _get_eval_service
+
+    yield app
+
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def mock_provider():
+    provider = Mock()
+    provider.id = "openai"
+    provider.type = "openai"
+    provider.api_key = "sk-test"
+    provider.is_active = True
+    provider.models = ["gpt-4o"]
+    return provider
+
+
+def _capture_eval_events(execution_service):
+    captured_events: list[dict] = []
+    original_unregister = execution_service.unregister_observer
+
+    def _capture_then_unregister(rid):
+        obs = execution_service.get_observer(rid)
+        if obs:
+            while not obs.queue.empty():
+                captured_events.append(obs.queue.get_nowait())
+        original_unregister(rid)
+
+    execution_service.unregister_observer = _capture_then_unregister
+    return captured_events
+
+
+class TestRun800LiveCustomAssertionPath:
+    @pytest.mark.asyncio
+    async def test_api_run_persists_promptfoo_custom_assertion_results_and_sse(
+        self, app_with_real_services, db_engine, mock_provider
+    ):
+        from httpx import ASGITransport, AsyncClient
+
+        execution_service = app_with_real_services.state.execution_service
+        captured_events = _capture_eval_events(execution_service)
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_real_services),
+            base_url="http://test",
+        ) as client:
+            with (
+                patch(
+                    "runsight_core.llm.client.LiteLLMClient.achat",
+                    new_callable=AsyncMock,
+                    return_value=_make_achat_response("calm response"),
+                ),
+                patch.object(
+                    execution_service.provider_repo,
+                    "list_all",
+                    return_value=[mock_provider],
+                ),
+            ):
+                response = await client.post(
+                    "/api/runs",
+                    json={
+                        "workflow_id": "run800-promptfoo",
+                        "task_data": {"instruction": "Analyze this"},
+                    },
+                )
+                assert response.status_code == 200
+                run_id = response.json()["id"]
+                await _wait_for_run_terminal(db_engine, run_id)
+
+            nodes_response = await client.get(f"/api/runs/{run_id}/nodes")
+
+        assert nodes_response.status_code == 200
+        analyze_node = next(node for node in nodes_response.json() if node["node_id"] == "analyze")
+        assert analyze_node["eval_passed"] is True
+        assert analyze_node["eval_score"] == pytest.approx(0.95)
+        assert analyze_node["eval_results"] is not None
+        assert analyze_node["eval_results"]["assertions"][0]["type"] == "custom:tone_check"
+        assert analyze_node["eval_results"]["assertions"][0]["passed"] is True
+
+        eval_events = [
+            event for event in captured_events if event.get("event") == "node_eval_complete"
+        ]
+        assert len(eval_events) >= 1
+        assert eval_events[0]["data"]["assertions"][0]["type"] == "custom:tone_check"
+        assert eval_events[0]["data"]["passed"] is True
+
+    @pytest.mark.asyncio
+    async def test_api_run_supports_negated_custom_assertions_with_builtin_regression(
+        self, app_with_real_services, db_engine, mock_provider
+    ):
+        from httpx import ASGITransport, AsyncClient
+
+        execution_service = app_with_real_services.state.execution_service
+        captured_events = _capture_eval_events(execution_service)
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_real_services),
+            base_url="http://test",
+        ) as client:
+            with (
+                patch(
+                    "runsight_core.llm.client.LiteLLMClient.achat",
+                    new_callable=AsyncMock,
+                    return_value=_make_achat_response("calm response"),
+                ),
+                patch.object(
+                    execution_service.provider_repo,
+                    "list_all",
+                    return_value=[mock_provider],
+                ),
+            ):
+                response = await client.post(
+                    "/api/runs",
+                    json={
+                        "workflow_id": "run800-negated-custom",
+                        "task_data": {"instruction": "Analyze this"},
+                    },
+                )
+                assert response.status_code == 200
+                run_id = response.json()["id"]
+                await _wait_for_run_terminal(db_engine, run_id)
+
+            nodes_response = await client.get(f"/api/runs/{run_id}/nodes")
+
+        assert nodes_response.status_code == 200
+        analyze_node = next(node for node in nodes_response.json() if node["node_id"] == "analyze")
+        assert analyze_node["eval_passed"] is True
+        assert analyze_node["eval_score"] == pytest.approx(1.0)
+        assert analyze_node["eval_results"] is not None
+        assert analyze_node["eval_results"]["assertions"][0]["type"] == "custom:blocked_word"
+        assert analyze_node["eval_results"]["assertions"][0]["passed"] is True
+
+        eval_events = [
+            event for event in captured_events if event.get("event") == "node_eval_complete"
+        ]
+        assert len(eval_events) >= 1
+        assert eval_events[0]["data"]["passed"] is True
+
+    @pytest.mark.asyncio
+    async def test_api_run_persists_invalid_config_failure_and_sse_via_real_load_path(
+        self, app_with_real_services, db_engine, mock_provider
+    ):
+        from httpx import ASGITransport, AsyncClient
+
+        execution_service = app_with_real_services.state.execution_service
+        captured_events = _capture_eval_events(execution_service)
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_real_services),
+            base_url="http://test",
+        ) as client:
+            with (
+                patch(
+                    "runsight_core.llm.client.LiteLLMClient.achat",
+                    new_callable=AsyncMock,
+                    return_value=_make_achat_response("calm response"),
+                ),
+                patch.object(
+                    execution_service.provider_repo,
+                    "list_all",
+                    return_value=[mock_provider],
+                ),
+            ):
+                response = await client.post(
+                    "/api/runs",
+                    json={
+                        "workflow_id": "run800-invalid-config",
+                        "task_data": {"instruction": "Analyze this"},
+                    },
+                )
+                assert response.status_code == 200
+                run_id = response.json()["id"]
+                await _wait_for_run_terminal(db_engine, run_id)
+
+            nodes_response = await client.get(f"/api/runs/{run_id}/nodes")
+
+        assert nodes_response.status_code == 200
+        analyze_node = next(node for node in nodes_response.json() if node["node_id"] == "analyze")
+        assert analyze_node["eval_passed"] is False
+        assert analyze_node["eval_score"] == pytest.approx(0.0)
+        assert analyze_node["eval_results"] is not None
+        assert analyze_node["eval_results"]["assertions"][0]["type"] == "custom:budget_guard"
+        assert analyze_node["eval_results"]["assertions"][0]["reason"].startswith(
+            "Config validation failed:"
         )
 
-        obs.on_block_complete(
-            "custom_eval_workflow", "analyze", "LinearBlock", 1.0, sample_state, soul=sample_soul
+        eval_events = [
+            event for event in captured_events if event.get("event") == "node_eval_complete"
+        ]
+        assert len(eval_events) >= 1
+        assert eval_events[0]["data"]["assertions"][0]["reason"].startswith(
+            "Config validation failed:"
         )
-
-        with Session(engine) as session:
-            node = session.get(RunNode, f"{run_id}:analyze")
-            assert node.eval_passed is False
-            assert node.eval_score == pytest.approx(0.0)
-            assert node.eval_results["assertions"][0]["type"] == "custom:budget_guard"
-            assert node.eval_results["assertions"][0]["reason"].startswith(
-                "Config validation failed:"
-            )
-
-        event = sse_queue.get_nowait()
-        assert event["data"]["passed"] is False
-        assert event["data"]["assertions"][0]["reason"].startswith("Config validation failed:")

--- a/apps/site/astro.config.mjs
+++ b/apps/site/astro.config.mjs
@@ -98,6 +98,7 @@ export default defineConfig({
 					label: 'Evaluation',
 					items: [
 						{ label: 'Assertions', slug: 'docs/evaluation/assertions' },
+						{ label: 'Custom Assertions', slug: 'docs/evaluation/custom-assertions' },
 						{ label: 'Transform Hooks', slug: 'docs/evaluation/transform-hooks' },
 						{ label: 'Eval Test Harness', slug: 'docs/evaluation/eval-test-harness' },
 						{ label: 'Regressions', slug: 'docs/evaluation/regressions' },

--- a/apps/site/src/content/docs/docs/evaluation/assertions.md
+++ b/apps/site/src/content/docs/docs/evaluation/assertions.md
@@ -1,27 +1,38 @@
 ---
 title: Assertions
-description: All block-level assertion types, their parameters, and how pass/fail is computed per node.
+description: Built-in and custom block-level assertions, their config fields, and how Runsight computes eval results.
 ---
 
-Assertions are quality checks that run automatically after a block completes. You define them directly on a block in your workflow YAML, and the engine evaluates each one against the block's output. Every assertion produces a pass/fail result and a numeric score (0.0 to 1.0).
+Assertions are quality checks that run after a block completes. You define them directly in workflow YAML, and each assertion produces a pass/fail result plus a numeric score from `0.0` to `1.0`.
+
+Runsight ships 15 built-in deterministic assertion types. You can also add your own scanner-discovered Python assertions under `custom/assertions/`. See [Custom Assertions](/docs/evaluation/custom-assertions) for the custom plugin workflow.
 
 ## Where assertions live
 
 Assertions are defined on the `assertions` field of any block definition. The field accepts a list of assertion config objects:
 
 ```yaml title="custom/workflows/research.yaml"
+version: "1.0"
 blocks:
   analyze:
-    type: llm
-    soul_ref: analyst
+    type: code
+    code: |
+      def main(data):
+          return "analysis ready"
     assertions:
       - type: contains
         value: "analysis"
       - type: cost
         threshold: 0.05
+workflow:
+  name: assertions_demo
+  entry: analyze
+  transitions:
+    - from: analyze
+      to: null
 ```
 
-The `assertions` field is declared on `BaseBlockDef` as `Optional[List[Dict[str, Any]]]` and defaults to `None`. Every block type inherits it.
+The `assertions` field is declared on `BaseBlockDef` as `Optional[List[Dict[str, Any]]]` and defaults to `None`.
 
 ## Assertion config fields
 
@@ -29,14 +40,15 @@ Each assertion in the list is a dict with these fields:
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `type` | `str` | yes | -- | Assertion type identifier (see table below) |
-| `value` | `any` | depends | `""` | Comparison value. Required for string assertions, optional for performance assertions |
+| `type` | `str` | yes | -- | Assertion type identifier. For custom assertions, use `custom:<file_stem>` |
+| `value` | `any` | depends | `""` | Comparison value. Required for most string and linguistic assertions |
 | `threshold` | `float` | no | varies | Numeric threshold. Meaning depends on assertion type |
+| `config` | `any` | no | `None` | Per-assertion config payload. Built-ins ignore it. Custom assertions receive it as `context["config"]` |
 | `weight` | `float` | no | `1.0` | Weight in the aggregate score calculation |
 | `metric` | `str` | no | `None` | Named metric label. When set, the score is stored in `named_scores` under this key |
 | `transform` | `str` | no | `None` | Pre-process output before evaluation. See [Transform Hooks](/docs/evaluation/transform-hooks) |
 
-## Assertion types
+## Built-in assertion types
 
 Runsight ships 15 deterministic assertion types across four categories.
 
@@ -44,7 +56,7 @@ Runsight ships 15 deterministic assertion types across four categories.
 
 | Type | Value | Behavior |
 |------|-------|----------|
-| `equals` | `str` | Exact string match. Also attempts JSON deep-equal if both sides parse as JSON |
+| `equals` | `str` | Exact string match. Use `config: {mode: json}` to opt into JSON deep-equal |
 | `contains` | `str` | Case-sensitive substring check |
 | `icontains` | `str` | Case-insensitive substring check |
 | `contains-all` | `list[str]` | All items must appear as substrings |
@@ -117,7 +129,7 @@ assertions:
 | `cost` | -- | `float` (USD) | Passes if `cost_usd` from the execution context is at or below `threshold` |
 | `latency` | -- | `float` (ms) | Passes if `latency_ms` from the execution context is at or below `threshold` |
 
-Performance assertions read from the `AssertionContext`, not from the block output string. The context is populated with actual execution metrics (cost, latency, tokens) from the `RunNode` record.
+Performance assertions read from the `AssertionContext`, not from the block output string. In live API runs that context is populated with run metrics such as cost, latency, and tokens; offline eval uses zeroed metric fields.
 
 ```yaml title="Performance assertion examples"
 assertions:
@@ -145,6 +157,26 @@ assertions:
     threshold: 0.3
 ```
 
+## Custom assertions
+
+Custom assertions are discovered from manifest files under `custom/assertions/*.yaml` and are referenced by file stem:
+
+```yaml title="Custom assertion usage"
+assertions:
+  - type: custom:tone_check
+    config:
+      prefix: calm
+```
+
+Important details:
+
+- The runtime key is always `custom:<file_stem>`.
+- The manifest `name` is display-only.
+- Custom assertions can be used alongside built-in assertions in the same list.
+- Custom assertions support the same `not-` negation prefix as built-in assertions.
+
+See [Custom Assertions](/docs/evaluation/custom-assertions) for the manifest format, Python contract, params schema validation, context keys, and migration guidance.
+
 ## Negation with not- prefix
 
 Any assertion type can be negated by prefixing it with `not-`. The engine inverts both the pass/fail boolean and the score (1.0 - original):
@@ -154,7 +186,12 @@ assertions:
   - type: not-contains
     value: "error"
   - type: not-contains-json
+  - type: not-custom:blocked_word
+    config:
+      blocked: storm
 ```
+
+Negation works for both built-in and custom assertion types.
 
 ## Weighted scoring
 
@@ -176,29 +213,43 @@ assertions:
 
 The `AssertionsResult` class accumulates weighted results. Its `aggregate_score` property returns the weighted average: `total_score / total_weight`. The `passed()` method without a threshold returns `True` only if every individual assertion passed.
 
-## Assertion chaining
+## Execution model
 
-A block can have any number of assertions. Each assertion runs independently -- they do not share state or depend on each other's results. The engine runs all of them concurrently via `asyncio.gather`, so a failure in one assertion never prevents the others from completing.
+Assertions do not share state with each other. Each configured assertion is evaluated independently against the same block result.
+
+Runsight has two execution surfaces:
+
+- Offline eval and other async callers use the shared async registry path, `run_assertions()`
+- Live API block evaluation uses `EvalObserver` and the shared sync registry path, `run_assertions_sync()`
+
+That means assertions are not always executed through the same concurrency model:
+
+- Async registry callers can evaluate a block's assertions concurrently
+- The live API `EvalObserver` path evaluates the block's assertions through the synchronous registry surface
+
+In both paths:
+
+- every configured assertion still gets its own result
+- transform failures on one assertion do not prevent the rest of the list from producing results
+- aggregate scoring still follows the same weighted scoring rules
+
+## Assertion chaining
 
 This is especially useful with `transform` hooks. Each assertion can target a different field in the block output using its own `json_path` transform:
 
 ```yaml title="Multiple assertions with different transforms"
-blocks:
-  process_order:
-    type: llm
-    soul_ref: processor
-    assertions:
-      - type: equals
-        value: "completed"
-        transform: "json_path:$.status"
-      - type: contains
-        value: "success"
-        transform: "json_path:$.message"
-      - type: cost
-        threshold: 0.02
+assertions:
+  - type: equals
+    value: "completed"
+    transform: "json_path:$.status"
+  - type: contains
+    value: "success"
+    transform: "json_path:$.message"
+  - type: cost
+    threshold: 0.02
 ```
 
-In this example, the first assertion extracts `$.status` and checks for an exact match, the second extracts `$.message` and checks for a substring, and the third checks execution cost without any transform. All three run in parallel.
+In this example, the first assertion extracts `$.status` and checks for an exact match, the second extracts `$.message` and checks for a substring, and the third checks execution cost without any transform.
 
 If a transform fails on one assertion (e.g., the output is not valid JSON, or the path does not exist), that assertion returns `passed=False` with a descriptive reason. The other assertions still run normally and produce their own results. The aggregate score and pass/fail are then computed across all of them using the standard [weighted scoring](#weighted-scoring) rules.
 
@@ -206,23 +257,24 @@ If a transform fails on one assertion (e.g., the output is not valid JSON, or th
 
 When a workflow runs via the API, the engine wires assertions automatically:
 
-1. The `ExecutionService._build_assertion_configs` method reads `assertions` from each block in the parsed workflow
-2. An `EvalObserver` is created with the assertion configs and attached to the workflow run
-3. After each block completes, `EvalObserver.on_block_complete` fires:
+1. `parse_workflow_yaml()` attaches each block's `assertions` to the runtime workflow
+2. `ExecutionService._build_assertion_configs()` collects those assertion lists by block ID
+3. `EvalObserver` receives the config map and watches block completion events
+4. After a block completes, `EvalObserver.on_block_complete()`:
    - Extracts the block output from `WorkflowState`
    - Builds an `AssertionContext` with output, cost, latency, soul info, and tokens
-   - Runs all assertion configs for that block
+   - Calls the shared sync registry path for that block's assertion list
    - Persists `eval_score`, `eval_passed`, and `eval_results` on the `RunNode` record
-   - Emits a `node_eval_complete` SSE event with scores, pass/fail, and baseline delta
+   - Emits a `node_eval_complete` SSE event
 
 The `RunNode` entity stores three eval fields:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `eval_score` | `Optional[float]` | Weighted average score across all assertions (0.0 to 1.0) |
-| `eval_passed` | `Optional[bool]` | `True` if all individual assertions passed |
-| `eval_results` | `Optional[Dict]` | Detailed results with per-assertion type, passed, score, and reason |
+| `eval_score` | `Optional[float]` | Weighted average score across all assertions on the block |
+| `eval_passed` | `Optional[bool]` | `True` when every individual assertion passed |
+| `eval_results` | `Optional[Dict]` | Per-assertion results including pass/fail, score, reason, and handler type when the handler sets one |
 
 These fields are `None` when a block has no assertions configured.
 
-<!-- Linear: RUN-555, RUN-693, RUN-685, RUN-705 -- last verified against codebase 2026-04-07 -->
+<!-- Linear: RUN-555, RUN-685, RUN-693, RUN-705, RUN-769, RUN-800, RUN-801 -- last verified against codebase 2026-04-10 -->

--- a/apps/site/src/content/docs/docs/evaluation/custom-assertions.md
+++ b/apps/site/src/content/docs/docs/evaluation/custom-assertions.md
@@ -1,0 +1,349 @@
+---
+title: Custom Assertions
+description: Create project-local Python assertions under custom/assertions and use them in offline evals and live workflow runs.
+---
+
+Custom assertions let you add workspace-local checks alongside Runsight's built-in assertions. Runsight discovers them from `custom/assertions/*.yaml`, registers each one under `custom:{file_stem}`, and can run them in both offline evals and live API workflow runs.
+
+Use this page for custom assertions. For built-in assertion types and shared assertion config fields, see [Assertions](/docs/evaluation/assertions).
+
+## Quick Start
+
+This example creates a custom assertion named `tone_check`, then uses it in an offline eval case with a built-in assertion alongside it.
+
+```yaml title="custom/assertions/tone_check.yaml"
+version: "1.0"
+name: "Tone Check"
+description: "Passes when output starts with a configured prefix."
+returns: "grading_result"
+source: "tone_check.py"
+params:
+  type: object
+  properties:
+    prefix:
+      type: string
+  required: ["prefix"]
+```
+
+```python title="custom/assertions/tone_check.py"
+def get_assert(output, context):
+    config = context.get("config", {})
+    return {
+        "pass": output.startswith(config.get("prefix", "")),
+        "score": 0.9,
+        "reason": f"prefix={config.get('prefix', '')}",
+    }
+```
+
+```yaml title="custom/workflows/custom-assertions-demo.yaml"
+version: "1.0"
+config:
+  model_name: gpt-4o
+blocks:
+  analyze:
+    type: code
+    code: |
+      def main(data):
+          return "unused in fixture mode"
+workflow:
+  name: custom_assertions_demo
+  entry: analyze
+  transitions:
+    - from: analyze
+      to: null
+eval:
+  threshold: 0.5
+  cases:
+    - id: tone_case
+      fixtures:
+        analyze: "calm response"
+      expected:
+        analyze:
+          - type: custom:tone_check
+            config:
+              prefix: calm
+          - type: contains
+            value: "response"
+```
+
+What this does:
+
+- The assertion's canonical ID is `tone_check` because the manifest file is `tone_check.yaml`.
+- The runtime type is `custom:tone_check`.
+- The `config` object is validated against `params` before the plugin runs.
+- The same custom assertion can also be used under a block's normal `assertions:` list during API workflow runs.
+
+:::note
+Offline eval auto-discovers custom assertions only when `run_eval()` is given a workflow file path. Passing raw YAML text to `run_eval()` does not trigger scanner-based custom assertion registration.
+:::
+
+## YAML Manifest Reference
+
+Each custom assertion is defined by a YAML manifest in `custom/assertions/<id>.yaml`.
+
+```yaml title="custom/assertions/example.yaml"
+version: "1.0"
+name: "Example Assertion"
+description: "Checks something about the block output."
+returns: "bool"
+source: "example.py"
+params:
+  type: object
+  properties:
+    enabled:
+      type: boolean
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `version` | `string` | yes | Manifest version string |
+| `name` | `string` | yes | Display name for humans. This is not the runtime ID |
+| `description` | `string` | yes | Short description of the assertion |
+| `returns` | `"bool"` or `"grading_result"` | yes | Declares the plugin return contract |
+| `source` | `string` | yes | Python file to load, relative to the manifest file |
+| `params` | JSON Schema object | no | Schema used to validate the assertion's `config` before plugin execution |
+
+Important details:
+
+- The canonical runtime ID is the file stem, not `name`.
+- `custom/assertions/tone_check.yaml` always registers as `custom:tone_check`.
+- Extra top-level manifest fields are rejected.
+- Built-in assertion name collisions are rejected at scan time.
+- The source file must exist relative to the manifest file.
+
+## Python Contract
+
+A custom assertion source file must define exactly this function:
+
+```python title="custom/assertions/example.py"
+def get_assert(output, context):
+    return True
+```
+
+Rules:
+
+- The function name must be `get_assert`.
+- The parameter list must be exactly `(output, context)`.
+- The function must be synchronous.
+- Runsight validates the function contract before registration.
+- The plugin runs in a separate subprocess with a minimal environment.
+- Plugin execution times out after 30 seconds.
+
+The plugin receives:
+
+- `output`: the block output string being checked
+- `context`: a plain Python dict with assertion metadata and per-assertion config
+
+Runsight does not forward API keys into the plugin subprocess environment.
+
+## Return Types
+
+The manifest `returns` field controls how Runsight interprets the plugin result.
+
+### `bool`
+
+Use `returns: "bool"` when the assertion is a simple pass/fail check.
+
+```python title="custom/assertions/contains_calm.py"
+def get_assert(output, context):
+    return "calm" in output
+```
+
+`True` becomes a passing result with score `1.0`. `False` becomes a failing result with score `0.0`.
+
+### `grading_result`
+
+Use `returns: "grading_result"` when you need to control the score or reason.
+
+```python title="custom/assertions/tone_check.py"
+def get_assert(output, context):
+    config = context.get("config", {})
+    return {
+        "pass": output.startswith(config.get("prefix", "")),
+        "score": 0.9,
+        "reason": f"prefix={config.get('prefix', '')}",
+    }
+```
+
+Accepted fields:
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `passed` or `pass_` or `pass` | yes | Runsight accepts these aliases in that precedence |
+| `score` | yes | Must be numeric and between `0.0` and `1.0` |
+| `reason` | no | Optional. Non-string values are coerced with `str()` |
+
+Notes:
+
+- `score` may be an `int` or `float`; Runsight converts it to `float`.
+- If the returned shape does not match the declared contract, the assertion fails with a runtime error message instead of crashing the run.
+
+## Config & Params
+
+Each assertion entry in workflow YAML can include a `config` field:
+
+```yaml title="Block assertion config"
+assertions:
+  - type: custom:tone_check
+    config:
+      prefix: calm
+```
+
+For custom assertions, Runsight passes that value through two stages:
+
+1. If the manifest defines `params`, Runsight validates `config` against that JSON Schema.
+2. If validation succeeds, the exact value is exposed to the plugin as `context["config"]`.
+
+If the manifest does not define `params`, Runsight skips config validation.
+
+:::note
+Custom plugins receive their per-assertion input through `config`. The generic `value` and `threshold` fields still exist on assertion objects, but Runsight does not inject them into the plugin context dict.
+:::
+
+### Schema-validated config
+
+```yaml title="custom/assertions/budget_guard.yaml"
+version: "1.0"
+name: "Budget Guard"
+description: "Requires a numeric budget."
+returns: "bool"
+source: "budget_guard.py"
+params:
+  type: object
+  properties:
+    budget:
+      type: number
+  required: ["budget"]
+```
+
+```python title="custom/assertions/budget_guard.py"
+def get_assert(output, context):
+    return True
+```
+
+```yaml title="Workflow usage"
+assertions:
+  - type: custom:budget_guard
+    config:
+      budget: 0.05
+```
+
+If `config` is invalid, Runsight returns a failing result whose reason starts with `Config validation failed:` and skips plugin execution.
+
+### Generic assertion features still work
+
+Custom assertions use the same outer assertion config object as built-ins, so these features still apply:
+
+- `weight`
+- `metric`
+- `transform`
+- `not-` negation, for example `not-custom:blocked_word`
+
+## Context Dict Reference
+
+Custom assertions receive a plain dict, not an `AssertionContext` object.
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `vars` | `dict` | Workflow variables for the assertion context |
+| `config` | `any` | The per-assertion `config` value from workflow YAML |
+| `prompt` | `string` | Prompt text in the current assertion context |
+| `prompt_hash` | `string` | Prompt hash for the current run |
+| `soul_id` | `string` | Soul ID for the block being evaluated |
+| `soul_version` | `string` | Soul version hash or identifier |
+| `block_id` | `string` | Block ID |
+| `block_type` | `string` | Block type |
+| `cost_usd` | `float` | Execution cost in USD |
+| `total_tokens` | `int` | Total tokens used |
+| `latency_ms` | `float` | Block latency in milliseconds |
+| `run_id` | `string` | Run ID |
+| `workflow_id` | `string` | Workflow identifier from the current assertion context. In live API runs this is currently the workflow name; offline eval uses an empty string |
+
+Notes:
+
+- The key is `vars`, not `variables`.
+- The key is `config`, even when the config value is `None`.
+- Offline eval populates most context fields with empty strings or zeros.
+- Live API execution fills prompt, soul, cost, token, latency, run, and workflow fields from the run context.
+
+## Migrating from Promptfoo
+
+Runsight's custom assertion contract is intentionally close to promptfoo-style Python assertions.
+
+A promptfoo-style function body like this works unchanged:
+
+```python title="custom/assertions/tone_check.py"
+def get_assert(output, context):
+    config = context.get("config", {})
+    return {
+        "pass": output.startswith(config.get("prefix", "")),
+        "score": 0.9,
+        "reason": f"prefix={config.get('prefix', '')}",
+    }
+```
+
+The main Runsight-specific additions are:
+
+1. Put the code in `custom/assertions/<id>.py`
+2. Add a matching manifest in `custom/assertions/<id>.yaml`
+3. Reference it in workflow YAML as `custom:<id>`
+
+Example:
+
+```yaml title="Workflow assertion entry"
+assertions:
+  - type: custom:tone_check
+    config:
+      prefix: calm
+```
+
+Remember that `tone_check` comes from the filename, not the manifest `name`.
+
+## Limitations
+
+Current custom assertion support is intentionally narrow:
+
+- Discovery only looks for YAML manifests in `custom/assertions/*.yaml`.
+- The Python contract is only `def get_assert(output, context)`.
+- Supported return contracts are only `bool` and `grading_result`.
+- Manifest fields are fixed to `version`, `name`, `description`, `returns`, `source`, and optional `params`.
+- Plugins run in a separate subprocess with a minimal environment and a 30 second timeout.
+- API keys are not forwarded into that subprocess environment.
+- Offline eval auto-discovers custom assertions only from workflow file paths, not raw YAML strings.
+- This feature documents local Python assertions only. LLM-calling plugins are not supported today because Runsight does not forward API keys into the plugin subprocess.
+
+See [RUN-306](https://linear.app/runsight/issue/RUN-306/batch-eval-llm-graded-assertions-defensive-red-team) for future LLM-graded assertion work.
+
+## Error Messages
+
+These are the most common failure modes you will see.
+
+### Manifest and discovery errors
+
+These happen before the assertion is registered:
+
+- Missing or invalid required manifest fields
+- Unsupported extra manifest fields
+- Invalid `returns` value
+- Built-in ID collision such as `contains.yaml`
+- Invalid Python signature such as anything other than `def get_assert(output, context)`
+
+### Runtime assertion errors
+
+These return failing results instead of crashing the run:
+
+- `Config validation failed: ...`
+- `Custom assertion 'name' failed: plugin exploded`
+- `Custom assertion 'name' declares returns: bool but get_assert returned 'dict'`
+- `custom assertion plugin timed out after 30s`
+
+### What happens on failure
+
+In both offline eval and live API execution:
+
+- The assertion result is recorded as failed
+- The run continues
+- Other assertions on the same block still produce their own results
+- Live API runs still persist `eval_score`, `eval_passed`, and `eval_results`, and still emit `node_eval_complete` SSE events
+
+<!-- Linear: RUN-769, RUN-794, RUN-795, RUN-796, RUN-797, RUN-798, RUN-799, RUN-800, RUN-801 -- last verified against codebase 2026-04-10 -->

--- a/apps/site/src/content/docs/docs/evaluation/eval-test-harness.md
+++ b/apps/site/src/content/docs/docs/evaluation/eval-test-harness.md
@@ -13,9 +13,10 @@ Add an `eval:` section at the top level of your workflow file, alongside `blocks
 version: "1.0"
 blocks:
   analyze:
-    type: llm
-    soul_ref: analyst
-    prompt_template: "Analyze: {task_instruction}"
+    type: code
+    code: |
+      def main(data):
+          return "unused in fixture mode"
     assertions:
       - type: contains
         value: "analysis"
@@ -47,7 +48,7 @@ The `eval:` section is parsed as an `EvalSectionDef` model:
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `threshold` | `float` | no | `1.0` (when omitted) | Minimum aggregate score for the suite to pass. Range: 0.0 to 1.0 |
+| `threshold` | `float` | no | `None` in the schema, treated as `1.0` at runtime when omitted | Minimum aggregate score for the suite to pass. Range: 0.0 to 1.0 |
 | `cases` | `list[EvalCaseDef]` | yes | -- | At least one test case required (`min_length=1`) |
 
 Case IDs must be unique within the eval section. Duplicates cause a validation error.
@@ -92,6 +93,10 @@ eval:
 
 If a case has `expected` blocks without matching fixtures, the runner requires an executor callback. If no executor is provided, it raises a `RuntimeError`.
 
+:::note
+Custom assertions are supported in `expected` just like built-in assertions, but scanner-based auto-discovery only happens when `run_eval()` is given a workflow file path. Passing raw YAML text does not scan `custom/assertions`.
+:::
+
 ## Running offline evals
 
 When you run evals, the harness loads your workflow YAML, finds the `eval:` section, and executes each case. Fixture-only cases run instantly with no LLM calls. The result tells you whether the suite passed and gives per-case scores.
@@ -104,7 +109,7 @@ The suite result contains:
 |-------|------|-------------|
 | `passed` | `bool` | `True` if `score >= threshold` |
 | `score` | `float` | Average of all case scores |
-| `threshold` | `float` | From `eval.threshold` (defaults to `1.0` if omitted) |
+| `threshold` | `float` | From `eval.threshold`, or `1.0` at runtime when the field is omitted |
 | `case_results` | `list[EvalCaseResult]` | Per-case breakdown |
 
 Each `EvalCaseResult` contains:
@@ -118,7 +123,7 @@ Each `EvalCaseResult` contains:
 
 ### Score computation
 
-1. Each assertion produces a score (0.0 or 1.0 for deterministic types)
+1. Each assertion produces a score between `0.0` and `1.0`
 2. Block score = weighted average of assertion scores
 3. Case score = average of block scores
 4. Suite score = average of case scores
@@ -126,7 +131,7 @@ Each `EvalCaseResult` contains:
 
 ## Executor mode
 
-For cases that need actual LLM execution (no fixtures for some blocks), the harness runs each block through the real execution pipeline. This means those cases make live LLM calls, cost tokens, and produce non-deterministic results. Use executor mode when you want to validate actual model behavior rather than testing assertion logic against known outputs.
+For cases that need live execution (no fixtures for some blocks), `run_eval()` awaits a caller-supplied `executor(raw, inputs)` function that must return a `WorkflowState`. That executor can call the real workflow runtime, a test double, or any other harness you provide. `run_eval()` itself does not automatically run the full execution pipeline.
 
 ## Mixing fixture and executor cases
 
@@ -152,6 +157,6 @@ eval:
             value: "transformer"
 ```
 
-The fixture case runs without an executor. The live case requires one. If no executor is provided, only fixture cases succeed -- the live case raises a `RuntimeError`.
+The fixture case runs without an executor. The live case requires one. If no executor is provided, `run_eval()` raises a `RuntimeError` when it reaches the first executor-required case; it does not return partial suite results.
 
-<!-- Linear: RUN-694, RUN-695, RUN-699, RUN-700 -- last verified against codebase 2026-04-07 -->
+<!-- Linear: RUN-694, RUN-695, RUN-699, RUN-700, RUN-769, RUN-800, RUN-801 -- last verified against codebase 2026-04-10 -->

--- a/apps/site/src/content/docs/docs/evaluation/regressions.md
+++ b/apps/site/src/content/docs/docs/evaluation/regressions.md
@@ -25,7 +25,7 @@ These fields live on the `RunNode` entity and are populated by the `EvalObserver
 
 - **`eval_score`** (`Optional[float]`): The weighted average of all assertion scores for that node. A value of `1.0` means every assertion scored perfectly; `0.0` means all failed.
 - **`eval_passed`** (`Optional[bool]`): `True` only if every individual assertion passed. A node can have a high score but still fail if one assertion did not pass.
-- **`eval_results`** (`Optional[Dict]`): Detailed breakdown with per-assertion `type`, `passed`, `score`, and `reason`.
+- **`eval_results`** (`Optional[Dict]`): Detailed breakdown with per-assertion `passed`, `score`, and `reason`, plus `type` when the assertion handler sets one. Custom assertions do; many built-in deterministic assertions leave it as `null`.
 
 When a block has no assertions, all three fields are `None` and the node is excluded from regression detection.
 
@@ -57,7 +57,7 @@ Each regression issue in the response contains:
 | Field | Type | Description |
 |-------|------|-------------|
 | `node_id` | `str` | The block that regressed |
-| `node_name` | `str` | Display name of the node |
+| `node_name` | `str` | Display label for the node when available; otherwise it falls back to `node_id` |
 | `type` | `str` | One of `assertion_regression`, `cost_spike`, `quality_drop` |
 | `delta` | `dict` | Type-specific comparison data (see table above) |
 | `run_id` | `str` | (workflow endpoint only) Which run introduced this regression |
@@ -88,4 +88,4 @@ The regression response schema on the frontend validates three regression types:
 
 The `EvalService.get_attention_items` method scans production runs from the last 24 hours and surfaces regressions as attention items on the dashboard. It flags the same three conditions as the regression endpoints, plus a `new_baseline` info item for the first production run of a soul version. Items are sorted by severity (warnings before info) and recency.
 
-<!-- Linear: RUN-555, RUN-558 -- last verified against codebase 2026-04-07 -->
+<!-- Linear: RUN-555, RUN-558, RUN-769, RUN-801 -- last verified against codebase 2026-04-10 -->

--- a/apps/site/src/content/docs/docs/evaluation/transform-hooks.md
+++ b/apps/site/src/content/docs/docs/evaluation/transform-hooks.md
@@ -7,13 +7,15 @@ When a block produces structured output (like JSON), you often want to assert on
 
 ## Add a transform to an assertion
 
-Set the `transform` field on any assertion config. The transform runs before the assertion evaluator sees the output:
+Set the `transform` field on any assertion config. The transform runs before handler lookup and before the assertion evaluator sees the output, so it works with built-in assertions, `custom:*` assertions, and `not-custom:*` assertions:
 
 ```yaml title="custom/workflows/extract-check.yaml"
 blocks:
   classify:
-    type: llm
-    soul_ref: classifier
+    type: code
+    code: |
+      def main(data):
+          return '{"sentiment": "positive"}'
     assertions:
       - type: contains-any
         value: ["positive", "negative", "neutral"]
@@ -56,8 +58,10 @@ Runsight uses the `jsonpath_ng` library. Common patterns:
 ```yaml title="Extract and assert on a JSON field"
 blocks:
   analyze:
-    type: llm
-    soul_ref: analyst
+    type: code
+    code: |
+      def main(data):
+          return '{"outlook": "bullish", "confidence": 0.92}'
     assertions:
       - type: contains-any
         value: ["bullish", "bearish", "neutral"]
@@ -71,8 +75,10 @@ If the block output is `{"outlook": "bullish", "confidence": 0.92}`, the asserti
 ```yaml title="Check a numeric field with equals"
 blocks:
   scorer:
-    type: llm
-    soul_ref: evaluator
+    type: code
+    code: |
+      def main(data):
+          return '{"rating": 4, "explanation": "Good quality"}'
     assertions:
       - type: regex
         value: "^[1-5]$"
@@ -109,4 +115,4 @@ When a transform fails, the assertion itself does not run. The failing `GradingR
 A single transform extracts only the **first match** from the JSONPath expression. If your path matches multiple values (e.g., `$.items[*].name`), only the first one is used for that assertion. To check multiple fields, add separate assertions each with its own `transform` -- see [Assertion chaining](/docs/evaluation/assertions#assertion-chaining).
 :::
 
-<!-- Linear: RUN-695, RUN-685 -- last verified against codebase 2026-04-07 -->
+<!-- Linear: RUN-685, RUN-695, RUN-769, RUN-801 -- last verified against codebase 2026-04-10 -->

--- a/apps/site/src/content/docs/docs/reference/assertion-reference.md
+++ b/apps/site/src/content/docs/docs/reference/assertion-reference.md
@@ -16,6 +16,7 @@ Every assertion config supports these fields:
 | `type` | `str` | -- | Assertion type name (see sections below). Prefix with `not-` to negate. |
 | `value` | `Any` | `""` | Comparison value (type-specific) |
 | `threshold` | `float` | varies | Pass threshold (type-specific) |
+| `config` | `Any` | none | Optional per-assertion config. Built-ins usually ignore it; `equals` uses `config.mode: json` for JSON deep-equal |
 | `weight` | `float` | `1.0` | Weight for aggregated scoring |
 | `metric` | `str` | none | Named score key for tracking |
 | `transform` | `str` | none | Pre-processing transform (see [Transform hooks](#transform-hooks)) |
@@ -26,7 +27,7 @@ Every assertion config supports these fields:
 
 ### equals
 
-Exact string match or JSON deep-equal. Tries JSON parsing first; falls back to string comparison.
+Exact string match by default. To compare parsed JSON values explicitly, set `config.mode: json`.
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
@@ -35,6 +36,13 @@ Exact string match or JSON deep-equal. Tries JSON parsing first; falls back to s
 ```yaml
 - type: equals
   value: "expected output"
+```
+
+```yaml
+- type: equals
+  value: '{"a": 1, "b": 2}'
+  config:
+    mode: json
 ```
 
 ### contains

--- a/packages/core/src/runsight_core/assertions/__init__.py
+++ b/packages/core/src/runsight_core/assertions/__init__.py
@@ -10,6 +10,7 @@ from runsight_core.assertions.registry import (
     register_assertion,
     run_assertion,
     run_assertions,
+    run_assertions_sync,
 )
 from runsight_core.assertions.scoring import AssertionsResult
 
@@ -22,4 +23,5 @@ __all__ = [
     "register_assertion",
     "run_assertion",
     "run_assertions",
+    "run_assertions_sync",
 ]

--- a/packages/core/src/runsight_core/assertions/contract.py
+++ b/packages/core/src/runsight_core/assertions/contract.py
@@ -1,0 +1,4 @@
+"""Shared contract constants for custom assertion plugins."""
+
+ASSERTION_FUNCTION_NAME = "get_assert"
+ASSERTION_FUNCTION_PARAMS = ("output", "context")

--- a/packages/core/src/runsight_core/assertions/custom.py
+++ b/packages/core/src/runsight_core/assertions/custom.py
@@ -7,6 +7,7 @@ import asyncio
 import json
 import os
 import sys
+import threading
 from typing import Any, Callable
 
 from runsight_core.assertions.base import AssertionContext, GradingResult
@@ -78,6 +79,8 @@ _RETURN_VALIDATORS: dict[str, Callable[[Any, str], GradingResult]] = {
     "bool": _validate_bool_return,
     "grading_result": _validate_grading_result_return,
 }
+
+_DEFAULT_PLUGIN_TIMEOUT_SECONDS = 30
 
 
 def _validate_adapter_code(code: str) -> None:
@@ -181,7 +184,13 @@ def _minimal_subprocess_env() -> dict[str, str]:
     return minimal_env
 
 
-async def _run_plugin(harness: str, output: str, plugin_context: dict[str, Any]) -> Any:
+async def _run_plugin(
+    harness: str,
+    output: str,
+    plugin_context: dict[str, Any],
+    *,
+    timeout_seconds: int = _DEFAULT_PLUGIN_TIMEOUT_SECONDS,
+) -> Any:
     proc = await asyncio.create_subprocess_exec(
         sys.executable,
         "-c",
@@ -193,7 +202,18 @@ async def _run_plugin(harness: str, output: str, plugin_context: dict[str, Any])
     )
 
     stdin_data = json.dumps({"output": output, "context": plugin_context}).encode()
-    stdout_bytes, stderr_bytes = await proc.communicate(input=stdin_data)
+    try:
+        stdout_bytes, stderr_bytes = await asyncio.wait_for(
+            proc.communicate(input=stdin_data),
+            timeout=timeout_seconds,
+        )
+    except asyncio.TimeoutError as exc:
+        try:
+            proc.kill()
+            await proc.wait()
+        except ProcessLookupError:
+            pass
+        raise TimeoutError(f"custom assertion plugin timed out after {timeout_seconds}s") from exc
 
     if proc.returncode != 0:
         error_msg = stderr_bytes.decode(errors="replace").strip() or "plugin subprocess failed"
@@ -204,6 +224,44 @@ async def _run_plugin(harness: str, output: str, plugin_context: dict[str, Any])
         return json.loads(stdout)
     except json.JSONDecodeError as exc:
         raise ValueError(f"plugin returned invalid JSON: {stdout!r}") from exc
+
+
+def _run_plugin_sync(
+    harness: str,
+    output: str,
+    plugin_context: dict[str, Any],
+    *,
+    timeout_seconds: int = _DEFAULT_PLUGIN_TIMEOUT_SECONDS,
+) -> Any:
+    coroutine = _run_plugin(
+        harness,
+        output,
+        plugin_context,
+        timeout_seconds=timeout_seconds,
+    )
+
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coroutine)
+
+    result: Any | None = None
+    error: BaseException | None = None
+
+    def _runner() -> None:
+        nonlocal result, error
+        try:
+            result = asyncio.run(coroutine)
+        except BaseException as exc:  # pragma: no cover - surfaced to caller
+            error = exc
+
+    thread = threading.Thread(target=_runner, daemon=True)
+    thread.start()
+    thread.join()
+
+    if error is not None:
+        raise error
+    return result
 
 
 def _build_adapter_class(plugin_name: str, code: str, returns: str) -> type:
@@ -233,7 +291,7 @@ def _build_adapter_class(plugin_name: str, code: str, returns: str) -> type:
         def evaluate(self, output: str, context: AssertionContext) -> GradingResult:
             plugin_context = _build_plugin_context(self.config, context)
             try:
-                raw = asyncio.run(_run_plugin(harness, output, plugin_context))
+                raw = _run_plugin_sync(harness, output, plugin_context)
                 return validator(raw, plugin_name)
             except Exception as exc:
                 return GradingResult(

--- a/packages/core/src/runsight_core/assertions/custom.py
+++ b/packages/core/src/runsight_core/assertions/custom.py
@@ -37,6 +37,12 @@ def _validate_bool_return(raw: Any, plugin_name: str) -> GradingResult:
 
 
 def _validate_grading_result_return(raw: Any, plugin_name: str) -> GradingResult:
+    """Validate promptfoo-compatible grading results at the adapter boundary.
+
+    We accept ``passed``, ``pass_``, and ``pass`` here so existing promptfoo-style
+    Python plugins can run unchanged while the rest of the system uses a single
+    normalized GradingResult shape internally.
+    """
     if not isinstance(raw, dict):
         raise TypeError(
             f"Custom assertion {plugin_name!r} declares returns: grading_result but get_assert "

--- a/packages/core/src/runsight_core/assertions/custom.py
+++ b/packages/core/src/runsight_core/assertions/custom.py
@@ -10,6 +10,8 @@ import sys
 import threading
 from typing import Any, Callable
 
+from jsonschema import ValidationError, validate
+
 from runsight_core.assertions.base import AssertionContext, GradingResult
 from runsight_core.assertions.contract import ASSERTION_FUNCTION_NAME, ASSERTION_FUNCTION_PARAMS
 from runsight_core.blocks.code import BLOCKED_BUILTINS, BLOCKED_MODULES, DEFAULT_ALLOWED_IMPORTS
@@ -80,6 +82,7 @@ _RETURN_VALIDATORS: dict[str, Callable[[Any, str], GradingResult]] = {
     "bool": _validate_bool_return,
     "grading_result": _validate_grading_result_return,
 }
+_PARAM_SCHEMAS: dict[str, dict[str, Any]] = {}
 
 _DEFAULT_PLUGIN_TIMEOUT_SECONDS = 30
 
@@ -292,6 +295,18 @@ def _build_adapter_class(plugin_name: str, code: str, returns: str) -> type:
             self.config = config
 
         def evaluate(self, output: str, context: AssertionContext) -> GradingResult:
+            param_schema = _PARAM_SCHEMAS.get(plugin_name)
+            if param_schema is not None:
+                try:
+                    validate(instance=self.config, schema=param_schema)
+                except ValidationError as exc:
+                    return GradingResult(
+                        passed=False,
+                        score=0.0,
+                        reason=f"Config validation failed: {exc.message}",
+                        assertion_type=assertion_type,
+                    )
+
             plugin_context = _build_plugin_context(self.config, context)
             try:
                 raw = _run_plugin_sync(harness, output, plugin_context)

--- a/packages/core/src/runsight_core/assertions/custom.py
+++ b/packages/core/src/runsight_core/assertions/custom.py
@@ -2,9 +2,15 @@
 
 from __future__ import annotations
 
+import ast
+import asyncio
+import json
+import os
+import sys
 from typing import Any, Callable
 
-from runsight_core.assertions.base import GradingResult
+from runsight_core.assertions.base import AssertionContext, GradingResult
+from runsight_core.blocks.code import BLOCKED_BUILTINS, BLOCKED_MODULES, DEFAULT_ALLOWED_IMPORTS
 
 
 def _custom_assertion_type(plugin_name: str) -> str:
@@ -72,3 +78,170 @@ _RETURN_VALIDATORS: dict[str, Callable[[Any, str], GradingResult]] = {
     "bool": _validate_bool_return,
     "grading_result": _validate_grading_result_return,
 }
+
+
+def _validate_adapter_code(code: str) -> None:
+    """Validate custom assertion code before execution."""
+    try:
+        tree = ast.parse(code)
+    except SyntaxError as exc:
+        raise ValueError(f"Custom assertion code has a syntax error: {exc}") from exc
+
+    has_get_assert = False
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                top = alias.name.split(".")[0]
+                if top in BLOCKED_MODULES:
+                    raise ValueError(f"Import of '{alias.name}' is not allowed")
+                if top not in DEFAULT_ALLOWED_IMPORTS:
+                    raise ValueError(f"Import of '{alias.name}' is not in the allowed list")
+
+        if isinstance(node, ast.ImportFrom) and node.module is not None:
+            top = node.module.split(".")[0]
+            if top in BLOCKED_MODULES:
+                raise ValueError(f"Import from '{node.module}' is not allowed")
+            if top not in DEFAULT_ALLOWED_IMPORTS:
+                raise ValueError(f"Import from '{node.module}' is not in the allowed list")
+
+        if isinstance(node, ast.Call):
+            func = node.func
+            name: str | None = None
+            if isinstance(func, ast.Name):
+                name = func.id
+            elif isinstance(func, ast.Attribute):
+                name = func.attr
+            if name and name in BLOCKED_BUILTINS:
+                raise ValueError(f"Call to '{name}()' is not allowed")
+
+        if isinstance(node, ast.Attribute):
+            attr = node.attr
+            if attr.startswith("__") and attr.endswith("__"):
+                raise ValueError(f"Access to dunder attribute '{attr}' is not allowed")
+
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "get_assert":
+            raise ValueError("Custom assertion code must define 'def get_assert(output, context)'")
+
+        if isinstance(node, ast.FunctionDef) and node.name == "get_assert":
+            has_get_assert = True
+            if (
+                len(node.args.posonlyargs) != 0
+                or len(node.args.args) != 2
+                or node.args.args[0].arg != "output"
+                or node.args.args[1].arg != "context"
+                or node.args.vararg is not None
+                or len(node.args.kwonlyargs) != 0
+                or node.args.kwarg is not None
+            ):
+                raise ValueError(
+                    "Custom assertion code must define 'def get_assert(output, context)'"
+                )
+
+    if not has_get_assert:
+        raise ValueError("Custom assertion code must define 'def get_assert(output, context)'")
+
+
+def _adapter_harness(code: str) -> str:
+    return (
+        "import json\n\n"
+        + code
+        + "\n\n"
+        + "_input = json.loads(open(0).read())\n"
+        + "_result = get_assert(_input['output'], _input['context'])\n"
+        + "print(json.dumps(_result), end='')\n"
+    )
+
+
+def _build_plugin_context(
+    config: dict[str, Any] | None, context: AssertionContext
+) -> dict[str, Any]:
+    return {
+        "vars": context.variables,
+        "config": config,
+        "prompt": context.prompt,
+        "prompt_hash": context.prompt_hash,
+        "soul_id": context.soul_id,
+        "soul_version": context.soul_version,
+        "block_id": context.block_id,
+        "block_type": context.block_type,
+        "cost_usd": context.cost_usd,
+        "total_tokens": context.total_tokens,
+        "latency_ms": context.latency_ms,
+        "run_id": context.run_id,
+        "workflow_id": context.workflow_id,
+    }
+
+
+def _minimal_subprocess_env() -> dict[str, str]:
+    minimal_env = {"PATH": os.environ.get("PATH", "/usr/bin:/bin:/usr/sbin:/sbin")}
+    for key in ("HOME", "DYLD_LIBRARY_PATH", "DYLD_FALLBACK_LIBRARY_PATH"):
+        if key in os.environ:
+            minimal_env[key] = os.environ[key]
+    return minimal_env
+
+
+async def _run_plugin(harness: str, output: str, plugin_context: dict[str, Any]) -> Any:
+    proc = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-c",
+        harness,
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        env=_minimal_subprocess_env(),
+    )
+
+    stdin_data = json.dumps({"output": output, "context": plugin_context}).encode()
+    stdout_bytes, stderr_bytes = await proc.communicate(input=stdin_data)
+
+    if proc.returncode != 0:
+        error_msg = stderr_bytes.decode(errors="replace").strip() or "plugin subprocess failed"
+        raise RuntimeError(error_msg)
+
+    stdout = stdout_bytes.decode(errors="replace").strip()
+    try:
+        return json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"plugin returned invalid JSON: {stdout!r}") from exc
+
+
+def _build_adapter_class(plugin_name: str, code: str, returns: str) -> type:
+    """Build a synchronous assertion adapter class for a custom plugin."""
+    _validate_adapter_code(code)
+    harness = _adapter_harness(code)
+    assertion_type = _custom_assertion_type(plugin_name)
+
+    if returns not in _RETURN_VALIDATORS:
+        raise ValueError(f"Unsupported custom assertion return contract: {returns!r}")
+
+    validator = _RETURN_VALIDATORS[returns]
+
+    class CustomAssertionAdapter:
+        type = assertion_type
+
+        def __init__(
+            self,
+            value: Any = None,
+            threshold: float | None = None,
+            config: dict[str, Any] | None = None,
+        ) -> None:
+            self.value = value
+            self.threshold = threshold
+            self.config = config
+
+        def evaluate(self, output: str, context: AssertionContext) -> GradingResult:
+            plugin_context = _build_plugin_context(self.config, context)
+            try:
+                raw = asyncio.run(_run_plugin(harness, output, plugin_context))
+                return validator(raw, plugin_name)
+            except Exception as exc:
+                return GradingResult(
+                    passed=False,
+                    score=0.0,
+                    reason=f"Custom assertion {plugin_name!r} failed: {exc}",
+                    assertion_type=assertion_type,
+                )
+
+    CustomAssertionAdapter.__name__ = f"{plugin_name.title().replace('_', '')}AssertionAdapter"
+    return CustomAssertionAdapter

--- a/packages/core/src/runsight_core/assertions/custom.py
+++ b/packages/core/src/runsight_core/assertions/custom.py
@@ -1,0 +1,74 @@
+"""Helpers for custom assertion plugin adapters."""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from runsight_core.assertions.base import GradingResult
+
+
+def _custom_assertion_type(plugin_name: str) -> str:
+    return f"custom:{plugin_name}"
+
+
+def _validate_bool_return(raw: Any, plugin_name: str) -> GradingResult:
+    if type(raw) is not bool:
+        raise TypeError(
+            f"Custom assertion {plugin_name!r} declares returns: bool but get_assert returned "
+            f"{type(raw).__name__!r}"
+        )
+
+    return GradingResult(
+        passed=raw,
+        score=1.0 if raw else 0.0,
+        reason=f"Custom assertion {plugin_name!r} returned {raw}",
+        assertion_type=_custom_assertion_type(plugin_name),
+    )
+
+
+def _validate_grading_result_return(raw: Any, plugin_name: str) -> GradingResult:
+    if not isinstance(raw, dict):
+        raise TypeError(
+            f"Custom assertion {plugin_name!r} declares returns: grading_result but get_assert "
+            f"returned {type(raw).__name__!r}; expected dict"
+        )
+
+    pass_key = next((key for key in ("passed", "pass_", "pass") if key in raw), None)
+    if pass_key is None or "score" not in raw:
+        actual_keys = sorted(raw.keys())
+        raise TypeError(
+            f"Custom assertion {plugin_name!r} grading_result must provide keys "
+            f"['passed'|'pass_'|'pass', 'score']; actual keys: {actual_keys}"
+        )
+
+    passed = raw[pass_key]
+    if type(passed) is not bool:
+        raise TypeError(
+            f"Custom assertion {plugin_name!r} grading_result field {pass_key!r} must be bool"
+        )
+
+    score = raw["score"]
+    if not isinstance(score, (int, float)) or isinstance(score, bool):
+        raise TypeError(
+            f"Custom assertion {plugin_name!r} grading_result field 'score' must be numeric"
+        )
+    score = float(score)
+    if not 0.0 <= score <= 1.0:
+        raise ValueError(f"Custom assertion {plugin_name!r}: score must be between 0.0 and 1.0")
+
+    reason = raw.get("reason", "")
+    if not isinstance(reason, str):
+        reason = str(reason)
+
+    return GradingResult(
+        passed=passed,
+        score=score,
+        reason=reason,
+        assertion_type=_custom_assertion_type(plugin_name),
+    )
+
+
+_RETURN_VALIDATORS: dict[str, Callable[[Any, str], GradingResult]] = {
+    "bool": _validate_bool_return,
+    "grading_result": _validate_grading_result_return,
+}

--- a/packages/core/src/runsight_core/assertions/custom.py
+++ b/packages/core/src/runsight_core/assertions/custom.py
@@ -11,6 +11,7 @@ import threading
 from typing import Any, Callable
 
 from runsight_core.assertions.base import AssertionContext, GradingResult
+from runsight_core.assertions.contract import ASSERTION_FUNCTION_NAME, ASSERTION_FUNCTION_PARAMS
 from runsight_core.blocks.code import BLOCKED_BUILTINS, BLOCKED_MODULES, DEFAULT_ALLOWED_IMPORTS
 
 
@@ -83,6 +84,11 @@ _RETURN_VALIDATORS: dict[str, Callable[[Any, str], GradingResult]] = {
 _DEFAULT_PLUGIN_TIMEOUT_SECONDS = 30
 
 
+def _assertion_signature() -> str:
+    params = ", ".join(ASSERTION_FUNCTION_PARAMS)
+    return f"def {ASSERTION_FUNCTION_NAME}({params})"
+
+
 def _validate_adapter_code(code: str) -> None:
     """Validate custom assertion code before execution."""
     try:
@@ -123,26 +129,23 @@ def _validate_adapter_code(code: str) -> None:
             if attr.startswith("__") and attr.endswith("__"):
                 raise ValueError(f"Access to dunder attribute '{attr}' is not allowed")
 
-        if isinstance(node, ast.AsyncFunctionDef) and node.name == "get_assert":
-            raise ValueError("Custom assertion code must define 'def get_assert(output, context)'")
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == ASSERTION_FUNCTION_NAME:
+            raise ValueError(f"Custom assertion code must define '{_assertion_signature()}'")
 
-        if isinstance(node, ast.FunctionDef) and node.name == "get_assert":
+        if isinstance(node, ast.FunctionDef) and node.name == ASSERTION_FUNCTION_NAME:
             has_get_assert = True
             if (
                 len(node.args.posonlyargs) != 0
-                or len(node.args.args) != 2
-                or node.args.args[0].arg != "output"
-                or node.args.args[1].arg != "context"
+                or len(node.args.args) != len(ASSERTION_FUNCTION_PARAMS)
+                or tuple(arg.arg for arg in node.args.args) != ASSERTION_FUNCTION_PARAMS
                 or node.args.vararg is not None
                 or len(node.args.kwonlyargs) != 0
                 or node.args.kwarg is not None
             ):
-                raise ValueError(
-                    "Custom assertion code must define 'def get_assert(output, context)'"
-                )
+                raise ValueError(f"Custom assertion code must define '{_assertion_signature()}'")
 
     if not has_get_assert:
-        raise ValueError("Custom assertion code must define 'def get_assert(output, context)'")
+        raise ValueError(f"Custom assertion code must define '{_assertion_signature()}'")
 
 
 def _adapter_harness(code: str) -> str:
@@ -151,7 +154,7 @@ def _adapter_harness(code: str) -> str:
         + code
         + "\n\n"
         + "_input = json.loads(open(0).read())\n"
-        + "_result = get_assert(_input['output'], _input['context'])\n"
+        + f"_result = {ASSERTION_FUNCTION_NAME}(_input['output'], _input['context'])\n"
         + "print(json.dumps(_result), end='')\n"
     )
 

--- a/packages/core/src/runsight_core/assertions/deterministic/linguistic.py
+++ b/packages/core/src/runsight_core/assertions/deterministic/linguistic.py
@@ -20,9 +20,15 @@ class LevenshteinAssertion:
 
     type = "levenshtein"
 
-    def __init__(self, value: Any = "", threshold: float | None = None) -> None:
+    def __init__(
+        self,
+        value: Any = "",
+        threshold: float | None = None,
+        config: dict[str, Any] | None = None,
+    ) -> None:
         self.value = str(value)
         self.threshold = threshold if threshold is not None else 5
+        self.config = config
 
     def evaluate(self, output: str, context: AssertionContext) -> GradingResult:
         distance = editdistance.eval(output, self.value)
@@ -37,9 +43,15 @@ class BleuAssertion:
 
     type = "bleu"
 
-    def __init__(self, value: Any = "", threshold: float | None = None) -> None:
+    def __init__(
+        self,
+        value: Any = "",
+        threshold: float | None = None,
+        config: dict[str, Any] | None = None,
+    ) -> None:
         self.value = str(value)
         self.threshold = threshold if threshold is not None else 0.5
+        self.config = config
 
     def evaluate(self, output: str, context: AssertionContext) -> GradingResult:
         score = _compute_bleu(reference=self.value, candidate=output)
@@ -55,9 +67,15 @@ class RougeNAssertion:
 
     type = "rouge-n"
 
-    def __init__(self, value: Any = "", threshold: float | None = None) -> None:
+    def __init__(
+        self,
+        value: Any = "",
+        threshold: float | None = None,
+        config: dict[str, Any] | None = None,
+    ) -> None:
         self.value = str(value)
         self.threshold = threshold if threshold is not None else 0.75
+        self.config = config
 
     def evaluate(self, output: str, context: AssertionContext) -> GradingResult:
         if not output or not self.value:

--- a/packages/core/src/runsight_core/assertions/deterministic/performance.py
+++ b/packages/core/src/runsight_core/assertions/deterministic/performance.py
@@ -15,9 +15,15 @@ class CostAssertion:
 
     type = "cost"
 
-    def __init__(self, value: Any = None, threshold: float | None = None) -> None:
+    def __init__(
+        self,
+        value: Any = None,
+        threshold: float | None = None,
+        config: dict[str, Any] | None = None,
+    ) -> None:
         self.value = value
         self.threshold = threshold
+        self.config = config
 
     def evaluate(self, output: str, context: AssertionContext) -> GradingResult:
         cost = context.cost_usd
@@ -38,9 +44,15 @@ class LatencyAssertion:
 
     type = "latency"
 
-    def __init__(self, value: Any = None, threshold: float | None = None) -> None:
+    def __init__(
+        self,
+        value: Any = None,
+        threshold: float | None = None,
+        config: dict[str, Any] | None = None,
+    ) -> None:
         self.value = value
         self.threshold = threshold
+        self.config = config
 
     def evaluate(self, output: str, context: AssertionContext) -> GradingResult:
         latency = context.latency_ms

--- a/packages/core/src/runsight_core/assertions/deterministic/string.py
+++ b/packages/core/src/runsight_core/assertions/deterministic/string.py
@@ -18,9 +18,15 @@ class EqualsAssertion:
 
     type = "equals"
 
-    def __init__(self, value: Any = "", threshold: float | None = None) -> None:
+    def __init__(
+        self,
+        value: Any = "",
+        threshold: float | None = None,
+        config: dict[str, Any] | None = None,
+    ) -> None:
         self.value = value
         self.threshold = threshold
+        self.config = config
 
     def evaluate(self, output: str, context: AssertionContext) -> GradingResult:
         value_str = str(self.value)
@@ -56,9 +62,15 @@ class ContainsAssertion:
 
     type = "contains"
 
-    def __init__(self, value: Any = "", threshold: float | None = None) -> None:
+    def __init__(
+        self,
+        value: Any = "",
+        threshold: float | None = None,
+        config: dict[str, Any] | None = None,
+    ) -> None:
         self.value = str(value)
         self.threshold = threshold
+        self.config = config
 
     def evaluate(self, output: str, context: AssertionContext) -> GradingResult:
         if self.value in output:
@@ -73,9 +85,15 @@ class IContainsAssertion:
 
     type = "icontains"
 
-    def __init__(self, value: Any = "", threshold: float | None = None) -> None:
+    def __init__(
+        self,
+        value: Any = "",
+        threshold: float | None = None,
+        config: dict[str, Any] | None = None,
+    ) -> None:
         self.value = str(value)
         self.threshold = threshold
+        self.config = config
 
     def evaluate(self, output: str, context: AssertionContext) -> GradingResult:
         if self.value.lower() in output.lower():
@@ -94,9 +112,15 @@ class ContainsAllAssertion:
 
     type = "contains-all"
 
-    def __init__(self, value: Any = None, threshold: float | None = None) -> None:
+    def __init__(
+        self,
+        value: Any = None,
+        threshold: float | None = None,
+        config: dict[str, Any] | None = None,
+    ) -> None:
         self.value: list[str] = value if value is not None else []
         self.threshold = threshold
+        self.config = config
 
     def evaluate(self, output: str, context: AssertionContext) -> GradingResult:
         missing = [item for item in self.value if str(item) not in output]
@@ -112,9 +136,15 @@ class ContainsAnyAssertion:
 
     type = "contains-any"
 
-    def __init__(self, value: Any = None, threshold: float | None = None) -> None:
+    def __init__(
+        self,
+        value: Any = None,
+        threshold: float | None = None,
+        config: dict[str, Any] | None = None,
+    ) -> None:
         self.value: list[str] = value if value is not None else []
         self.threshold = threshold
+        self.config = config
 
     def evaluate(self, output: str, context: AssertionContext) -> GradingResult:
         if not self.value:
@@ -132,9 +162,15 @@ class StartsWithAssertion:
 
     type = "starts-with"
 
-    def __init__(self, value: Any = "", threshold: float | None = None) -> None:
+    def __init__(
+        self,
+        value: Any = "",
+        threshold: float | None = None,
+        config: dict[str, Any] | None = None,
+    ) -> None:
         self.value = str(value)
         self.threshold = threshold
+        self.config = config
 
     def evaluate(self, output: str, context: AssertionContext) -> GradingResult:
         if output.startswith(self.value):
@@ -151,9 +187,15 @@ class RegexAssertion:
 
     type = "regex"
 
-    def __init__(self, value: Any = "", threshold: float | None = None) -> None:
+    def __init__(
+        self,
+        value: Any = "",
+        threshold: float | None = None,
+        config: dict[str, Any] | None = None,
+    ) -> None:
         self.value = str(value)
         self.threshold = threshold
+        self.config = config
 
     def evaluate(self, output: str, context: AssertionContext) -> GradingResult:
         try:
@@ -173,9 +215,15 @@ class WordCountAssertion:
 
     type = "word-count"
 
-    def __init__(self, value: Any = None, threshold: float | None = None) -> None:
+    def __init__(
+        self,
+        value: Any = None,
+        threshold: float | None = None,
+        config: dict[str, Any] | None = None,
+    ) -> None:
         self.value = value
         self.threshold = threshold
+        self.config = config
 
     def evaluate(self, output: str, context: AssertionContext) -> GradingResult:
         words = output.split()

--- a/packages/core/src/runsight_core/assertions/deterministic/string.py
+++ b/packages/core/src/runsight_core/assertions/deterministic/string.py
@@ -14,7 +14,7 @@ from runsight_core.assertions.base import AssertionContext, GradingResult
 
 
 class EqualsAssertion:
-    """Exact string match or JSON deep-equal."""
+    """Exact string match, or explicit JSON deep-equal when configured."""
 
     type = "equals"
 
@@ -30,11 +30,25 @@ class EqualsAssertion:
 
     def evaluate(self, output: str, context: AssertionContext) -> GradingResult:
         value_str = str(self.value)
+        if self.config is not None and not isinstance(self.config, dict):
+            return GradingResult(
+                passed=False,
+                score=0.0,
+                reason="equals config must be a mapping when provided",
+            )
 
-        # Try JSON deep-equal first
-        try:
-            output_parsed = json.loads(output)
-            value_parsed = json.loads(value_str)
+        mode = self.config.get("mode", "string") if self.config else "string"
+        if mode == "json":
+            try:
+                output_parsed = json.loads(output)
+                value_parsed = json.loads(value_str)
+            except (json.JSONDecodeError, TypeError):
+                return GradingResult(
+                    passed=False,
+                    score=0.0,
+                    reason="JSON comparison failed: output or expected value is not valid JSON",
+                )
+
             if output_parsed == value_parsed:
                 return GradingResult(
                     passed=True, score=1.0, reason="Output matches expected value (JSON deep-equal)"
@@ -44,10 +58,14 @@ class EqualsAssertion:
                 score=0.0,
                 reason=f"JSON values differ: expected {value_str!r}, got {output!r}",
             )
-        except (json.JSONDecodeError, TypeError):
-            pass
 
-        # Fall back to exact string match
+        if mode != "string":
+            return GradingResult(
+                passed=False,
+                score=0.0,
+                reason=f"Unsupported equals mode: {mode!r}",
+            )
+
         if output == value_str:
             return GradingResult(
                 passed=True, score=1.0, reason="Output exactly matches expected value"

--- a/packages/core/src/runsight_core/assertions/deterministic/structural.py
+++ b/packages/core/src/runsight_core/assertions/deterministic/structural.py
@@ -18,9 +18,15 @@ class IsJsonAssertion:
 
     type = "is-json"
 
-    def __init__(self, value: Any = None, threshold: float | None = None) -> None:
+    def __init__(
+        self,
+        value: Any = None,
+        threshold: float | None = None,
+        config: dict[str, Any] | None = None,
+    ) -> None:
         self.value = value
         self.threshold = threshold
+        self.config = config
 
     def evaluate(self, output: str, context: AssertionContext) -> GradingResult:
         try:
@@ -44,9 +50,15 @@ class ContainsJsonAssertion:
 
     type = "contains-json"
 
-    def __init__(self, value: Any = None, threshold: float | None = None) -> None:
+    def __init__(
+        self,
+        value: Any = None,
+        threshold: float | None = None,
+        config: dict[str, Any] | None = None,
+    ) -> None:
         self.value = value
         self.threshold = threshold
+        self.config = config
 
     def evaluate(self, output: str, context: AssertionContext) -> GradingResult:
         parsed = _extract_json(output)

--- a/packages/core/src/runsight_core/assertions/registry.py
+++ b/packages/core/src/runsight_core/assertions/registry.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any
 
 from jsonpath_ng import parse as jp_parse
 
+from runsight_core.assertions import custom as custom_assertions
 from runsight_core.assertions.base import AssertionContext, GradingResult
 from runsight_core.assertions.custom import _build_adapter_class
 from runsight_core.assertions.scoring import AssertionsResult
@@ -29,6 +30,10 @@ def register_assertion(type_str: str, handler: type) -> None:
 def register_custom_assertions(index: "ScanIndex[AssertionMeta]") -> None:
     """Register custom assertions from a discovery scan index."""
     for meta in index.stems().values():
+        if meta.manifest.params is not None:
+            custom_assertions._PARAM_SCHEMAS[meta.assertion_id] = meta.manifest.params
+        else:
+            custom_assertions._PARAM_SCHEMAS.pop(meta.assertion_id, None)
         adapter_class = _build_adapter_class(
             plugin_name=meta.assertion_id,
             code=meta.code or "",

--- a/packages/core/src/runsight_core/assertions/registry.py
+++ b/packages/core/src/runsight_core/assertions/registry.py
@@ -5,12 +5,16 @@ from __future__ import annotations
 import asyncio
 import inspect
 import json
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from jsonpath_ng import parse as jp_parse
 
 from runsight_core.assertions.base import AssertionContext, GradingResult
+from runsight_core.assertions.custom import _build_adapter_class
 from runsight_core.assertions.scoring import AssertionsResult
+
+if TYPE_CHECKING:
+    from runsight_core.yaml.discovery import AssertionMeta, ScanIndex
 
 _REGISTRY: dict[str, type] = {}
 
@@ -20,6 +24,17 @@ NOT_PREFIX = "not-"
 def register_assertion(type_str: str, handler: type) -> None:
     """Register an assertion handler class by type string."""
     _REGISTRY[type_str] = handler
+
+
+def register_custom_assertions(index: "ScanIndex[AssertionMeta]") -> None:
+    """Register custom assertions from a discovery scan index."""
+    for meta in index.stems().values():
+        adapter_class = _build_adapter_class(
+            plugin_name=meta.assertion_id,
+            code=meta.code or "",
+            returns=meta.manifest.returns,
+        )
+        register_assertion(f"custom:{meta.assertion_id}", adapter_class)
 
 
 def _get_handler(type_str: str) -> type:

--- a/packages/core/src/runsight_core/assertions/registry.py
+++ b/packages/core/src/runsight_core/assertions/registry.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import json
 from typing import Any
 
@@ -75,6 +76,36 @@ def _apply_transform(transform: str, output: str) -> str | GradingResult:
     return str(extracted) if not isinstance(extracted, str) else extracted
 
 
+def _build_handler(
+    handler_cls: type,
+    *,
+    value: Any,
+    threshold: float | None,
+    config: dict[str, Any] | None,
+) -> Any:
+    """Construct a handler using the supported assertion constructor contract."""
+    if handler_cls.__init__ is object.__init__:
+        return handler_cls()
+
+    parameters = inspect.signature(handler_cls).parameters
+    accepts_var_kwargs = any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD for parameter in parameters.values()
+    )
+
+    if not accepts_var_kwargs and "value" not in parameters:
+        raise TypeError(
+            f"{handler_cls.__name__} must accept a 'value' keyword argument to be used as an assertion"
+        )
+
+    kwargs: dict[str, Any] = {"value": value}
+    if accepts_var_kwargs or "threshold" in parameters:
+        kwargs["threshold"] = threshold
+    if accepts_var_kwargs or "config" in parameters:
+        kwargs["config"] = config
+
+    return handler_cls(**kwargs)
+
+
 def run_assertion(
     *,
     type: str,
@@ -82,6 +113,7 @@ def run_assertion(
     context: AssertionContext,
     value: Any = "",
     threshold: float | None = None,
+    config: dict[str, Any] | None = None,
     weight: float = 1.0,
     metric: str | None = None,
     transform: str | None = None,
@@ -97,10 +129,7 @@ def run_assertion(
     base_type = type[len(NOT_PREFIX) :] if negated else type
 
     handler_cls = _get_handler(base_type)
-    try:
-        handler = handler_cls(value=value)
-    except TypeError:
-        handler = handler_cls()
+    handler = _build_handler(handler_cls, value=value, threshold=threshold, config=config)
     result = handler.evaluate(output, context)
 
     if negated:
@@ -142,6 +171,7 @@ async def run_assertions(
                 context=context,
                 value=cfg.get("value", ""),
                 threshold=cfg.get("threshold"),
+                config=cfg.get("config"),
                 weight=weight,
                 metric=cfg.get("metric"),
                 transform=cfg.get("transform"),
@@ -154,6 +184,38 @@ async def run_assertions(
     completed = await asyncio.gather(*tasks)
 
     for result, weight in completed:
+        agg.add_result(result, weight=weight)
+
+    return agg
+
+
+def run_assertions_sync(
+    config: list[dict[str, Any]],
+    *,
+    output: str,
+    context: AssertionContext,
+) -> AssertionsResult:
+    """Run a list of assertion configs synchronously and return aggregated results."""
+    agg = AssertionsResult()
+
+    if not config:
+        return agg
+
+    for cfg in config:
+        weight = cfg.get("weight", 1.0)
+        result = run_assertion(
+            type=cfg["type"],
+            output=output,
+            context=context,
+            value=cfg.get("value", ""),
+            threshold=cfg.get("threshold"),
+            config=cfg.get("config"),
+            weight=weight,
+            metric=cfg.get("metric"),
+            transform=cfg.get("transform"),
+        )
+        if cfg.get("metric"):
+            result.named_scores[cfg["metric"]] = result.score
         agg.add_result(result, weight=weight)
 
     return agg

--- a/packages/core/src/runsight_core/eval/runner.py
+++ b/packages/core/src/runsight_core/eval/runner.py
@@ -13,6 +13,7 @@ from runsight_core.assertions.registry import register_custom_assertions, run_as
 from runsight_core.assertions.scoring import AssertionsResult
 from runsight_core.state import BlockResult, WorkflowState
 from runsight_core.yaml.discovery import AssertionScanner
+from runsight_core.yaml.parser import _find_project_root
 from runsight_core.yaml.schema import EvalSectionDef
 
 
@@ -65,23 +66,6 @@ def _has_fixtures_for_all_expected(
     if not fixtures:
         return False
     return all(block_id in fixtures for block_id in expected)
-
-
-def _find_project_root(start: Path) -> str:
-    """Walk up from *start* to find the directory that contains ``custom/``."""
-    current = start.resolve()
-    for candidate in [current, *current.parents]:
-        custom_dir = candidate / "custom"
-        if not custom_dir.is_dir():
-            continue
-        if candidate == current:
-            return str(candidate)
-        try:
-            current.relative_to(custom_dir)
-        except ValueError:
-            continue
-        return str(candidate)
-    return str(start)
 
 
 def _load_eval_workflow_source(workflow_yaml: str) -> tuple[dict[str, Any], str | None]:

--- a/packages/core/src/runsight_core/eval/runner.py
+++ b/packages/core/src/runsight_core/eval/runner.py
@@ -12,8 +12,7 @@ from runsight_core.assertions.base import AssertionContext
 from runsight_core.assertions.registry import register_custom_assertions, run_assertions
 from runsight_core.assertions.scoring import AssertionsResult
 from runsight_core.state import BlockResult, WorkflowState
-from runsight_core.yaml.discovery import AssertionScanner
-from runsight_core.yaml.parser import _find_project_root
+from runsight_core.yaml.discovery import AssertionScanner, resolve_discovery_base_dir
 from runsight_core.yaml.schema import EvalSectionDef
 
 
@@ -79,7 +78,7 @@ def _load_eval_workflow_source(workflow_yaml: str) -> tuple[dict[str, Any], str 
     if is_file_path:
         workflow_path = Path(stripped).resolve()
         with open(workflow_path, "r", encoding="utf-8") as handle:
-            return yaml.safe_load(handle), _find_project_root(workflow_path.parent)
+            return yaml.safe_load(handle), resolve_discovery_base_dir(workflow_path.parent)
     return yaml.safe_load(workflow_yaml), None
 
 

--- a/packages/core/src/runsight_core/eval/runner.py
+++ b/packages/core/src/runsight_core/eval/runner.py
@@ -3,14 +3,16 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Callable
 
 import yaml
 
 from runsight_core.assertions.base import AssertionContext
-from runsight_core.assertions.registry import run_assertions
+from runsight_core.assertions.registry import register_custom_assertions, run_assertions
 from runsight_core.assertions.scoring import AssertionsResult
 from runsight_core.state import BlockResult, WorkflowState
+from runsight_core.yaml.discovery import AssertionScanner
 from runsight_core.yaml.schema import EvalSectionDef
 
 
@@ -65,6 +67,38 @@ def _has_fixtures_for_all_expected(
     return all(block_id in fixtures for block_id in expected)
 
 
+def _find_project_root(start: Path) -> str:
+    """Walk up from *start* to find the directory that contains ``custom/``."""
+    current = start.resolve()
+    for candidate in [current, *current.parents]:
+        custom_dir = candidate / "custom"
+        if not custom_dir.is_dir():
+            continue
+        if candidate == current:
+            return str(candidate)
+        try:
+            current.relative_to(custom_dir)
+        except ValueError:
+            continue
+        return str(candidate)
+    return str(start)
+
+
+def _load_eval_workflow_source(workflow_yaml: str) -> tuple[dict[str, Any], str | None]:
+    """Load eval workflow input from either raw YAML content or a workflow file path."""
+    stripped = workflow_yaml.strip()
+    is_file_path = (
+        "\n" not in stripped
+        and stripped.endswith((".yaml", ".yml", ".json"))
+        and Path(stripped).exists()
+    )
+    if is_file_path:
+        workflow_path = Path(stripped).resolve()
+        with open(workflow_path, "r", encoding="utf-8") as handle:
+            return yaml.safe_load(handle), _find_project_root(workflow_path.parent)
+    return yaml.safe_load(workflow_yaml), None
+
+
 async def run_eval(
     workflow_yaml: str,
     *,
@@ -77,7 +111,10 @@ async def run_eval(
     - Otherwise, calls executor to get a WorkflowState.
     - Runs assertions per block and aggregates scores.
     """
-    raw = yaml.safe_load(workflow_yaml)
+    raw, workflow_base_dir = _load_eval_workflow_source(workflow_yaml)
+    if workflow_base_dir is not None:
+        assertion_index = AssertionScanner(workflow_base_dir).scan()
+        register_custom_assertions(assertion_index)
     eval_raw = raw.get("eval")
     if eval_raw is None:
         raise ValueError("Workflow YAML has no eval section")

--- a/packages/core/src/runsight_core/yaml/discovery/__init__.py
+++ b/packages/core/src/runsight_core/yaml/discovery/__init__.py
@@ -1,5 +1,6 @@
 """Public scanner surface for Runsight YAML asset discovery."""
 
+from runsight_core.yaml.discovery._assertion import AssertionMeta, AssertionScanner
 from runsight_core.yaml.discovery._base import BaseScanner, ScanIndex, ScanResult
 from runsight_core.yaml.discovery._soul import SoulScanner
 from runsight_core.yaml.discovery._tool import (
@@ -10,6 +11,8 @@ from runsight_core.yaml.discovery._tool import (
 from runsight_core.yaml.discovery._workflow import WorkflowScanner
 
 __all__ = [
+    "AssertionMeta",
+    "AssertionScanner",
     "BaseScanner",
     "RESERVED_BUILTIN_TOOL_IDS",
     "ScanIndex",

--- a/packages/core/src/runsight_core/yaml/discovery/__init__.py
+++ b/packages/core/src/runsight_core/yaml/discovery/__init__.py
@@ -5,7 +5,12 @@ from runsight_core.yaml.discovery._assertion import (
     AssertionMeta,
     AssertionScanner,
 )
-from runsight_core.yaml.discovery._base import BaseScanner, ScanIndex, ScanResult
+from runsight_core.yaml.discovery._base import (
+    BaseScanner,
+    ScanIndex,
+    ScanResult,
+    resolve_discovery_base_dir,
+)
 from runsight_core.yaml.discovery._soul import SoulScanner
 from runsight_core.yaml.discovery._tool import (
     RESERVED_BUILTIN_TOOL_IDS,
@@ -26,4 +31,5 @@ __all__ = [
     "ToolMeta",
     "ToolScanner",
     "WorkflowScanner",
+    "resolve_discovery_base_dir",
 ]

--- a/packages/core/src/runsight_core/yaml/discovery/__init__.py
+++ b/packages/core/src/runsight_core/yaml/discovery/__init__.py
@@ -1,6 +1,10 @@
 """Public scanner surface for Runsight YAML asset discovery."""
 
-from runsight_core.yaml.discovery._assertion import AssertionMeta, AssertionScanner
+from runsight_core.yaml.discovery._assertion import (
+    AssertionManifest,
+    AssertionMeta,
+    AssertionScanner,
+)
 from runsight_core.yaml.discovery._base import BaseScanner, ScanIndex, ScanResult
 from runsight_core.yaml.discovery._soul import SoulScanner
 from runsight_core.yaml.discovery._tool import (
@@ -11,6 +15,7 @@ from runsight_core.yaml.discovery._tool import (
 from runsight_core.yaml.discovery._workflow import WorkflowScanner
 
 __all__ = [
+    "AssertionManifest",
     "AssertionMeta",
     "AssertionScanner",
     "BaseScanner",

--- a/packages/core/src/runsight_core/yaml/discovery/_assertion.py
+++ b/packages/core/src/runsight_core/yaml/discovery/_assertion.py
@@ -124,7 +124,14 @@ class AssertionScanner(BaseScanner[AssertionMeta]):
             return ScanIndex()
 
         results: list[ScanResult[AssertionMeta]] = []
+        seen_stems: set[str] = set()
         for yaml_file in self._glob_yaml_files(asset_dir):
+            if yaml_file.stem in seen_stems:
+                raise _fail_assertion_file(
+                    yaml_file,
+                    f"duplicate custom assertion id collision for {yaml_file.stem!r}",
+                )
+            seen_stems.add(yaml_file.stem)
             result = self._scan_yaml_file(yaml_file)
             if result is not None:
                 results.append(result)
@@ -151,15 +158,23 @@ class AssertionScanner(BaseScanner[AssertionMeta]):
             return ScanIndex()
 
         results: list[ScanResult[AssertionMeta]] = []
+        seen_stems: set[str] = set()
         for line in result.stdout.splitlines():
             candidate = line.strip()
             if not candidate or not candidate.endswith(".yaml"):
                 continue
+            candidate_path = Path(candidate)
+            if candidate_path.stem in seen_stems:
+                raise _fail_assertion_file(
+                    candidate_path,
+                    f"duplicate custom assertion id collision for {candidate_path.stem!r}",
+                )
+            seen_stems.add(candidate_path.stem)
             try:
                 raw_yaml = git_service.read_file(candidate, git_ref)
             except Exception:
                 continue
-            result_item = self._scan_yaml_content(Path(candidate), raw_yaml)
+            result_item = self._scan_yaml_content(candidate_path, raw_yaml)
             if result_item is not None:
                 results.append(result_item)
         return ScanIndex(results)

--- a/packages/core/src/runsight_core/yaml/discovery/_assertion.py
+++ b/packages/core/src/runsight_core/yaml/discovery/_assertion.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import ast
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from runsight_core.assertions.deterministic import _ALL_ASSERTIONS
+from runsight_core.yaml.discovery._base import BaseScanner, ScanIndex, ScanResult
+
+ALLOWED_ASSERTION_RETURNS = frozenset({"bool", "grading_result"})
+RESERVED_BUILTIN_ASSERTION_IDS = frozenset(assertion.type for assertion in _ALL_ASSERTIONS)
+
+
+@dataclass
+class AssertionMeta:
+    """Metadata for a discovered custom assertion manifest."""
+
+    assertion_id: str
+    file_path: Path
+    version: str
+    name: str
+    description: str
+    returns: str
+    source: str
+    params: dict[str, Any] | None = None
+    code: str | None = None
+
+
+def _fail_assertion_file(yaml_file: Path, message: str) -> ValueError:
+    return ValueError(f"{yaml_file.name}: {message}")
+
+
+def _require_string(raw: dict[str, Any], key: str, *, yaml_file: Path) -> str:
+    value = raw.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise _fail_assertion_file(yaml_file, f"missing or invalid {key!r}")
+    return value
+
+
+def _require_optional_mapping(
+    raw: dict[str, Any], key: str, *, yaml_file: Path
+) -> dict[str, Any] | None:
+    value = raw.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise _fail_assertion_file(yaml_file, f"invalid {key!r}")
+    return value
+
+
+def _read_assertion_source_file(yaml_file: Path, source: str) -> str:
+    source_path = yaml_file.parent / source
+    if not source_path.exists():
+        raise _fail_assertion_file(yaml_file, f"referenced source does not exist: {source}")
+    if not source_path.is_file():
+        raise _fail_assertion_file(yaml_file, f"referenced source is not readable: {source}")
+
+    try:
+        return source_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise _fail_assertion_file(
+            yaml_file, f"referenced source is not readable: {source}"
+        ) from exc
+
+
+def _validate_get_assert_contract(code: str) -> None:
+    """Require a strict ``def get_assert(args)`` function in custom assertion code."""
+    try:
+        tree = ast.parse(code)
+    except SyntaxError as exc:
+        raise ValueError(f"Assertion code has a syntax error: {exc}") from exc
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef) or node.name != "get_assert":
+            continue
+
+        if (
+            len(node.args.posonlyargs) != 0
+            or len(node.args.args) != 1
+            or node.args.args[0].arg != "args"
+            or node.args.vararg is not None
+            or len(node.args.kwonlyargs) != 0
+            or node.args.kwarg is not None
+        ):
+            raise ValueError("Assertion code must define 'def get_assert(args)'")
+        return
+
+    raise ValueError("Assertion code must define 'def get_assert(args)'")
+
+
+class AssertionScanner(BaseScanner[AssertionMeta]):
+    """Scanner for custom assertion metadata YAML files."""
+
+    def __init__(
+        self,
+        base_dir: str | Path,
+        *,
+        assertions_subdir: str = "custom/assertions",
+    ) -> None:
+        super().__init__(base_dir)
+        self._assertions_subdir = assertions_subdir
+
+    @property
+    def asset_subdir(self) -> str:
+        return self._assertions_subdir
+
+    def _glob_yaml_files(self, directory: Path) -> list[Path]:
+        return sorted(directory.glob("*.yaml"), key=lambda path: path.name)
+
+    def _parse_file(self, path: Path, raw_yaml: str) -> AssertionMeta:
+        parsed = yaml.safe_load(raw_yaml)
+        if not isinstance(parsed, dict):
+            raise _fail_assertion_file(path, "invalid assertion metadata")
+        return self._parse_assertion_mapping(path, parsed)
+
+    def _scan_filesystem(self) -> ScanIndex[AssertionMeta]:
+        asset_dir = self.asset_dir
+        if not asset_dir.exists():
+            return ScanIndex()
+
+        results: list[ScanResult[AssertionMeta]] = []
+        for yaml_file in self._glob_yaml_files(asset_dir):
+            result = self._scan_yaml_file(yaml_file)
+            if result is not None:
+                results.append(result)
+        return ScanIndex(results)
+
+    def _scan_git(self, git_ref: str, git_service: Any) -> ScanIndex[AssertionMeta]:
+        command = [
+            "git",
+            "ls-tree",
+            "-r",
+            "--name-only",
+            git_ref,
+            "--",
+            f"{self.asset_subdir}/",
+        ]
+        result = subprocess.run(
+            command,
+            cwd=str(git_service.repo_path),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            return ScanIndex()
+
+        results: list[ScanResult[AssertionMeta]] = []
+        for line in result.stdout.splitlines():
+            candidate = line.strip()
+            if not candidate or not candidate.endswith(".yaml"):
+                continue
+            try:
+                raw_yaml = git_service.read_file(candidate, git_ref)
+            except Exception:
+                continue
+            result_item = self._scan_yaml_content(Path(candidate), raw_yaml)
+            if result_item is not None:
+                results.append(result_item)
+        return ScanIndex(results)
+
+    def _parse_assertion_mapping(self, yaml_file: Path, raw: dict[str, Any]) -> AssertionMeta:
+        assertion_id = yaml_file.stem
+        if assertion_id in RESERVED_BUILTIN_ASSERTION_IDS:
+            collision_path: Path | str = yaml_file
+            try:
+                collision_path = yaml_file.relative_to(self.base_dir)
+            except ValueError:
+                try:
+                    collision_path = yaml_file.resolve().relative_to(self.base_dir.resolve())
+                except ValueError:
+                    pass
+            raise _fail_assertion_file(
+                yaml_file,
+                f"reserved builtin assertion id {assertion_id!r} collides with custom assertion metadata at "
+                f"{collision_path}",
+            )
+
+        allowed_fields = {"version", "name", "description", "returns", "source", "params"}
+        extra_fields = sorted(set(raw.keys()) - allowed_fields)
+        if extra_fields:
+            joined = ", ".join(extra_fields)
+            raise _fail_assertion_file(yaml_file, f"unsupported assertion fields: {joined}")
+
+        version = _require_string(raw, "version", yaml_file=yaml_file)
+        name = _require_string(raw, "name", yaml_file=yaml_file)
+        description = _require_string(raw, "description", yaml_file=yaml_file)
+        returns = _require_string(raw, "returns", yaml_file=yaml_file)
+        source = _require_string(raw, "source", yaml_file=yaml_file)
+        params = _require_optional_mapping(raw, "params", yaml_file=yaml_file)
+
+        if returns not in ALLOWED_ASSERTION_RETURNS:
+            allowed = ", ".join(sorted(ALLOWED_ASSERTION_RETURNS))
+            raise _fail_assertion_file(
+                yaml_file,
+                f"invalid returns {returns!r}; expected one of: {allowed}",
+            )
+
+        code = _read_assertion_source_file(yaml_file, source)
+        try:
+            _validate_get_assert_contract(code)
+        except ValueError as exc:
+            raise _fail_assertion_file(yaml_file, str(exc)) from exc
+
+        return AssertionMeta(
+            assertion_id=assertion_id,
+            file_path=yaml_file,
+            version=version,
+            name=name,
+            description=description,
+            returns=returns,
+            source=source,
+            params=params,
+            code=code,
+        )

--- a/packages/core/src/runsight_core/yaml/discovery/_assertion.py
+++ b/packages/core/src/runsight_core/yaml/discovery/_assertion.py
@@ -4,15 +4,31 @@ import ast
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Annotated, Any, Literal
 
 import yaml
+from pydantic import BaseModel, ConfigDict, StringConstraints, ValidationError
 
+from runsight_core.assertions.contract import ASSERTION_FUNCTION_NAME, ASSERTION_FUNCTION_PARAMS
 from runsight_core.assertions.deterministic import _ALL_ASSERTIONS
 from runsight_core.yaml.discovery._base import BaseScanner, ScanIndex, ScanResult
 
-ALLOWED_ASSERTION_RETURNS = frozenset({"bool", "grading_result"})
 RESERVED_BUILTIN_ASSERTION_IDS = frozenset(assertion.type for assertion in _ALL_ASSERTIONS)
+NonEmptyString = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+AssertionReturn = Literal["bool", "grading_result"]
+
+
+class AssertionManifest(BaseModel):
+    """Validated custom assertion manifest schema."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    version: NonEmptyString
+    name: NonEmptyString
+    description: NonEmptyString
+    returns: AssertionReturn
+    source: NonEmptyString
+    params: dict[str, Any] | None = None
 
 
 @dataclass
@@ -21,35 +37,12 @@ class AssertionMeta:
 
     assertion_id: str
     file_path: Path
-    version: str
-    name: str
-    description: str
-    returns: str
-    source: str
-    params: dict[str, Any] | None = None
+    manifest: AssertionManifest
     code: str | None = None
 
 
 def _fail_assertion_file(yaml_file: Path, message: str) -> ValueError:
     return ValueError(f"{yaml_file.name}: {message}")
-
-
-def _require_string(raw: dict[str, Any], key: str, *, yaml_file: Path) -> str:
-    value = raw.get(key)
-    if not isinstance(value, str) or not value.strip():
-        raise _fail_assertion_file(yaml_file, f"missing or invalid {key!r}")
-    return value
-
-
-def _require_optional_mapping(
-    raw: dict[str, Any], key: str, *, yaml_file: Path
-) -> dict[str, Any] | None:
-    value = raw.get(key)
-    if value is None:
-        return None
-    if not isinstance(value, dict):
-        raise _fail_assertion_file(yaml_file, f"invalid {key!r}")
-    return value
 
 
 def _read_assertion_source_file(yaml_file: Path, source: str) -> str:
@@ -67,29 +60,37 @@ def _read_assertion_source_file(yaml_file: Path, source: str) -> str:
         ) from exc
 
 
+def _assertion_signature() -> str:
+    params = ", ".join(ASSERTION_FUNCTION_PARAMS)
+    return f"def {ASSERTION_FUNCTION_NAME}({params})"
+
+
 def _validate_get_assert_contract(code: str) -> None:
-    """Require a strict ``def get_assert(args)`` function in custom assertion code."""
+    """Require the shared custom assertion entrypoint contract."""
     try:
         tree = ast.parse(code)
     except SyntaxError as exc:
         raise ValueError(f"Assertion code has a syntax error: {exc}") from exc
 
     for node in ast.walk(tree):
-        if not isinstance(node, ast.FunctionDef) or node.name != "get_assert":
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == ASSERTION_FUNCTION_NAME:
+            raise ValueError(f"Assertion code must define '{_assertion_signature()}'")
+
+        if not isinstance(node, ast.FunctionDef) or node.name != ASSERTION_FUNCTION_NAME:
             continue
 
         if (
             len(node.args.posonlyargs) != 0
-            or len(node.args.args) != 1
-            or node.args.args[0].arg != "args"
+            or len(node.args.args) != len(ASSERTION_FUNCTION_PARAMS)
+            or tuple(arg.arg for arg in node.args.args) != ASSERTION_FUNCTION_PARAMS
             or node.args.vararg is not None
             or len(node.args.kwonlyargs) != 0
             or node.args.kwarg is not None
         ):
-            raise ValueError("Assertion code must define 'def get_assert(args)'")
+            raise ValueError(f"Assertion code must define '{_assertion_signature()}'")
         return
 
-    raise ValueError("Assertion code must define 'def get_assert(args)'")
+    raise ValueError(f"Assertion code must define '{_assertion_signature()}'")
 
 
 class AssertionScanner(BaseScanner[AssertionMeta]):
@@ -180,27 +181,12 @@ class AssertionScanner(BaseScanner[AssertionMeta]):
                 f"{collision_path}",
             )
 
-        allowed_fields = {"version", "name", "description", "returns", "source", "params"}
-        extra_fields = sorted(set(raw.keys()) - allowed_fields)
-        if extra_fields:
-            joined = ", ".join(extra_fields)
-            raise _fail_assertion_file(yaml_file, f"unsupported assertion fields: {joined}")
+        try:
+            manifest = AssertionManifest.model_validate(raw)
+        except ValidationError as exc:
+            raise _fail_assertion_file(yaml_file, str(exc)) from exc
 
-        version = _require_string(raw, "version", yaml_file=yaml_file)
-        name = _require_string(raw, "name", yaml_file=yaml_file)
-        description = _require_string(raw, "description", yaml_file=yaml_file)
-        returns = _require_string(raw, "returns", yaml_file=yaml_file)
-        source = _require_string(raw, "source", yaml_file=yaml_file)
-        params = _require_optional_mapping(raw, "params", yaml_file=yaml_file)
-
-        if returns not in ALLOWED_ASSERTION_RETURNS:
-            allowed = ", ".join(sorted(ALLOWED_ASSERTION_RETURNS))
-            raise _fail_assertion_file(
-                yaml_file,
-                f"invalid returns {returns!r}; expected one of: {allowed}",
-            )
-
-        code = _read_assertion_source_file(yaml_file, source)
+        code = _read_assertion_source_file(yaml_file, manifest.source)
         try:
             _validate_get_assert_contract(code)
         except ValueError as exc:
@@ -209,11 +195,6 @@ class AssertionScanner(BaseScanner[AssertionMeta]):
         return AssertionMeta(
             assertion_id=assertion_id,
             file_path=yaml_file,
-            version=version,
-            name=name,
-            description=description,
-            returns=returns,
-            source=source,
-            params=params,
+            manifest=manifest,
             code=code,
         )

--- a/packages/core/src/runsight_core/yaml/discovery/_base.py
+++ b/packages/core/src/runsight_core/yaml/discovery/_base.py
@@ -12,6 +12,24 @@ import yaml
 T = TypeVar("T")
 
 
+def resolve_discovery_base_dir(start: Path) -> str:
+    """Resolve the authoritative discovery base directory for a workflow location."""
+    current = start.resolve()
+    current_custom_dir = current / "custom"
+    if current_custom_dir.is_dir():
+        return str(current)
+
+    for candidate in current.parents:
+        custom_dir = candidate / "custom"
+        if not custom_dir.is_dir():
+            continue
+        workflows_dir = candidate / "workflows"
+        if current.is_relative_to(workflows_dir) or current.is_relative_to(custom_dir):
+            return str(candidate)
+
+    return str(current)
+
+
 class AssetType(str, Enum):
     SOUL = "SOUL"
     TOOL = "TOOL"

--- a/packages/core/src/runsight_core/yaml/parser.py
+++ b/packages/core/src/runsight_core/yaml/parser.py
@@ -386,15 +386,13 @@ def _find_project_root(start: Path) -> str:
     current = start.resolve()
     for candidate in [current, *current.parents]:
         custom_dir = candidate / "custom"
+        workflows_dir = candidate / "workflows"
         if not custom_dir.is_dir():
             continue
         if candidate == current:
             return str(candidate)
-        try:
-            current.relative_to(custom_dir)
-        except ValueError:
-            continue
-        return str(candidate)
+        if current.is_relative_to(custom_dir) or current.is_relative_to(workflows_dir):
+            return str(candidate)
     return str(start)
 
 

--- a/packages/core/src/runsight_core/yaml/parser.py
+++ b/packages/core/src/runsight_core/yaml/parser.py
@@ -385,23 +385,7 @@ def _find_project_root(start: Path) -> str:
     """Walk up from *start* to find the directory that contains ``custom/``."""
     current = start.resolve()
     for candidate in [current, *current.parents]:
-        if not (candidate / "custom").is_dir():
-            continue
-        if candidate == current:
-            return str(candidate)
-        # Prefer project-like roots over unrelated ambient temp directories that
-        # may also contain a top-level custom/ folder.
-        if any(
-            (
-                (candidate / "workflows").is_dir(),
-                (candidate / "examples").is_dir(),
-                (candidate / "tests").is_dir(),
-                (candidate / "packages").is_dir(),
-                (candidate / "apps").is_dir(),
-                (candidate / "pyproject.toml").is_file(),
-                (candidate / ".git").is_dir(),
-            )
-        ):
+        if (candidate / "custom").is_dir():
             return str(candidate)
     return str(start)
 

--- a/packages/core/src/runsight_core/yaml/parser.py
+++ b/packages/core/src/runsight_core/yaml/parser.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel
 if TYPE_CHECKING:
     from runsight_core.yaml.registry import WorkflowRegistry
 
+from runsight_core.assertions.registry import register_custom_assertions
 from runsight_core.blocks.base import BaseBlock
 from runsight_core.conditions.engine import (
     Condition,
@@ -25,7 +26,7 @@ from runsight_core.primitives import Soul, Step, Task
 from runsight_core.runner import RunsightTeamRunner
 from runsight_core.tools._catalog import RESERVED_BUILTIN_TOOL_IDS, resolve_tool_id
 from runsight_core.workflow import Workflow
-from runsight_core.yaml.discovery import SoulScanner, ToolScanner, WorkflowScanner
+from runsight_core.yaml.discovery import AssertionScanner, SoulScanner, ToolScanner, WorkflowScanner
 from runsight_core.yaml.schema import (
     CaseDef,
     ConditionDef,
@@ -384,8 +385,16 @@ def _find_project_root(start: Path) -> str:
     """Walk up from *start* to find the directory that contains ``custom/``."""
     current = start.resolve()
     for candidate in [current, *current.parents]:
-        if (candidate / "custom").is_dir():
+        custom_dir = candidate / "custom"
+        if not custom_dir.is_dir():
+            continue
+        if candidate == current:
             return str(candidate)
+        try:
+            current.relative_to(custom_dir)
+        except ValueError:
+            continue
+        return str(candidate)
     return str(start)
 
 
@@ -624,6 +633,9 @@ def parse_workflow_yaml(
         file_def,
         workflow_label=getattr(file_def.workflow, "name", "<root>"),
     )
+
+    assertion_index = AssertionScanner(workflow_base_dir).scan()
+    register_custom_assertions(assertion_index)
 
     # Step 3: Discover library souls from custom/souls/.
     souls_dir = Path(workflow_base_dir) / "custom" / "souls"

--- a/packages/core/src/runsight_core/yaml/parser.py
+++ b/packages/core/src/runsight_core/yaml/parser.py
@@ -26,7 +26,13 @@ from runsight_core.primitives import Soul, Step, Task
 from runsight_core.runner import RunsightTeamRunner
 from runsight_core.tools._catalog import RESERVED_BUILTIN_TOOL_IDS, resolve_tool_id
 from runsight_core.workflow import Workflow
-from runsight_core.yaml.discovery import AssertionScanner, SoulScanner, ToolScanner, WorkflowScanner
+from runsight_core.yaml.discovery import (
+    AssertionScanner,
+    SoulScanner,
+    ToolScanner,
+    WorkflowScanner,
+    resolve_discovery_base_dir,
+)
 from runsight_core.yaml.schema import (
     CaseDef,
     ConditionDef,
@@ -381,15 +387,6 @@ _rebuild()
 del _rebuild
 
 
-def _find_project_root(start: Path) -> str:
-    """Walk up from *start* to find the directory that contains ``custom/``."""
-    current = start.resolve()
-    for candidate in [current, *current.parents]:
-        if (candidate / "custom").is_dir():
-            return str(candidate)
-    return str(start)
-
-
 def _validate_workflow_block_contract(
     block_id: str,
     block_def: Any,
@@ -539,7 +536,7 @@ def validate_workflow_call_contracts(
 
         validate_workflow_call_contracts(
             child_file,
-            base_dir=_find_project_root(child_path.parent),
+            base_dir=resolve_discovery_base_dir(child_path.parent),
             validation_index=validation_index,
             current_workflow_ref=child_ref,
             ancestry=(*ancestry, child_ref),
@@ -587,7 +584,9 @@ def parse_workflow_yaml(
             stripped.endswith(".yaml") or stripped.endswith(".yml") or stripped.endswith(".json")
         )
         if is_file_path:
-            workflow_base_dir = _base_dir or _find_project_root(Path(stripped).resolve().parent)
+            workflow_base_dir = _base_dir or resolve_discovery_base_dir(
+                Path(stripped).resolve().parent
+            )
             require_custom_metadata = True
             with open(stripped, "r", encoding="utf-8") as f:
                 raw: Any = yaml.safe_load(f)

--- a/packages/core/src/runsight_core/yaml/parser.py
+++ b/packages/core/src/runsight_core/yaml/parser.py
@@ -51,6 +51,11 @@ _UNSET_RUNNER_MODEL_NAME = "__runsight_explicit_model_required__"
 logger = logging.getLogger(__name__)
 
 
+def _find_project_root(start: str | Path) -> str:
+    """Backward-compatible alias for shared discovery base-dir resolution."""
+    return resolve_discovery_base_dir(Path(start))
+
+
 def _bootstrap_runner_model_name(souls_map: Dict[str, Soul]) -> str:
     """Choose an explicit bootstrap model for parser-owned runner construction."""
     for soul in souls_map.values():

--- a/packages/core/src/runsight_core/yaml/parser.py
+++ b/packages/core/src/runsight_core/yaml/parser.py
@@ -385,13 +385,23 @@ def _find_project_root(start: Path) -> str:
     """Walk up from *start* to find the directory that contains ``custom/``."""
     current = start.resolve()
     for candidate in [current, *current.parents]:
-        custom_dir = candidate / "custom"
-        workflows_dir = candidate / "workflows"
-        if not custom_dir.is_dir():
+        if not (candidate / "custom").is_dir():
             continue
         if candidate == current:
             return str(candidate)
-        if current.is_relative_to(custom_dir) or current.is_relative_to(workflows_dir):
+        # Prefer project-like roots over unrelated ambient temp directories that
+        # may also contain a top-level custom/ folder.
+        if any(
+            (
+                (candidate / "workflows").is_dir(),
+                (candidate / "examples").is_dir(),
+                (candidate / "tests").is_dir(),
+                (candidate / "packages").is_dir(),
+                (candidate / "apps").is_dir(),
+                (candidate / "pyproject.toml").is_file(),
+                (candidate / ".git").is_dir(),
+            )
+        ):
             return str(candidate)
     return str(start)
 

--- a/packages/core/tests/assertions/test_registry.py
+++ b/packages/core/tests/assertions/test_registry.py
@@ -225,6 +225,7 @@ class TestRunAssertion:
             value="exact match",
         )
         assert isinstance(result, GradingResult)
+        assert result.passed is True
 
     def test_run_assertion_passes_threshold_to_cost_constructor(self, monkeypatch):
         """Cost assertions receive the configured threshold during construction."""

--- a/packages/core/tests/assertions/test_registry.py
+++ b/packages/core/tests/assertions/test_registry.py
@@ -9,6 +9,7 @@ from runsight_core.assertions.registry import (
     register_assertion,
     run_assertion,
     run_assertions,
+    run_assertions_sync,
 )
 from runsight_core.assertions.scoring import AssertionsResult
 
@@ -300,6 +301,35 @@ class TestRunAssertion:
         )
         assert isinstance(result, GradingResult)
 
+    def test_run_assertion_passes_config_to_builtin_constructor_without_changing_behavior(
+        self, monkeypatch
+    ):
+        """Builtins receive config in the constructor and still behave the same."""
+        import runsight_core.assertions.deterministic  # noqa: F401
+        from runsight_core.assertions.deterministic.performance import CostAssertion
+
+        register_assertion("cost", CostAssertion)
+        ctx = _make_context(cost_usd=0.04)
+        captured: dict[str, object] = {}
+        original_init = CostAssertion.__init__
+
+        def recording_init(self, value=None, threshold=None, config=None):
+            captured["config"] = config
+            original_init(self, value=value, threshold=threshold, config=config)
+
+        monkeypatch.setattr(CostAssertion, "__init__", recording_init)
+
+        result = run_assertion(
+            type="cost",
+            output="Hello",
+            context=ctx,
+            threshold=0.05,
+            config={"mode": "strict"},
+        )
+
+        assert captured["config"] == {"mode": "strict"}
+        assert result.passed is True
+
 
 # ---------------------------------------------------------------------------
 # AC-11: run_assertions() runs all with concurrency limit
@@ -407,3 +437,123 @@ class TestRunAssertions:
         result = await run_assertions(config, output="Hello world", context=ctx)
         # Only weight=1.0 assertion in aggregate
         assert abs(result.aggregate_score - 1.0) < 1e-9
+
+    @pytest.mark.asyncio
+    async def test_run_assertions_passes_config_to_custom_handler_constructor(self):
+        captured: list[object] = []
+
+        class RecordingAssertion:
+            type = "recording-async-config"
+
+            def __init__(self, value="", threshold=None, config=None):
+                captured.append(config)
+
+            def evaluate(self, output: str, context: AssertionContext) -> GradingResult:
+                return GradingResult(
+                    passed=True,
+                    score=1.0,
+                    reason="config recorded",
+                    assertion_type=self.type,
+                )
+
+        register_assertion("recording-async-config", RecordingAssertion)
+        ctx = _make_context()
+
+        result = await run_assertions(
+            [{"type": "recording-async-config", "config": {"mode": "strict"}}],
+            output="Hello world",
+            context=ctx,
+        )
+
+        assert result.results[0].passed is True
+        assert captured == [{"mode": "strict"}]
+
+    @pytest.mark.asyncio
+    async def test_run_assertions_missing_config_defaults_to_none(self):
+        captured: list[object] = []
+
+        class RecordingAssertion:
+            type = "recording-none-config"
+
+            def __init__(self, value="", threshold=None, config=None):
+                captured.append(config)
+
+            def evaluate(self, output: str, context: AssertionContext) -> GradingResult:
+                return GradingResult(
+                    passed=True,
+                    score=1.0,
+                    reason="config recorded",
+                    assertion_type=self.type,
+                )
+
+        register_assertion("recording-none-config", RecordingAssertion)
+        ctx = _make_context()
+
+        result = await run_assertions(
+            [{"type": "recording-none-config"}],
+            output="Hello world",
+            context=ctx,
+        )
+
+        assert result.results[0].passed is True
+        assert captured == [None]
+
+
+class TestRunAssertionsSync:
+    def test_run_assertions_sync_passes_config_to_custom_handler_constructor(self):
+        captured: list[object] = []
+
+        class RecordingAssertion:
+            type = "recording-sync-config"
+
+            def __init__(self, value="", threshold=None, config=None):
+                captured.append(config)
+
+            def evaluate(self, output: str, context: AssertionContext) -> GradingResult:
+                return GradingResult(
+                    passed=True,
+                    score=1.0,
+                    reason="config recorded",
+                    assertion_type=self.type,
+                )
+
+        register_assertion("recording-sync-config", RecordingAssertion)
+        ctx = _make_context()
+
+        result = run_assertions_sync(
+            [{"type": "recording-sync-config", "config": {"mode": "strict"}}],
+            output="Hello world",
+            context=ctx,
+        )
+
+        assert result.results[0].passed is True
+        assert captured == [{"mode": "strict"}]
+
+    def test_run_assertions_sync_passes_non_dict_config_through_unchanged(self):
+        captured: list[object] = []
+
+        class RecordingAssertion:
+            type = "recording-raw-config"
+
+            def __init__(self, value="", threshold=None, config=None):
+                captured.append(config)
+
+            def evaluate(self, output: str, context: AssertionContext) -> GradingResult:
+                return GradingResult(
+                    passed=True,
+                    score=1.0,
+                    reason="config recorded",
+                    assertion_type=self.type,
+                )
+
+        register_assertion("recording-raw-config", RecordingAssertion)
+        ctx = _make_context()
+
+        result = run_assertions_sync(
+            [{"type": "recording-raw-config", "config": "raw-config-token"}],
+            output="Hello world",
+            context=ctx,
+        )
+
+        assert result.results[0].passed is True
+        assert captured == ["raw-config-token"]

--- a/packages/core/tests/assertions/test_registry.py
+++ b/packages/core/tests/assertions/test_registry.py
@@ -225,7 +225,62 @@ class TestRunAssertion:
             value="exact match",
         )
         assert isinstance(result, GradingResult)
-        assert result.passed is True
+
+    def test_run_assertion_passes_threshold_to_cost_constructor(self, monkeypatch):
+        """Cost assertions receive the configured threshold during construction."""
+        import runsight_core.assertions.deterministic  # noqa: F401
+        from runsight_core.assertions.deterministic.performance import CostAssertion
+
+        register_assertion("cost", CostAssertion)
+        ctx = _make_context(cost_usd=0.04)
+        captured: dict[str, object] = {}
+        original_init = CostAssertion.__init__
+
+        def recording_init(self, value=None, threshold=None, config=None):
+            captured["value"] = value
+            captured["threshold"] = threshold
+            captured["config"] = config
+            original_init(self, value=value, threshold=threshold)
+
+        monkeypatch.setattr(CostAssertion, "__init__", recording_init)
+
+        run_assertion(
+            type="cost",
+            output="Hello",
+            context=ctx,
+            threshold=0.05,
+        )
+
+        assert captured["threshold"] == 0.05
+
+    def test_run_assertion_raises_when_constructor_rejects_kwargs(self):
+        """Unsupported assertion constructors should fail loudly instead of falling back."""
+
+        class NoKwargsAssertion:
+            type: str = "no-kwargs"
+
+            def __init__(self):
+                self.initialized = True
+
+            def evaluate(self, output: str, context: AssertionContext) -> GradingResult:
+                return GradingResult(
+                    passed=True,
+                    score=1.0,
+                    reason="unexpected success",
+                    assertion_type="no-kwargs",
+                )
+
+        register_assertion("no-kwargs", NoKwargsAssertion)
+        ctx = _make_context()
+
+        with pytest.raises(TypeError):
+            run_assertion(
+                type="no-kwargs",
+                output="Hello",
+                context=ctx,
+                value="Hello",
+                threshold=0.5,
+            )
 
     def test_run_assertion_accepts_threshold_and_weight_and_metric(self):
         """run_assertion accepts threshold, weight, and metric parameters."""

--- a/packages/core/tests/assertions/test_run795_custom_return_validators.py
+++ b/packages/core/tests/assertions/test_run795_custom_return_validators.py
@@ -1,0 +1,130 @@
+"""Red tests for RUN-795: custom assertion return validators."""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from runsight_core.assertions.base import GradingResult
+
+
+def _load_symbols():
+    module = importlib.import_module("runsight_core.assertions.custom")
+    return (
+        module._validate_bool_return,
+        module._validate_grading_result_return,
+        module._RETURN_VALIDATORS,
+    )
+
+
+class TestValidateBoolReturn:
+    def test_true_maps_to_passing_grading_result(self):
+        validate_bool_return, _, _ = _load_symbols()
+
+        result = validate_bool_return(True, "budget_guard")
+
+        assert isinstance(result, GradingResult)
+        assert result.passed is True
+        assert result.score == 1.0
+        assert result.assertion_type == "custom:budget_guard"
+
+    def test_false_maps_to_failing_grading_result(self):
+        validate_bool_return, _, _ = _load_symbols()
+
+        result = validate_bool_return(False, "budget_guard")
+
+        assert isinstance(result, GradingResult)
+        assert result.passed is False
+        assert result.score == 0.0
+        assert result.assertion_type == "custom:budget_guard"
+
+    def test_non_bool_raises_type_error_with_plugin_name_and_actual_type(self):
+        validate_bool_return, _, _ = _load_symbols()
+
+        with pytest.raises(TypeError) as exc_info:
+            validate_bool_return(0.85, "budget_guard")
+
+        message = str(exc_info.value)
+        assert "budget_guard" in message
+        assert "returns: bool" in message
+        assert "float" in message
+
+
+class TestValidateGradingResultReturn:
+    def test_pass_alias_is_accepted(self):
+        _, validate_grading_result_return, _ = _load_symbols()
+
+        result = validate_grading_result_return(
+            {"pass": True, "score": 0.9},
+            "budget_guard",
+        )
+
+        assert isinstance(result, GradingResult)
+        assert result.passed is True
+        assert result.score == 0.9
+        assert result.reason == ""
+        assert result.assertion_type == "custom:budget_guard"
+
+    def test_passed_key_wins_over_aliases(self):
+        _, validate_grading_result_return, _ = _load_symbols()
+
+        result = validate_grading_result_return(
+            {"passed": False, "pass_": True, "pass": True, "score": 0.2},
+            "budget_guard",
+        )
+
+        assert result.passed is False
+        assert result.score == 0.2
+
+    def test_reason_is_coerced_to_string(self):
+        _, validate_grading_result_return, _ = _load_symbols()
+
+        result = validate_grading_result_return(
+            {"passed": True, "score": 1, "reason": 404},
+            "budget_guard",
+        )
+
+        assert result.passed is True
+        assert result.score == 1.0
+        assert result.reason == "404"
+
+    def test_missing_score_key_raises_type_error_with_expected_and_actual_keys(self):
+        _, validate_grading_result_return, _ = _load_symbols()
+
+        with pytest.raises(TypeError) as exc_info:
+            validate_grading_result_return({"passed": True}, "budget_guard")
+
+        message = str(exc_info.value)
+        assert "budget_guard" in message
+        assert "score" in message
+        assert "passed" in message
+
+    def test_non_mapping_raises_type_error(self):
+        _, validate_grading_result_return, _ = _load_symbols()
+
+        with pytest.raises(TypeError) as exc_info:
+            validate_grading_result_return(True, "budget_guard")
+
+        message = str(exc_info.value)
+        assert "budget_guard" in message
+        assert "dict" in message
+        assert "bool" in message
+
+    def test_score_out_of_range_raises_value_error(self):
+        _, validate_grading_result_return, _ = _load_symbols()
+
+        with pytest.raises(ValueError) as exc_info:
+            validate_grading_result_return({"passed": True, "score": 1.5}, "budget_guard")
+
+        message = str(exc_info.value)
+        assert "budget_guard" in message
+        assert "between 0.0 and 1.0" in message
+
+
+class TestReturnValidatorsTable:
+    def test_dispatch_table_contains_supported_return_contracts(self):
+        validate_bool_return, validate_grading_result_return, validators = _load_symbols()
+
+        assert validators["bool"] is validate_bool_return
+        assert validators["grading_result"] is validate_grading_result_return
+        assert set(validators) == {"bool", "grading_result"}

--- a/packages/core/tests/assertions/test_run796_custom_adapter.py
+++ b/packages/core/tests/assertions/test_run796_custom_adapter.py
@@ -355,3 +355,240 @@ def get_assert(output, context):
         assert "30" in result.reason or "timed out" in result.reason
         assert proc.kill_called is True
         assert proc.wait_called is True
+
+
+class TestAdapterParamSchemaValidation:
+    def test_valid_config_against_declared_params_schema_runs_plugin_and_passes(self, monkeypatch):
+        module, build_adapter_class = _load_symbols()
+        monkeypatch.setattr(
+            module,
+            "_PARAM_SCHEMAS",
+            {
+                "budget_guard": {
+                    "type": "object",
+                    "properties": {"budget": {"type": "number"}},
+                    "required": ["budget"],
+                }
+            },
+            raising=False,
+        )
+        plugin_calls: list[dict[str, Any]] = []
+        adapter_cls = build_adapter_class(
+            "budget_guard",
+            """
+def get_assert(output, context):
+    return True
+""",
+            "bool",
+        )
+        adapter = adapter_cls(config={"budget": 0.05})
+
+        def fake_run_plugin_sync(harness, output, plugin_context, *, timeout_seconds=30):
+            plugin_calls.append(plugin_context)
+            return True
+
+        monkeypatch.setattr(module, "_run_plugin_sync", fake_run_plugin_sync)
+
+        result = adapter.evaluate("needle in haystack", _make_context())
+
+        assert result.passed is True
+        assert plugin_calls == [
+            {
+                "vars": {"topic": "launch", "severity": "high"},
+                "config": {"budget": 0.05},
+                "prompt": "Find the launch blocker.",
+                "prompt_hash": "prompt-hash-123",
+                "soul_id": "soul-1",
+                "soul_version": "v7",
+                "block_id": "block-a",
+                "block_type": "LinearBlock",
+                "cost_usd": 0.031,
+                "total_tokens": 321,
+                "latency_ms": 245.5,
+                "run_id": "run-123",
+                "workflow_id": "wf-456",
+            }
+        ]
+
+    def test_missing_required_field_returns_failing_grading_result_and_skips_plugin(
+        self, monkeypatch
+    ):
+        module, build_adapter_class = _load_symbols()
+        monkeypatch.setattr(
+            module,
+            "_PARAM_SCHEMAS",
+            {
+                "budget_guard": {
+                    "type": "object",
+                    "properties": {"budget": {"type": "number"}},
+                    "required": ["budget"],
+                }
+            },
+            raising=False,
+        )
+        plugin_calls: list[dict[str, Any]] = []
+        adapter_cls = build_adapter_class(
+            "budget_guard",
+            """
+def get_assert(output, context):
+    return True
+""",
+            "bool",
+        )
+        adapter = adapter_cls(config={})
+
+        def fake_run_plugin_sync(harness, output, plugin_context, *, timeout_seconds=30):
+            plugin_calls.append(plugin_context)
+            return True
+
+        monkeypatch.setattr(module, "_run_plugin_sync", fake_run_plugin_sync)
+
+        result = adapter.evaluate("needle in haystack", _make_context())
+
+        assert result.passed is False
+        assert result.reason.startswith("Config validation failed:")
+        assert plugin_calls == []
+
+    def test_wrong_type_returns_failing_grading_result_and_skips_plugin(self, monkeypatch):
+        module, build_adapter_class = _load_symbols()
+        monkeypatch.setattr(
+            module,
+            "_PARAM_SCHEMAS",
+            {
+                "budget_guard": {
+                    "type": "object",
+                    "properties": {"budget": {"type": "number"}},
+                    "required": ["budget"],
+                }
+            },
+            raising=False,
+        )
+        plugin_calls: list[dict[str, Any]] = []
+        adapter_cls = build_adapter_class(
+            "budget_guard",
+            """
+def get_assert(output, context):
+    return True
+""",
+            "bool",
+        )
+        adapter = adapter_cls(config={"budget": "expensive"})
+
+        def fake_run_plugin_sync(harness, output, plugin_context, *, timeout_seconds=30):
+            plugin_calls.append(plugin_context)
+            return True
+
+        monkeypatch.setattr(module, "_run_plugin_sync", fake_run_plugin_sync)
+
+        result = adapter.evaluate("needle in haystack", _make_context())
+
+        assert result.passed is False
+        assert result.reason.startswith("Config validation failed:")
+        assert plugin_calls == []
+
+    def test_no_params_schema_skips_validation_and_runs_plugin(self, monkeypatch):
+        module, build_adapter_class = _load_symbols()
+        monkeypatch.setattr(module, "_PARAM_SCHEMAS", {}, raising=False)
+        plugin_calls: list[dict[str, Any]] = []
+        adapter_cls = build_adapter_class(
+            "no_schema_guard",
+            """
+def get_assert(output, context):
+    return True
+""",
+            "bool",
+        )
+        adapter = adapter_cls(config=None)
+
+        def fake_run_plugin_sync(harness, output, plugin_context, *, timeout_seconds=30):
+            plugin_calls.append(plugin_context)
+            return True
+
+        monkeypatch.setattr(module, "_run_plugin_sync", fake_run_plugin_sync)
+
+        result = adapter.evaluate("needle in haystack", _make_context())
+
+        assert result.passed is True
+        assert len(plugin_calls) == 1
+
+    def test_config_none_with_required_params_returns_failing_grading_result(self, monkeypatch):
+        module, build_adapter_class = _load_symbols()
+        monkeypatch.setattr(
+            module,
+            "_PARAM_SCHEMAS",
+            {
+                "budget_guard": {
+                    "type": "object",
+                    "properties": {"budget": {"type": "number"}},
+                    "required": ["budget"],
+                }
+            },
+            raising=False,
+        )
+        plugin_calls: list[dict[str, Any]] = []
+        adapter_cls = build_adapter_class(
+            "budget_guard",
+            """
+def get_assert(output, context):
+    return True
+""",
+            "bool",
+        )
+        adapter = adapter_cls(config=None)
+
+        def fake_run_plugin_sync(harness, output, plugin_context, *, timeout_seconds=30):
+            plugin_calls.append(plugin_context)
+            return True
+
+        monkeypatch.setattr(module, "_run_plugin_sync", fake_run_plugin_sync)
+
+        result = adapter.evaluate("needle in haystack", _make_context())
+
+        assert result.passed is False
+        assert result.reason.startswith("Config validation failed:")
+        assert plugin_calls == []
+
+    def test_nested_schema_validation_returns_failing_grading_result_and_skips_plugin(
+        self, monkeypatch
+    ):
+        module, build_adapter_class = _load_symbols()
+        monkeypatch.setattr(
+            module,
+            "_PARAM_SCHEMAS",
+            {
+                "nested_guard": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "properties": {"budget": {"type": "number"}},
+                            "required": ["budget"],
+                        }
+                    },
+                    "required": ["limits"],
+                }
+            },
+            raising=False,
+        )
+        plugin_calls: list[dict[str, Any]] = []
+        adapter_cls = build_adapter_class(
+            "nested_guard",
+            """
+def get_assert(output, context):
+    return True
+""",
+            "bool",
+        )
+        adapter = adapter_cls(config={"limits": {"budget": "too-high"}})
+
+        def fake_run_plugin_sync(harness, output, plugin_context, *, timeout_seconds=30):
+            plugin_calls.append(plugin_context)
+            return True
+
+        monkeypatch.setattr(module, "_run_plugin_sync", fake_run_plugin_sync)
+
+        result = adapter.evaluate("needle in haystack", _make_context())
+
+        assert result.passed is False
+        assert result.reason.startswith("Config validation failed:")
+        assert plugin_calls == []

--- a/packages/core/tests/assertions/test_run796_custom_adapter.py
+++ b/packages/core/tests/assertions/test_run796_custom_adapter.py
@@ -263,6 +263,22 @@ def get_assert(output, context):
 
         assert result.passed is True
 
+    def test_adapter_passes_non_dict_config_through_to_plugin_context(self):
+        _, build_adapter_class = _load_symbols()
+        adapter_cls = build_adapter_class(
+            "raw_config_passthrough",
+            """
+def get_assert(output, context):
+    return context["config"] == "raw-config-token"
+""",
+            "bool",
+        )
+        adapter = adapter_cls(config="raw-config-token")
+
+        result = adapter.evaluate("needle in haystack", _make_context())
+
+        assert result.passed is True
+
     def test_adapter_subprocess_env_is_minimal_and_does_not_forward_api_keys(self, monkeypatch):
         module, build_adapter_class = _load_symbols()
         adapter_cls = build_adapter_class(

--- a/packages/core/tests/assertions/test_run796_custom_adapter.py
+++ b/packages/core/tests/assertions/test_run796_custom_adapter.py
@@ -52,12 +52,8 @@ class TestBuildAdapterClass:
         adapter_cls = build_adapter_class(
             "budget_guard",
             """
-def get_assert(args):
-    return (
-        args["output"] == "needle in haystack"
-        and args["value"] == "needle"
-        and args["threshold"] == 0.8
-    )
+def get_assert(output, context):
+    return output == "needle in haystack" and context["vars"]["topic"] == "launch"
 """,
             "bool",
         )
@@ -65,8 +61,8 @@ def get_assert(args):
 
         assert adapter_cls.type == "custom:budget_guard"
 
-        adapter = adapter_cls(value="needle", threshold=0.8, config={"budget": 0.05})
-        assert adapter.value == "needle"
+        adapter = adapter_cls(value="ignored", threshold=0.8, config={"budget": 0.05})
+        assert adapter.value == "ignored"
         assert adapter.threshold == 0.8
         assert adapter.config == {"budget": 0.05}
 
@@ -82,22 +78,22 @@ def get_assert(args):
         adapter_cls = build_adapter_class(
             "promptfoo_contract",
             """
-def get_assert(args):
-    ctx = args["context"]
+def get_assert(output, context):
     return (
-        ctx["vars"]["topic"] == "launch"
-        and ctx["config"]["budget"] == 0.05
-        and ctx["prompt"] == "Find the launch blocker."
-        and ctx["prompt_hash"] == "prompt-hash-123"
-        and ctx["soul_id"] == "soul-1"
-        and ctx["soul_version"] == "v7"
-        and ctx["block_id"] == "block-a"
-        and ctx["block_type"] == "LinearBlock"
-        and ctx["cost_usd"] == 0.031
-        and ctx["total_tokens"] == 321
-        and ctx["latency_ms"] == 245.5
-        and ctx["run_id"] == "run-123"
-        and ctx["workflow_id"] == "wf-456"
+        output == "needle in haystack"
+        and context["vars"]["topic"] == "launch"
+        and context["config"]["budget"] == 0.05
+        and context["prompt"] == "Find the launch blocker."
+        and context["prompt_hash"] == "prompt-hash-123"
+        and context["soul_id"] == "soul-1"
+        and context["soul_version"] == "v7"
+        and context["block_id"] == "block-a"
+        and context["block_type"] == "LinearBlock"
+        and context["cost_usd"] == 0.031
+        and context["total_tokens"] == 321
+        and context["latency_ms"] == 245.5
+        and context["run_id"] == "run-123"
+        and context["workflow_id"] == "wf-456"
     )
 """,
             "bool",
@@ -114,11 +110,11 @@ def get_assert(args):
         adapter_cls = build_adapter_class(
             "rich_result",
             """
-def get_assert(args):
+def get_assert(output, context):
     return {
-        "passed": args["context"]["vars"]["topic"] == "launch",
+        "passed": output == "needle in haystack",
         "score": 0.9,
-        "reason": "topic matched vars alias",
+        "reason": f'topic matched {context["vars"]["topic"]}',
     }
 """,
             "grading_result",
@@ -130,7 +126,7 @@ def get_assert(args):
         assert isinstance(result, GradingResult)
         assert result.passed is True
         assert result.score == 0.9
-        assert result.reason == "topic matched vars alias"
+        assert result.reason == "topic matched launch"
         assert result.assertion_type == "custom:rich_result"
 
     def test_adapter_wraps_plugin_exception_in_failing_grading_result(self):
@@ -138,7 +134,7 @@ def get_assert(args):
         adapter_cls = build_adapter_class(
             "boom_guard",
             """
-def get_assert(args):
+def get_assert(output, context):
     raise RuntimeError("kaboom")
 """,
             "bool",
@@ -163,7 +159,7 @@ def get_assert(args):
                 """
 import os
 
-def get_assert(args):
+def get_assert(output, context):
     return True
 """,
                 "bool",
@@ -173,14 +169,38 @@ def get_assert(args):
         assert "os" in message
         assert "not allowed" in message or "allowed list" in message
 
+    @pytest.mark.parametrize(
+        ("code", "expected_fragment"),
+        [
+            ("def nope(output, context):\n    return True\n", "get_assert"),
+            ("def get_assert(output):\n    return True\n", "get_assert"),
+            (
+                "def get_assert(args, context, extra):\n    return True\n",
+                "get_assert",
+            ),
+            ("def get_assert(output, context)\n    return True\n", "syntax"),
+        ],
+    )
+    def test_build_adapter_class_rejects_invalid_get_assert_contract_before_execution(
+        self,
+        code: str,
+        expected_fragment: str,
+    ):
+        _, build_adapter_class = _load_symbols()
+
+        with pytest.raises(ValueError) as exc_info:
+            build_adapter_class("bad_contract", code, "bool")
+
+        message = str(exc_info.value).lower()
+        assert expected_fragment in message
+
     def test_adapter_does_not_expose_variables_key_in_context_dict(self):
         _, build_adapter_class = _load_symbols()
         adapter_cls = build_adapter_class(
             "vars_only",
             """
-def get_assert(args):
-    ctx = args["context"]
-    return "variables" not in ctx and ctx["vars"]["severity"] == "high"
+def get_assert(output, context):
+    return "variables" not in context and context["vars"]["severity"] == "high"
 """,
             "bool",
         )
@@ -195,7 +215,7 @@ def get_assert(args):
         adapter_cls = build_adapter_class(
             "isolated_guard",
             """
-def get_assert(args):
+def get_assert(output, context):
     return True
 """,
             "bool",

--- a/packages/core/tests/assertions/test_run796_custom_adapter.py
+++ b/packages/core/tests/assertions/test_run796_custom_adapter.py
@@ -129,6 +129,41 @@ def get_assert(output, context):
         assert result.reason == "topic matched launch"
         assert result.assertion_type == "custom:rich_result"
 
+    def test_adapter_routes_raw_plugin_result_through_return_validators_table(self, monkeypatch):
+        module, build_adapter_class = _load_symbols()
+        validator_calls: list[tuple[object, str]] = []
+
+        def fake_validator(raw: object, plugin_name: str) -> GradingResult:
+            validator_calls.append((raw, plugin_name))
+            return GradingResult(
+                passed=True,
+                score=0.75,
+                reason="validated through shared table",
+                assertion_type=f"custom:{plugin_name}",
+            )
+
+        monkeypatch.setitem(module._RETURN_VALIDATORS, "bool", fake_validator)
+        adapter_cls = build_adapter_class(
+            "validator_seam",
+            """
+def get_assert(output, context):
+    return {"raw_output": output, "topic": context["vars"]["topic"]}
+""",
+            "bool",
+        )
+        adapter = adapter_cls(config={"budget": 0.05})
+
+        result = adapter.evaluate("needle in haystack", _make_context())
+
+        assert result.passed is True
+        assert result.score == 0.75
+        assert validator_calls == [
+            (
+                {"raw_output": "needle in haystack", "topic": "launch"},
+                "validator_seam",
+            )
+        ]
+
     def test_adapter_wraps_plugin_exception_in_failing_grading_result(self):
         _, build_adapter_class = _load_symbols()
         adapter_cls = build_adapter_class(

--- a/packages/core/tests/assertions/test_run796_custom_adapter.py
+++ b/packages/core/tests/assertions/test_run796_custom_adapter.py
@@ -1,0 +1,222 @@
+"""Red tests for RUN-796: custom assertion adapter class builder."""
+
+from __future__ import annotations
+
+import importlib
+import json
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+from runsight_core.assertions.base import AssertionContext, GradingResult
+
+
+def _load_symbols():
+    module = importlib.import_module("runsight_core.assertions.custom")
+    return module, module._build_adapter_class
+
+
+def _make_context(**overrides: Any) -> AssertionContext:
+    defaults = dict(
+        output="needle in haystack",
+        prompt="Find the launch blocker.",
+        prompt_hash="prompt-hash-123",
+        soul_id="soul-1",
+        soul_version="v7",
+        block_id="block-a",
+        block_type="LinearBlock",
+        cost_usd=0.031,
+        total_tokens=321,
+        latency_ms=245.5,
+        variables={"topic": "launch", "severity": "high"},
+        run_id="run-123",
+        workflow_id="wf-456",
+    )
+    defaults.update(overrides)
+    return AssertionContext(**defaults)
+
+
+@dataclass
+class _FakeProc:
+    stdout_payload: bytes
+    stderr_payload: bytes = b""
+    returncode: int = 0
+
+    async def communicate(self, input: bytes | None = None):
+        return self.stdout_payload, self.stderr_payload
+
+
+class TestBuildAdapterClass:
+    def test_build_adapter_class_creates_custom_assertion_type_and_bool_result(self):
+        _, build_adapter_class = _load_symbols()
+        adapter_cls = build_adapter_class(
+            "budget_guard",
+            """
+def get_assert(args):
+    return (
+        args["output"] == "needle in haystack"
+        and args["value"] == "needle"
+        and args["threshold"] == 0.8
+    )
+""",
+            "bool",
+        )
+        ctx = _make_context()
+
+        assert adapter_cls.type == "custom:budget_guard"
+
+        adapter = adapter_cls(value="needle", threshold=0.8, config={"budget": 0.05})
+        assert adapter.value == "needle"
+        assert adapter.threshold == 0.8
+        assert adapter.config == {"budget": 0.05}
+
+        result = adapter.evaluate("needle in haystack", ctx)
+
+        assert isinstance(result, GradingResult)
+        assert result.passed is True
+        assert result.score == 1.0
+        assert result.assertion_type == "custom:budget_guard"
+
+    def test_adapter_passes_promptfoo_context_aliases_vars_and_config(self):
+        _, build_adapter_class = _load_symbols()
+        adapter_cls = build_adapter_class(
+            "promptfoo_contract",
+            """
+def get_assert(args):
+    ctx = args["context"]
+    return (
+        ctx["vars"]["topic"] == "launch"
+        and ctx["config"]["budget"] == 0.05
+        and ctx["prompt"] == "Find the launch blocker."
+        and ctx["prompt_hash"] == "prompt-hash-123"
+        and ctx["soul_id"] == "soul-1"
+        and ctx["soul_version"] == "v7"
+        and ctx["block_id"] == "block-a"
+        and ctx["block_type"] == "LinearBlock"
+        and ctx["cost_usd"] == 0.031
+        and ctx["total_tokens"] == 321
+        and ctx["latency_ms"] == 245.5
+        and ctx["run_id"] == "run-123"
+        and ctx["workflow_id"] == "wf-456"
+    )
+""",
+            "bool",
+        )
+        adapter = adapter_cls(config={"budget": 0.05})
+
+        result = adapter.evaluate("needle in haystack", _make_context())
+
+        assert result.passed is True
+        assert result.assertion_type == "custom:promptfoo_contract"
+
+    def test_adapter_validates_grading_result_dict_return(self):
+        _, build_adapter_class = _load_symbols()
+        adapter_cls = build_adapter_class(
+            "rich_result",
+            """
+def get_assert(args):
+    return {
+        "passed": args["context"]["vars"]["topic"] == "launch",
+        "score": 0.9,
+        "reason": "topic matched vars alias",
+    }
+""",
+            "grading_result",
+        )
+        adapter = adapter_cls(config={"budget": 0.05})
+
+        result = adapter.evaluate("needle in haystack", _make_context())
+
+        assert isinstance(result, GradingResult)
+        assert result.passed is True
+        assert result.score == 0.9
+        assert result.reason == "topic matched vars alias"
+        assert result.assertion_type == "custom:rich_result"
+
+    def test_adapter_wraps_plugin_exception_in_failing_grading_result(self):
+        _, build_adapter_class = _load_symbols()
+        adapter_cls = build_adapter_class(
+            "boom_guard",
+            """
+def get_assert(args):
+    raise RuntimeError("kaboom")
+""",
+            "bool",
+        )
+        adapter = adapter_cls()
+
+        result = adapter.evaluate("needle in haystack", _make_context())
+
+        assert isinstance(result, GradingResult)
+        assert result.passed is False
+        assert result.score == 0.0
+        assert "Custom assertion 'boom_guard' failed:" in result.reason
+        assert "kaboom" in result.reason
+        assert result.assertion_type == "custom:boom_guard"
+
+    def test_build_adapter_class_rejects_blocked_imports_before_execution(self):
+        _, build_adapter_class = _load_symbols()
+
+        with pytest.raises(ValueError) as exc_info:
+            build_adapter_class(
+                "unsafe_guard",
+                """
+import os
+
+def get_assert(args):
+    return True
+""",
+                "bool",
+            )
+
+        message = str(exc_info.value)
+        assert "os" in message
+        assert "not allowed" in message or "allowed list" in message
+
+    def test_adapter_does_not_expose_variables_key_in_context_dict(self):
+        _, build_adapter_class = _load_symbols()
+        adapter_cls = build_adapter_class(
+            "vars_only",
+            """
+def get_assert(args):
+    ctx = args["context"]
+    return "variables" not in ctx and ctx["vars"]["severity"] == "high"
+""",
+            "bool",
+        )
+        adapter = adapter_cls(config={"budget": 0.05})
+
+        result = adapter.evaluate("needle in haystack", _make_context())
+
+        assert result.passed is True
+
+    def test_adapter_subprocess_env_is_minimal_and_does_not_forward_api_keys(self, monkeypatch):
+        module, build_adapter_class = _load_symbols()
+        adapter_cls = build_adapter_class(
+            "isolated_guard",
+            """
+def get_assert(args):
+    return True
+""",
+            "bool",
+        )
+        adapter = adapter_cls()
+        captured_env: dict[str, str] | None = None
+
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-secret")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-anthropic-secret")
+
+        async def fake_create_subprocess_exec(*args, **kwargs):
+            nonlocal captured_env
+            captured_env = kwargs.get("env")
+            return _FakeProc(stdout_payload=json.dumps(True).encode())
+
+        monkeypatch.setattr(module.asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+
+        result = adapter.evaluate("needle in haystack", _make_context())
+
+        assert result.passed is True
+        assert captured_env is not None
+        assert "PATH" in captured_env
+        assert "OPENAI_API_KEY" not in captured_env
+        assert "ANTHROPIC_API_KEY" not in captured_env

--- a/packages/core/tests/assertions/test_run796_custom_adapter.py
+++ b/packages/core/tests/assertions/test_run796_custom_adapter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import importlib
 import json
 from dataclasses import dataclass
@@ -44,6 +45,23 @@ class _FakeProc:
 
     async def communicate(self, input: bytes | None = None):
         return self.stdout_payload, self.stderr_payload
+
+
+@dataclass
+class _HangingProc:
+    kill_called: bool = False
+    wait_called: bool = False
+    returncode: int | None = None
+
+    async def communicate(self, input: bytes | None = None):
+        raise asyncio.TimeoutError("timed out after 30s")
+
+    def kill(self):
+        self.kill_called = True
+
+    async def wait(self):
+        self.wait_called = True
+        self.returncode = -9
 
 
 class TestBuildAdapterClass:
@@ -275,3 +293,49 @@ def get_assert(output, context):
         assert "PATH" in captured_env
         assert "OPENAI_API_KEY" not in captured_env
         assert "ANTHROPIC_API_KEY" not in captured_env
+
+    @pytest.mark.asyncio
+    async def test_adapter_evaluate_succeeds_inside_running_event_loop(self):
+        _, build_adapter_class = _load_symbols()
+        adapter_cls = build_adapter_class(
+            "loop_safe_guard",
+            """
+def get_assert(output, context):
+    return output == "needle in haystack" and context["vars"]["topic"] == "launch"
+""",
+            "bool",
+        )
+        adapter = adapter_cls(config={"budget": 0.05})
+
+        result = adapter.evaluate("needle in haystack", _make_context())
+
+        assert result.passed is True
+        assert result.assertion_type == "custom:loop_safe_guard"
+
+    def test_adapter_timeout_kills_process_waits_and_returns_failing_result(self, monkeypatch):
+        module, build_adapter_class = _load_symbols()
+        adapter_cls = build_adapter_class(
+            "timeout_guard",
+            """
+def get_assert(output, context):
+    return True
+""",
+            "bool",
+        )
+        adapter = adapter_cls()
+        proc = _HangingProc()
+
+        async def fake_create_subprocess_exec(*args, **kwargs):
+            return proc
+
+        monkeypatch.setattr(module.asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+
+        result = adapter.evaluate("needle in haystack", _make_context())
+
+        assert isinstance(result, GradingResult)
+        assert result.passed is False
+        assert result.score == 0.0
+        assert "timeout_guard" in result.reason
+        assert "30" in result.reason or "timed out" in result.reason
+        assert proc.kill_called is True
+        assert proc.wait_called is True

--- a/packages/core/tests/assertions/test_string_assertions.py
+++ b/packages/core/tests/assertions/test_string_assertions.py
@@ -51,7 +51,7 @@ def make_context(output: str = "", **overrides) -> AssertionContext:
 
 
 class TestEqualsAssertion:
-    """AC-1: registered as 'equals', exact string match or deep-equal JSON."""
+    """AC-1: registered as 'equals', exact string match by default."""
 
     def test_type_attribute(self):
         a = EqualsAssertion(value="x")
@@ -89,18 +89,38 @@ class TestEqualsAssertion:
         result = a.evaluate("", ctx)
         assert result.passed is False
 
-    def test_json_deep_equal(self):
-        """equals should deep-equal JSON objects regardless of key order."""
+    def test_default_string_mode_does_not_do_implicit_json_deep_equal(self):
         a = EqualsAssertion(value='{"b": 2, "a": 1}')
+        ctx = make_context('{"a": 1, "b": 2}')
+        result = a.evaluate('{"a": 1, "b": 2}', ctx)
+        assert result.passed is False
+
+    def test_json_mode_deep_equal(self):
+        """JSON deep-equal is available only through explicit config."""
+        a = EqualsAssertion(value='{"b": 2, "a": 1}', config={"mode": "json"})
         ctx = make_context('{"a": 1, "b": 2}')
         result = a.evaluate('{"a": 1, "b": 2}', ctx)
         assert result.passed is True
 
-    def test_json_deep_equal_fails_different_values(self):
-        a = EqualsAssertion(value='{"a": 1}')
+    def test_json_mode_fails_different_values(self):
+        a = EqualsAssertion(value='{"a": 1}', config={"mode": "json"})
         ctx = make_context('{"a": 2}')
         result = a.evaluate('{"a": 2}', ctx)
         assert result.passed is False
+
+    def test_json_mode_fails_invalid_json(self):
+        a = EqualsAssertion(value='{"a": 1}', config={"mode": "json"})
+        ctx = make_context("not json")
+        result = a.evaluate("not json", ctx)
+        assert result.passed is False
+        assert "not valid JSON" in result.reason
+
+    def test_invalid_mode_fails_explicitly(self):
+        a = EqualsAssertion(value="x", config={"mode": "yaml"})
+        ctx = make_context("x")
+        result = a.evaluate("x", ctx)
+        assert result.passed is False
+        assert "Unsupported equals mode" in result.reason
 
     def test_returns_grading_result(self):
         a = EqualsAssertion(value="x")

--- a/packages/core/tests/test_run794_assertion_scanner.py
+++ b/packages/core/tests/test_run794_assertion_scanner.py
@@ -1,4 +1,4 @@
-"""Red tests for RUN-794: YAML assertion manifest discovery and validation."""
+"""Red tests for RUN-794: assertion manifest scanner architecture."""
 
 from __future__ import annotations
 
@@ -9,49 +9,48 @@ from textwrap import dedent
 
 import pytest
 import yaml
+from pydantic import BaseModel, ValidationError
 
 
-def _load_symbols():
-    from runsight_core.yaml.discovery import AssertionScanner, BaseScanner, ScanIndex
+def _load_discovery_module():
+    import runsight_core.yaml.discovery as discovery_module
 
-    assertion_module = importlib.import_module("runsight_core.yaml.discovery._assertion")
-    return (
-        AssertionScanner,
-        assertion_module.AssertionMeta,
-        BaseScanner,
-        ScanIndex,
-        assertion_module,
-    )
+    return discovery_module
+
+
+def _load_assertion_module():
+    return importlib.import_module("runsight_core.yaml.discovery._assertion")
+
+
+def _load_contract_module():
+    return importlib.import_module("runsight_core.assertions.contract")
 
 
 def _write_assertion_fixture(
     base_dir: Path,
     *,
     stem: str = "budget_guard",
+    name: str = "Budget Guard Display",
     returns: str = "bool",
     source_name: str = "budget_guard.py",
-    code: str = "def get_assert(args):\n    return True\n",
+    code: str = "def get_assert(output, context):\n    return True\n",
     params: dict | None = None,
-    extra_fields: dict | None = None,
     manifest_overrides: dict | None = None,
     drop_fields: set[str] | None = None,
     write_source: bool = True,
-    source_is_directory: bool = False,
 ) -> tuple[Path, Path]:
     assertions_dir = base_dir / "custom" / "assertions"
     assertions_dir.mkdir(parents=True, exist_ok=True)
 
     manifest = {
         "version": "1.0",
-        "name": "Budget Guard",
+        "name": name,
         "description": "Keeps cost under budget.",
         "returns": returns,
         "source": source_name,
     }
     if params is not None:
         manifest["params"] = params
-    if extra_fields:
-        manifest.update(extra_fields)
     if manifest_overrides:
         manifest.update(manifest_overrides)
     if drop_fields:
@@ -62,81 +61,101 @@ def _write_assertion_fixture(
     source_path = assertions_dir / source_name
     manifest_path.write_text(yaml.safe_dump(manifest, sort_keys=False), encoding="utf-8")
     if write_source:
-        if source_is_directory:
-            source_path.mkdir()
-        else:
-            source_path.write_text(code, encoding="utf-8")
+        source_path.write_text(code, encoding="utf-8")
     return manifest_path, source_path
 
 
 class TestAssertionScannerPublicSurface:
-    def test_assertion_scanner_uses_base_scanner_pattern(self):
-        AssertionScanner, AssertionMeta, BaseScanner, ScanIndex, assertion_module = _load_symbols()
+    def test_public_discovery_surface_exports_assertion_scanner_and_manifest_types(self):
+        discovery_module = _load_discovery_module()
 
-        assert issubclass(AssertionScanner, BaseScanner)
-        assert AssertionMeta.__module__ == assertion_module.AssertionMeta.__module__
-        assert ScanIndex is not None
+        assert hasattr(discovery_module, "AssertionScanner")
+        assert hasattr(discovery_module, "AssertionManifest")
+        assert hasattr(discovery_module, "AssertionMeta")
+        assert issubclass(discovery_module.AssertionScanner, discovery_module.BaseScanner)
 
-    def test_assertion_scanner_module_does_not_reintroduce_legacy_discover_custom_helpers(self):
-        _, _, _, _, assertion_module = _load_symbols()
+    def test_contract_module_exposes_shared_assertion_function_signature_constants(self):
+        contract_module = _load_contract_module()
 
+        assert contract_module.ASSERTION_FUNCTION_NAME == "get_assert"
+        assert contract_module.ASSERTION_FUNCTION_PARAMS == ("output", "context")
+
+    def test_assertion_module_does_not_reintroduce_legacy_discover_custom_helpers(self):
+        assertion_module = _load_assertion_module()
         source = Path(assertion_module.__file__).read_text(encoding="utf-8")
-        assert re.search(r"(?<!\\w)discover_custom_(?!\\w)", source) is None
+
+        assert re.search(r"(?<!\w)discover_custom_(?!\w)", source) is None
         assert not any(name.startswith("discover_custom_") for name in vars(assertion_module))
 
     def test_public_discovery_surface_does_not_export_legacy_discover_custom_helpers(self):
-        import runsight_core.yaml.discovery as discovery_module
+        discovery_module = _load_discovery_module()
 
         assert not any(name.startswith("discover_custom_") for name in vars(discovery_module))
 
+    def test_assertion_module_no_longer_exposes_hand_rolled_manifest_field_helpers(self):
+        assertion_module = _load_assertion_module()
 
-class TestDiscoverCustomAssertions:
+        assert not hasattr(assertion_module, "_require_string")
+        assert not hasattr(assertion_module, "_require_optional_mapping")
+
+
+class TestAssertionManifestModel:
+    def test_assertion_manifest_is_a_pydantic_model(self):
+        assertion_module = _load_assertion_module()
+
+        assert issubclass(assertion_module.AssertionManifest, BaseModel)
+
     @pytest.mark.parametrize(
-        ("drop_fields", "manifest_overrides", "expected_fragment"),
+        "manifest_overrides",
         [
-            ({"version"}, None, "version"),
-            (None, {"version": 1}, "version"),
-            ({"name"}, None, "name"),
-            (None, {"name": ""}, "name"),
-            ({"description"}, None, "description"),
-            (None, {"description": ""}, "description"),
-            ({"returns"}, None, "returns"),
-            (None, {"returns": ""}, "returns"),
-            ({"source"}, None, "source"),
-            (None, {"source": ""}, "source"),
+            {"timeout_seconds": 10},
+            {"returns": "number"},
         ],
     )
-    def test_missing_or_invalid_required_manifest_fields_raise_file_specific_error(
-        self,
-        tmp_path: Path,
-        drop_fields: set[str] | None,
-        manifest_overrides: dict | None,
-        expected_fragment: str,
+    def test_assertion_manifest_model_rejects_extra_fields_and_invalid_returns(
+        self, manifest_overrides: dict
     ):
-        AssertionScanner, _, _, _, _ = _load_symbols()
-        _write_assertion_fixture(
-            tmp_path,
-            drop_fields=drop_fields,
-            manifest_overrides=manifest_overrides,
-        )
+        assertion_module = _load_assertion_module()
+        raw = {
+            "version": "1.0",
+            "name": "Budget Guard Display",
+            "description": "Keeps cost under budget.",
+            "returns": "bool",
+            "source": "budget_guard.py",
+        }
+        raw.update(manifest_overrides)
 
-        with pytest.raises(ValueError) as exc_info:
-            AssertionScanner(tmp_path).scan()
+        with pytest.raises(ValidationError):
+            assertion_module.AssertionManifest.model_validate(raw)
 
-        message = str(exc_info.value)
-        assert "budget_guard.yaml" in message
-        assert expected_fragment in message
+    @pytest.mark.parametrize("drop_field", ["version", "name", "description", "returns", "source"])
+    def test_assertion_manifest_model_rejects_missing_required_fields(self, drop_field: str):
+        assertion_module = _load_assertion_module()
+        raw = {
+            "version": "1.0",
+            "name": "Budget Guard Display",
+            "description": "Keeps cost under budget.",
+            "returns": "bool",
+            "source": "budget_guard.py",
+        }
+        raw.pop(drop_field)
 
+        with pytest.raises(ValidationError):
+            assertion_module.AssertionManifest.model_validate(raw)
+
+
+class TestDiscoverCustomAssertions:
     def test_missing_custom_assertions_directory_returns_empty_scan_index(self, tmp_path: Path):
-        AssertionScanner, _, _, ScanIndex, _ = _load_symbols()
+        discovery_module = _load_discovery_module()
 
-        result = AssertionScanner(tmp_path).scan()
+        result = discovery_module.AssertionScanner(tmp_path).scan()
 
-        assert isinstance(result, ScanIndex)
+        assert isinstance(result, discovery_module.ScanIndex)
         assert result.stems() == {}
 
-    def test_valid_manifest_and_source_scan_into_assertion_meta(self, tmp_path: Path):
-        AssertionScanner, AssertionMeta, _, _, _ = _load_symbols()
+    def test_valid_manifest_and_source_scan_into_nested_assertion_meta(self, tmp_path: Path):
+        discovery_module = _load_discovery_module()
+        assertion_module = _load_assertion_module()
         manifest_path, source_path = _write_assertion_fixture(
             tmp_path,
             params={
@@ -146,73 +165,125 @@ class TestDiscoverCustomAssertions:
             },
         )
 
-        index = AssertionScanner(tmp_path).scan()
-        discovered = index.stems()
+        index = discovery_module.AssertionScanner(tmp_path).scan()
+        meta = index.stems()["budget_guard"]
 
-        assert set(discovered) == {"budget_guard"}
-        assert isinstance(discovered["budget_guard"], AssertionMeta)
-        meta = discovered["budget_guard"]
+        assert isinstance(meta, assertion_module.AssertionMeta)
         assert meta.assertion_id == "budget_guard"
         assert meta.file_path.resolve() == manifest_path.resolve()
-        assert meta.version == "1.0"
-        assert meta.name == "Budget Guard"
-        assert meta.description == "Keeps cost under budget."
-        assert meta.returns == "bool"
         assert meta.code == source_path.read_text(encoding="utf-8")
-        assert meta.params == {
+        assert meta.manifest.name == "Budget Guard Display"
+        assert meta.manifest.description == "Keeps cost under budget."
+        assert meta.manifest.returns == "bool"
+        assert meta.manifest.source == "budget_guard.py"
+        assert meta.manifest.params == {
             "type": "object",
             "properties": {"threshold": {"type": "number"}},
             "required": ["threshold"],
         }
-        assert index.get("budget_guard") is not None
-        assert index.get("custom/assertions/budget_guard.yaml") is not None
 
-    def test_invalid_returns_value_raises_file_specific_error(self, tmp_path: Path):
-        AssertionScanner, _, _, _, _ = _load_symbols()
-        _write_assertion_fixture(tmp_path, returns="number")
+    def test_assertion_meta_does_not_expose_flattened_manifest_fields_directly(
+        self, tmp_path: Path
+    ):
+        discovery_module = _load_discovery_module()
+        _write_assertion_fixture(tmp_path)
+
+        meta = discovery_module.AssertionScanner(tmp_path).scan().stems()["budget_guard"]
+
+        assert not hasattr(meta, "name")
+        assert not hasattr(meta, "description")
+        assert not hasattr(meta, "returns")
+        assert not hasattr(meta, "source")
+        assert not hasattr(meta, "version")
+        assert not hasattr(meta, "params")
+
+    def test_file_stem_slug_is_canonical_id_and_manifest_name_is_display_only(self, tmp_path: Path):
+        discovery_module = _load_discovery_module()
+        _write_assertion_fixture(
+            tmp_path,
+            stem="budget_guard",
+            name="Friendly Display Title",
+            source_name="friendly_name.py",
+        )
+
+        meta = discovery_module.AssertionScanner(tmp_path).scan().stems()["budget_guard"]
+
+        assert meta.assertion_id == "budget_guard"
+        assert meta.manifest.name == "Friendly Display Title"
+        assert meta.assertion_id != meta.manifest.name
+
+    def test_scanner_uses_assertion_manifest_model_validate(self, tmp_path: Path, monkeypatch):
+        discovery_module = _load_discovery_module()
+        assertion_module = _load_assertion_module()
+        _write_assertion_fixture(tmp_path)
+        calls: list[object] = []
+        original = assertion_module.AssertionManifest.model_validate
+
+        def spy_model_validate(cls, raw: object, *args, **kwargs):
+            calls.append(raw)
+            return original(raw, *args, **kwargs)
+
+        monkeypatch.setattr(
+            assertion_module,
+            "AssertionManifest",
+            assertion_module.AssertionManifest,
+        )
+        monkeypatch.setattr(
+            assertion_module.AssertionManifest,
+            "model_validate",
+            classmethod(spy_model_validate),
+        )
+
+        discovery_module.AssertionScanner(tmp_path).scan()
+
+        assert calls
+        assert isinstance(calls[0], dict)
+        assert calls[0]["name"] == "Budget Guard Display"
+
+    @pytest.mark.parametrize(
+        ("manifest_overrides", "drop_fields", "expected_fragment"),
+        [
+            ({"timeout_seconds": 10}, None, "timeout_seconds"),
+            ({"returns": "number"}, None, "returns"),
+            (None, {"version"}, "version"),
+        ],
+    )
+    def test_scanner_wraps_manifest_model_validation_errors_with_filename(
+        self,
+        tmp_path: Path,
+        manifest_overrides: dict | None,
+        drop_fields: set[str] | None,
+        expected_fragment: str,
+    ):
+        discovery_module = _load_discovery_module()
+        _write_assertion_fixture(
+            tmp_path,
+            manifest_overrides=manifest_overrides,
+            drop_fields=drop_fields,
+        )
 
         with pytest.raises(ValueError) as exc_info:
-            AssertionScanner(tmp_path).scan()
+            discovery_module.AssertionScanner(tmp_path).scan()
 
         message = str(exc_info.value)
         assert "budget_guard.yaml" in message
-        assert "bool" in message
-        assert "grading_result" in message
+        assert expected_fragment in message
 
-    def test_extra_unsupported_fields_raise_value_error(self, tmp_path: Path):
-        AssertionScanner, _, _, _, _ = _load_symbols()
-        _write_assertion_fixture(tmp_path, extra_fields={"timeout_seconds": 10})
+    def test_scanner_accepts_shared_get_assert_output_context_contract(self, tmp_path: Path):
+        discovery_module = _load_discovery_module()
+        _write_assertion_fixture(
+            tmp_path,
+            code=dedent(
+                """\
+                def get_assert(output, context):
+                    return output == "needle in haystack"
+                """
+            ),
+        )
 
-        with pytest.raises(ValueError) as exc_info:
-            AssertionScanner(tmp_path).scan()
+        meta = discovery_module.AssertionScanner(tmp_path).scan().stems()["budget_guard"]
 
-        message = str(exc_info.value)
-        assert "budget_guard.yaml" in message
-        assert "timeout_seconds" in message
-
-    def test_missing_source_file_raises_file_specific_error(self, tmp_path: Path):
-        AssertionScanner, _, _, _, _ = _load_symbols()
-        _write_assertion_fixture(tmp_path, write_source=False)
-
-        with pytest.raises(ValueError) as exc_info:
-            AssertionScanner(tmp_path).scan()
-
-        message = str(exc_info.value)
-        assert "budget_guard.yaml" in message
-        assert "budget_guard.py" in message
-        assert "source" in message
-
-    def test_unreadable_source_path_raises_file_specific_error(self, tmp_path: Path):
-        AssertionScanner, _, _, _, _ = _load_symbols()
-        _write_assertion_fixture(tmp_path, source_is_directory=True)
-
-        with pytest.raises(ValueError) as exc_info:
-            AssertionScanner(tmp_path).scan()
-
-        message = str(exc_info.value)
-        assert "budget_guard.yaml" in message
-        assert "budget_guard.py" in message
-        assert "source" in message
+        assert meta.code is not None
 
     @pytest.mark.parametrize(
         ("code", "expected_fragment"),
@@ -220,54 +291,56 @@ class TestDiscoverCustomAssertions:
             (
                 dedent(
                     """\
-                    def get_assert():
+                    def get_assert(args):
                         return True
                     """
                 ),
-                "get_assert",
+                "output",
             ),
             (
                 dedent(
                     """\
-                    def get_assert(config, context):
+                    def get_assert(output):
                         return True
                     """
                 ),
-                "get_assert",
+                "context",
             ),
             (
                 dedent(
                     """\
-                    def get_assert(payload):
+                    def get_assert(output, context, extra):
                         return True
                     """
                 ),
-                "args",
+                "get_assert",
             ),
         ],
     )
-    def test_bad_get_assert_signature_raises_value_error(
+    def test_scanner_rejects_legacy_or_wrong_arity_assertion_contract(
         self, tmp_path: Path, code: str, expected_fragment: str
     ):
-        AssertionScanner, _, _, _, _ = _load_symbols()
-        _write_assertion_fixture(
-            tmp_path,
-            code=code,
-        )
+        discovery_module = _load_discovery_module()
+        _write_assertion_fixture(tmp_path, code=code)
 
         with pytest.raises(ValueError) as exc_info:
-            AssertionScanner(tmp_path).scan()
+            discovery_module.AssertionScanner(tmp_path).scan()
 
         message = str(exc_info.value)
         assert "budget_guard.yaml" in message
         assert expected_fragment in message
 
-    def test_reserved_builtin_assertion_name_collision_raises_value_error(self, tmp_path: Path):
-        AssertionScanner, _, _, _, _ = _load_symbols()
-        _write_assertion_fixture(tmp_path, stem="contains", source_name="contains.py")
+    def test_reserved_builtin_collision_uses_file_stem_slug(self, tmp_path: Path):
+        discovery_module = _load_discovery_module()
+        _write_assertion_fixture(
+            tmp_path,
+            stem="contains",
+            name="Totally Different Display Name",
+            source_name="contains.py",
+        )
 
         with pytest.raises(ValueError) as exc_info:
-            AssertionScanner(tmp_path).scan()
+            discovery_module.AssertionScanner(tmp_path).scan()
 
         message = str(exc_info.value)
         assert "contains.yaml" in message

--- a/packages/core/tests/test_run794_assertion_scanner.py
+++ b/packages/core/tests/test_run794_assertion_scanner.py
@@ -32,6 +32,10 @@ def _write_assertion_fixture(
     code: str = "def get_assert(args):\n    return True\n",
     params: dict | None = None,
     extra_fields: dict | None = None,
+    manifest_overrides: dict | None = None,
+    drop_fields: set[str] | None = None,
+    write_source: bool = True,
+    source_is_directory: bool = False,
 ) -> tuple[Path, Path]:
     assertions_dir = base_dir / "custom" / "assertions"
     assertions_dir.mkdir(parents=True, exist_ok=True)
@@ -47,11 +51,20 @@ def _write_assertion_fixture(
         manifest["params"] = params
     if extra_fields:
         manifest.update(extra_fields)
+    if manifest_overrides:
+        manifest.update(manifest_overrides)
+    if drop_fields:
+        for field in drop_fields:
+            manifest.pop(field, None)
 
     manifest_path = assertions_dir / f"{stem}.yaml"
     source_path = assertions_dir / source_name
     manifest_path.write_text(yaml.safe_dump(manifest, sort_keys=False), encoding="utf-8")
-    source_path.write_text(code, encoding="utf-8")
+    if write_source:
+        if source_is_directory:
+            source_path.mkdir()
+        else:
+            source_path.write_text(code, encoding="utf-8")
     return manifest_path, source_path
 
 
@@ -72,6 +85,42 @@ class TestAssertionScannerPublicSurface:
 
 
 class TestDiscoverCustomAssertions:
+    @pytest.mark.parametrize(
+        ("drop_fields", "manifest_overrides", "expected_fragment"),
+        [
+            ({"version"}, None, "version"),
+            (None, {"version": 1}, "version"),
+            ({"name"}, None, "name"),
+            (None, {"name": ""}, "name"),
+            ({"description"}, None, "description"),
+            (None, {"description": ""}, "description"),
+            ({"returns"}, None, "returns"),
+            (None, {"returns": ""}, "returns"),
+            ({"source"}, None, "source"),
+            (None, {"source": ""}, "source"),
+        ],
+    )
+    def test_missing_or_invalid_required_manifest_fields_raise_file_specific_error(
+        self,
+        tmp_path: Path,
+        drop_fields: set[str] | None,
+        manifest_overrides: dict | None,
+        expected_fragment: str,
+    ):
+        AssertionScanner, _, _, _, _ = _load_symbols()
+        _write_assertion_fixture(
+            tmp_path,
+            drop_fields=drop_fields,
+            manifest_overrides=manifest_overrides,
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            AssertionScanner(tmp_path).scan()
+
+        message = str(exc_info.value)
+        assert "budget_guard.yaml" in message
+        assert expected_fragment in message
+
     def test_missing_custom_assertions_directory_returns_empty_scan_index(self, tmp_path: Path):
         AssertionScanner, _, _, ScanIndex, _ = _load_symbols()
 
@@ -135,16 +184,69 @@ class TestDiscoverCustomAssertions:
         assert "budget_guard.yaml" in message
         assert "timeout_seconds" in message
 
-    def test_bad_get_assert_signature_raises_value_error(self, tmp_path: Path):
+    def test_missing_source_file_raises_file_specific_error(self, tmp_path: Path):
+        AssertionScanner, _, _, _, _ = _load_symbols()
+        _write_assertion_fixture(tmp_path, write_source=False)
+
+        with pytest.raises(ValueError) as exc_info:
+            AssertionScanner(tmp_path).scan()
+
+        message = str(exc_info.value)
+        assert "budget_guard.yaml" in message
+        assert "budget_guard.py" in message
+        assert "source" in message
+
+    def test_unreadable_source_path_raises_file_specific_error(self, tmp_path: Path):
+        AssertionScanner, _, _, _, _ = _load_symbols()
+        _write_assertion_fixture(tmp_path, source_is_directory=True)
+
+        with pytest.raises(ValueError) as exc_info:
+            AssertionScanner(tmp_path).scan()
+
+        message = str(exc_info.value)
+        assert "budget_guard.yaml" in message
+        assert "budget_guard.py" in message
+        assert "source" in message
+
+    @pytest.mark.parametrize(
+        ("code", "expected_fragment"),
+        [
+            (
+                dedent(
+                    """\
+                    def get_assert():
+                        return True
+                    """
+                ),
+                "get_assert",
+            ),
+            (
+                dedent(
+                    """\
+                    def get_assert(config, context):
+                        return True
+                    """
+                ),
+                "get_assert",
+            ),
+            (
+                dedent(
+                    """\
+                    def get_assert(payload):
+                        return True
+                    """
+                ),
+                "args",
+            ),
+        ],
+    )
+    def test_bad_get_assert_signature_raises_value_error(
+        self, tmp_path: Path, code: str, expected_fragment: str
+    ):
         AssertionScanner, _, _, _, _ = _load_symbols()
         _write_assertion_fixture(
             tmp_path,
-            code=dedent(
-                """\
-                def get_assert():
-                    return True
-                """
-            ),
+            code=code,
         )
 
         with pytest.raises(ValueError) as exc_info:
@@ -152,7 +254,7 @@ class TestDiscoverCustomAssertions:
 
         message = str(exc_info.value)
         assert "budget_guard.yaml" in message
-        assert "get_assert" in message
+        assert expected_fragment in message
 
     def test_reserved_builtin_assertion_name_collision_raises_value_error(self, tmp_path: Path):
         AssertionScanner, _, _, _, _ = _load_symbols()

--- a/packages/core/tests/test_run794_assertion_scanner.py
+++ b/packages/core/tests/test_run794_assertion_scanner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+import re
 from pathlib import Path
 from textwrap import dedent
 
@@ -76,12 +77,17 @@ class TestAssertionScannerPublicSurface:
         assert AssertionMeta.__module__ == assertion_module.AssertionMeta.__module__
         assert ScanIndex is not None
 
-    def test_assertion_scanner_module_does_not_reintroduce_legacy_discover_custom_assets(self):
+    def test_assertion_scanner_module_does_not_reintroduce_legacy_discover_custom_helpers(self):
         _, _, _, _, assertion_module = _load_symbols()
 
         source = Path(assertion_module.__file__).read_text(encoding="utf-8")
-        assert "discover_custom_assets" not in source
-        assert not hasattr(assertion_module, "discover_custom_assets")
+        assert re.search(r"(?<!\\w)discover_custom_(?!\\w)", source) is None
+        assert not any(name.startswith("discover_custom_") for name in vars(assertion_module))
+
+    def test_public_discovery_surface_does_not_export_legacy_discover_custom_helpers(self):
+        import runsight_core.yaml.discovery as discovery_module
+
+        assert not any(name.startswith("discover_custom_") for name in vars(discovery_module))
 
 
 class TestDiscoverCustomAssertions:

--- a/packages/core/tests/test_run794_assertion_scanner.py
+++ b/packages/core/tests/test_run794_assertion_scanner.py
@@ -1,0 +1,167 @@
+"""Red tests for RUN-794: YAML assertion manifest discovery and validation."""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+import yaml
+
+
+def _load_symbols():
+    from runsight_core.yaml.discovery import AssertionScanner, BaseScanner, ScanIndex
+
+    assertion_module = importlib.import_module("runsight_core.yaml.discovery._assertion")
+    return (
+        AssertionScanner,
+        assertion_module.AssertionMeta,
+        BaseScanner,
+        ScanIndex,
+        assertion_module,
+    )
+
+
+def _write_assertion_fixture(
+    base_dir: Path,
+    *,
+    stem: str = "budget_guard",
+    returns: str = "bool",
+    source_name: str = "budget_guard.py",
+    code: str = "def get_assert(args):\n    return True\n",
+    params: dict | None = None,
+    extra_fields: dict | None = None,
+) -> tuple[Path, Path]:
+    assertions_dir = base_dir / "custom" / "assertions"
+    assertions_dir.mkdir(parents=True, exist_ok=True)
+
+    manifest = {
+        "version": "1.0",
+        "name": "Budget Guard",
+        "description": "Keeps cost under budget.",
+        "returns": returns,
+        "source": source_name,
+    }
+    if params is not None:
+        manifest["params"] = params
+    if extra_fields:
+        manifest.update(extra_fields)
+
+    manifest_path = assertions_dir / f"{stem}.yaml"
+    source_path = assertions_dir / source_name
+    manifest_path.write_text(yaml.safe_dump(manifest, sort_keys=False), encoding="utf-8")
+    source_path.write_text(code, encoding="utf-8")
+    return manifest_path, source_path
+
+
+class TestAssertionScannerPublicSurface:
+    def test_assertion_scanner_uses_base_scanner_pattern(self):
+        AssertionScanner, AssertionMeta, BaseScanner, ScanIndex, assertion_module = _load_symbols()
+
+        assert issubclass(AssertionScanner, BaseScanner)
+        assert AssertionMeta.__module__ == assertion_module.AssertionMeta.__module__
+        assert ScanIndex is not None
+
+    def test_assertion_scanner_module_does_not_reintroduce_legacy_discover_custom_assets(self):
+        _, _, _, _, assertion_module = _load_symbols()
+
+        source = Path(assertion_module.__file__).read_text(encoding="utf-8")
+        assert "discover_custom_assets" not in source
+        assert not hasattr(assertion_module, "discover_custom_assets")
+
+
+class TestDiscoverCustomAssertions:
+    def test_missing_custom_assertions_directory_returns_empty_scan_index(self, tmp_path: Path):
+        AssertionScanner, _, _, ScanIndex, _ = _load_symbols()
+
+        result = AssertionScanner(tmp_path).scan()
+
+        assert isinstance(result, ScanIndex)
+        assert result.stems() == {}
+
+    def test_valid_manifest_and_source_scan_into_assertion_meta(self, tmp_path: Path):
+        AssertionScanner, AssertionMeta, _, _, _ = _load_symbols()
+        manifest_path, source_path = _write_assertion_fixture(
+            tmp_path,
+            params={
+                "type": "object",
+                "properties": {"threshold": {"type": "number"}},
+                "required": ["threshold"],
+            },
+        )
+
+        index = AssertionScanner(tmp_path).scan()
+        discovered = index.stems()
+
+        assert set(discovered) == {"budget_guard"}
+        assert isinstance(discovered["budget_guard"], AssertionMeta)
+        meta = discovered["budget_guard"]
+        assert meta.assertion_id == "budget_guard"
+        assert meta.file_path.resolve() == manifest_path.resolve()
+        assert meta.version == "1.0"
+        assert meta.name == "Budget Guard"
+        assert meta.description == "Keeps cost under budget."
+        assert meta.returns == "bool"
+        assert meta.code == source_path.read_text(encoding="utf-8")
+        assert meta.params == {
+            "type": "object",
+            "properties": {"threshold": {"type": "number"}},
+            "required": ["threshold"],
+        }
+        assert index.get("budget_guard") is not None
+        assert index.get("custom/assertions/budget_guard.yaml") is not None
+
+    def test_invalid_returns_value_raises_file_specific_error(self, tmp_path: Path):
+        AssertionScanner, _, _, _, _ = _load_symbols()
+        _write_assertion_fixture(tmp_path, returns="number")
+
+        with pytest.raises(ValueError) as exc_info:
+            AssertionScanner(tmp_path).scan()
+
+        message = str(exc_info.value)
+        assert "budget_guard.yaml" in message
+        assert "bool" in message
+        assert "grading_result" in message
+
+    def test_extra_unsupported_fields_raise_value_error(self, tmp_path: Path):
+        AssertionScanner, _, _, _, _ = _load_symbols()
+        _write_assertion_fixture(tmp_path, extra_fields={"timeout_seconds": 10})
+
+        with pytest.raises(ValueError) as exc_info:
+            AssertionScanner(tmp_path).scan()
+
+        message = str(exc_info.value)
+        assert "budget_guard.yaml" in message
+        assert "timeout_seconds" in message
+
+    def test_bad_get_assert_signature_raises_value_error(self, tmp_path: Path):
+        AssertionScanner, _, _, _, _ = _load_symbols()
+        _write_assertion_fixture(
+            tmp_path,
+            code=dedent(
+                """\
+                def get_assert():
+                    return True
+                """
+            ),
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            AssertionScanner(tmp_path).scan()
+
+        message = str(exc_info.value)
+        assert "budget_guard.yaml" in message
+        assert "get_assert" in message
+
+    def test_reserved_builtin_assertion_name_collision_raises_value_error(self, tmp_path: Path):
+        AssertionScanner, _, _, _, _ = _load_symbols()
+        _write_assertion_fixture(tmp_path, stem="contains", source_name="contains.py")
+
+        with pytest.raises(ValueError) as exc_info:
+            AssertionScanner(tmp_path).scan()
+
+        message = str(exc_info.value)
+        assert "contains.yaml" in message
+        assert "contains" in message
+        assert "builtin" in message or "reserved" in message

--- a/packages/core/tests/test_run797_custom_assertion_registration.py
+++ b/packages/core/tests/test_run797_custom_assertion_registration.py
@@ -1,0 +1,375 @@
+"""Red tests for RUN-797: custom assertion discovery and registration wiring."""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+from runsight_core.assertions.base import AssertionContext
+from runsight_core.assertions.registry import run_assertion
+from runsight_core.eval.runner import run_eval
+from runsight_core.yaml.parser import parse_workflow_yaml
+
+
+def _load_registry_module():
+    return importlib.import_module("runsight_core.assertions.registry")
+
+
+def _load_parser_module():
+    return importlib.import_module("runsight_core.yaml.parser")
+
+
+def _load_discovery_module():
+    return importlib.import_module("runsight_core.yaml.discovery")
+
+
+def _write_yaml(path: Path, data: dict[str, Any]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+    return path
+
+
+def _write_assertion_fixture(
+    base_dir: Path,
+    *,
+    stem: str = "tone_check",
+    name: str = "Tone Check Display Name",
+    returns: str = "bool",
+    source_name: str | None = None,
+    code: str = "def get_assert(output, context):\n    return 'calm' in output\n",
+) -> Path:
+    assertions_dir = base_dir / "custom" / "assertions"
+    assertions_dir.mkdir(parents=True, exist_ok=True)
+
+    if source_name is None:
+        source_name = f"{stem}.py"
+
+    manifest_path = assertions_dir / f"{stem}.yaml"
+    source_path = assertions_dir / source_name
+    manifest = {
+        "version": "1.0",
+        "name": name,
+        "description": "Checks the output tone.",
+        "returns": returns,
+        "source": source_name,
+    }
+    manifest_path.write_text(yaml.safe_dump(manifest, sort_keys=False), encoding="utf-8")
+    source_path.write_text(code, encoding="utf-8")
+    return manifest_path
+
+
+def _write_workflow_file(base_dir: Path, data: dict[str, Any]) -> Path:
+    workflow_path = base_dir / "workflow.yaml"
+    return _write_yaml(workflow_path, data)
+
+
+def _workflow_with_block_assertion(assertion_type: str) -> dict[str, Any]:
+    return {
+        "version": "1.0",
+        "config": {"model_name": "gpt-4o"},
+        "blocks": {
+            "analyze": {
+                "type": "code",
+                "code": "def main(data):\n    return 'fixture output'\n",
+                "assertions": [{"type": assertion_type}],
+            }
+        },
+        "workflow": {
+            "name": "custom_assertion_parse_flow",
+            "entry": "analyze",
+            "transitions": [{"from": "analyze", "to": None}],
+        },
+    }
+
+
+def _workflow_with_eval_assertion(assertion_type: str) -> dict[str, Any]:
+    return {
+        "version": "1.0",
+        "config": {"model_name": "gpt-4o"},
+        "blocks": {
+            "analyze": {
+                "type": "code",
+                "code": "def main(data):\n    return 'ignored in fixture mode'\n",
+            }
+        },
+        "workflow": {
+            "name": "custom_assertion_eval_flow",
+            "entry": "analyze",
+            "transitions": [{"from": "analyze", "to": None}],
+        },
+        "eval": {
+            "threshold": 1.0,
+            "cases": [
+                {
+                    "id": "tone_case",
+                    "fixtures": {"analyze": "calm response"},
+                    "expected": {"analyze": [{"type": assertion_type}]},
+                }
+            ],
+        },
+    }
+
+
+def _assertion_context(output: str = "calm response") -> AssertionContext:
+    return AssertionContext(
+        output=output,
+        prompt="Summarize calmly.",
+        prompt_hash="prompt-hash",
+        soul_id="tone_soul",
+        soul_version="1.0",
+        block_id="analyze",
+        block_type="code",
+        cost_usd=0.01,
+        total_tokens=42,
+        latency_ms=12.0,
+        variables={"topic": "calm"},
+        run_id="run-1",
+        workflow_id="workflow-1",
+    )
+
+
+class TestRegisterCustomAssertions:
+    def test_register_custom_assertions_registers_slug_key_and_uses_assertion_id(
+        self, tmp_path: Path, monkeypatch
+    ):
+        discovery_module = _load_discovery_module()
+        registry_module = _load_registry_module()
+        _write_assertion_fixture(
+            tmp_path,
+            stem="tone_check",
+            name="Tone Check Display Name",
+        )
+        index = discovery_module.AssertionScanner(tmp_path).scan()
+        captured_build: list[dict[str, Any]] = []
+        captured_register: list[tuple[str, type]] = []
+
+        class _Adapter:
+            type = "custom:tone_check"
+
+        def fake_build_adapter_class(*, plugin_name: str, code: str, returns: str) -> type:
+            captured_build.append({"plugin_name": plugin_name, "code": code, "returns": returns})
+            return _Adapter
+
+        monkeypatch.setattr(
+            registry_module,
+            "_build_adapter_class",
+            fake_build_adapter_class,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            registry_module,
+            "register_assertion",
+            lambda key, handler: captured_register.append((key, handler)),
+            raising=False,
+        )
+
+        registry_module.register_custom_assertions(index)
+
+        assert captured_build == [
+            {
+                "plugin_name": "tone_check",
+                "code": index.stems()["tone_check"].code,
+                "returns": "bool",
+            }
+        ]
+        assert captured_register == [("custom:tone_check", _Adapter)]
+
+    def test_register_custom_assertions_is_idempotent_for_same_index(
+        self, tmp_path: Path, monkeypatch
+    ):
+        discovery_module = _load_discovery_module()
+        registry_module = _load_registry_module()
+        _write_assertion_fixture(tmp_path, stem="tone_check", name="Tone Check Display Name")
+        index = discovery_module.AssertionScanner(tmp_path).scan()
+        build_calls: list[str] = []
+        register_calls: list[str] = []
+
+        class _Adapter:
+            type = "custom:tone_check"
+
+        monkeypatch.setattr(
+            registry_module,
+            "_build_adapter_class",
+            lambda **kwargs: build_calls.append(kwargs["plugin_name"]) or _Adapter,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            registry_module,
+            "register_assertion",
+            lambda key, handler: register_calls.append(key),
+            raising=False,
+        )
+
+        registry_module.register_custom_assertions(index)
+        registry_module.register_custom_assertions(index)
+
+        assert build_calls == ["tone_check"]
+        assert register_calls == ["custom:tone_check"]
+
+    def test_register_custom_assertions_noops_when_index_is_empty(self, monkeypatch):
+        discovery_module = _load_discovery_module()
+        registry_module = _load_registry_module()
+        register_calls: list[str] = []
+
+        monkeypatch.setattr(
+            registry_module,
+            "register_assertion",
+            lambda key, handler: register_calls.append(key),
+            raising=False,
+        )
+
+        registry_module.register_custom_assertions(discovery_module.ScanIndex())
+
+        assert register_calls == []
+
+
+class TestAssertionScannerDuplicateStem:
+    def test_assertion_scanner_rejects_duplicate_yaml_stems(self, tmp_path: Path, monkeypatch):
+        discovery_module = _load_discovery_module()
+        scanner = discovery_module.AssertionScanner(tmp_path)
+        first = _write_assertion_fixture(tmp_path, stem="tone_check")
+        nested_dir = tmp_path / "custom" / "assertions" / "nested"
+        nested_dir.mkdir(parents=True, exist_ok=True)
+        second = nested_dir / "tone_check.yaml"
+        second.write_text(first.read_text(encoding="utf-8"), encoding="utf-8")
+        (nested_dir / "tone_check.py").write_text(
+            "def get_assert(output, context):\n    return True\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setattr(
+            scanner,
+            "_glob_yaml_files",
+            lambda directory: [first, second],
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            scanner.scan()
+
+        message = str(exc_info.value)
+        assert "duplicate custom assertion id collision" in message
+        assert "tone_check" in message
+
+
+class TestParseWorkflowYamlCustomAssertionIntegration:
+    def test_parse_workflow_yaml_registers_custom_assertions_for_dispatch(
+        self, tmp_path: Path, monkeypatch
+    ):
+        registry_module = _load_registry_module()
+        _write_assertion_fixture(
+            tmp_path,
+            stem="tone_check",
+            name="Tone Check Display Name",
+            code="def get_assert(output, context):\n    return output == 'calm response'\n",
+        )
+        workflow_path = _write_workflow_file(
+            tmp_path,
+            _workflow_with_block_assertion("custom:tone_check"),
+        )
+        monkeypatch.setattr(registry_module, "_REGISTRY", {}, raising=False)
+
+        workflow = parse_workflow_yaml(str(workflow_path))
+        block = workflow._blocks["analyze"]
+        result = run_assertion(
+            type=block.assertions[0]["type"],
+            output="calm response",
+            context=_assertion_context(),
+        )
+
+        assert result.passed is True
+
+    def test_parse_workflow_yaml_treats_missing_custom_assertions_dir_as_no_op(
+        self, tmp_path: Path, monkeypatch
+    ):
+        parser_module = _load_parser_module()
+        discovery_module = _load_discovery_module()
+        workflow_path = _write_workflow_file(
+            tmp_path,
+            _workflow_with_block_assertion("contains"),
+        )
+        scanner_bases: list[Path] = []
+        registered_indexes: list[object] = []
+
+        class _AssertionScanner:
+            def __init__(self, base_dir: str | Path) -> None:
+                scanner_bases.append(Path(base_dir).resolve())
+
+            def scan(self):
+                return discovery_module.ScanIndex()
+
+        def fake_register_custom_assertions(index) -> None:
+            registered_indexes.append(index)
+
+        monkeypatch.setattr(
+            parser_module,
+            "AssertionScanner",
+            _AssertionScanner,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            parser_module,
+            "register_custom_assertions",
+            fake_register_custom_assertions,
+            raising=False,
+        )
+
+        workflow = parse_workflow_yaml(str(workflow_path))
+
+        assert workflow.name == "custom_assertion_parse_flow"
+        assert scanner_bases == [tmp_path.resolve()]
+        assert len(registered_indexes) == 1
+        assert isinstance(registered_indexes[0], discovery_module.ScanIndex)
+        assert registered_indexes[0].stems() == {}
+
+    def test_parse_workflow_yaml_surfaces_duplicate_custom_assertion_stem_errors(
+        self, tmp_path: Path, monkeypatch
+    ):
+        parser_module = _load_parser_module()
+        workflow_path = _write_workflow_file(
+            tmp_path,
+            _workflow_with_block_assertion("custom:tone_check"),
+        )
+
+        class _AssertionScanner:
+            def __init__(self, base_dir: str | Path) -> None:
+                self.base_dir = Path(base_dir)
+
+            def scan(self):
+                raise ValueError("tone_check.yaml: duplicate custom assertion id collision")
+
+        monkeypatch.setattr(
+            parser_module,
+            "AssertionScanner",
+            _AssertionScanner,
+            raising=False,
+        )
+
+        with pytest.raises(ValueError, match="duplicate custom assertion id collision"):
+            parse_workflow_yaml(str(workflow_path))
+
+
+class TestRunEvalCustomAssertionIntegration:
+    @pytest.mark.asyncio
+    async def test_run_eval_discovers_and_registers_custom_assertions_from_workflow_path(
+        self, tmp_path: Path, monkeypatch
+    ):
+        registry_module = _load_registry_module()
+        _write_assertion_fixture(
+            tmp_path,
+            stem="tone_check",
+            name="Tone Check Display Name",
+            code="def get_assert(output, context):\n    return output == 'calm response'\n",
+        )
+        workflow_path = _write_workflow_file(
+            tmp_path,
+            _workflow_with_eval_assertion("custom:tone_check"),
+        )
+        monkeypatch.setattr(registry_module, "_REGISTRY", {}, raising=False)
+
+        result = await run_eval(str(workflow_path))
+
+        assert result.passed is True
+        assert result.case_results[0].block_results["analyze"].results[0].passed is True

--- a/packages/core/tests/test_run797_custom_assertion_registration.py
+++ b/packages/core/tests/test_run797_custom_assertion_registration.py
@@ -184,8 +184,6 @@ class TestRegisterCustomAssertions:
         registry_module = _load_registry_module()
         _write_assertion_fixture(tmp_path, stem="tone_check", name="Tone Check Display Name")
         index = discovery_module.AssertionScanner(tmp_path).scan()
-        build_calls: list[str] = []
-        register_calls: list[str] = []
 
         class _Adapter:
             type = "custom:tone_check"
@@ -193,21 +191,15 @@ class TestRegisterCustomAssertions:
         monkeypatch.setattr(
             registry_module,
             "_build_adapter_class",
-            lambda **kwargs: build_calls.append(kwargs["plugin_name"]) or _Adapter,
+            lambda **kwargs: _Adapter,
             raising=False,
         )
-        monkeypatch.setattr(
-            registry_module,
-            "register_assertion",
-            lambda key, handler: register_calls.append(key),
-            raising=False,
-        )
+        monkeypatch.setattr(registry_module, "_REGISTRY", {}, raising=False)
 
         registry_module.register_custom_assertions(index)
         registry_module.register_custom_assertions(index)
 
-        assert build_calls == ["tone_check"]
-        assert register_calls == ["custom:tone_check"]
+        assert registry_module._get_handler("custom:tone_check") is _Adapter
 
     def test_register_custom_assertions_noops_when_index_is_empty(self, monkeypatch):
         discovery_module = _load_discovery_module()

--- a/packages/core/tests/test_run797_custom_assertion_registration.py
+++ b/packages/core/tests/test_run797_custom_assertion_registration.py
@@ -26,6 +26,10 @@ def _load_discovery_module():
     return importlib.import_module("runsight_core.yaml.discovery")
 
 
+def _load_custom_assertion_module():
+    return importlib.import_module("runsight_core.assertions.custom")
+
+
 def _write_yaml(path: Path, data: dict[str, Any]) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
@@ -40,6 +44,7 @@ def _write_assertion_fixture(
     returns: str = "bool",
     source_name: str | None = None,
     code: str = "def get_assert(output, context):\n    return 'calm' in output\n",
+    params: dict[str, Any] | None = None,
 ) -> Path:
     assertions_dir = base_dir / "custom" / "assertions"
     assertions_dir.mkdir(parents=True, exist_ok=True)
@@ -56,6 +61,8 @@ def _write_assertion_fixture(
         "returns": returns,
         "source": source_name,
     }
+    if params is not None:
+        manifest["params"] = params
     manifest_path.write_text(yaml.safe_dump(manifest, sort_keys=False), encoding="utf-8")
     source_path.write_text(code, encoding="utf-8")
     return manifest_path
@@ -216,6 +223,37 @@ class TestRegisterCustomAssertions:
         registry_module.register_custom_assertions(discovery_module.ScanIndex())
 
         assert register_calls == []
+
+    def test_register_custom_assertions_stores_param_schemas_keyed_by_plugin_name(
+        self, tmp_path: Path, monkeypatch
+    ):
+        custom_module = _load_custom_assertion_module()
+        discovery_module = _load_discovery_module()
+        registry_module = _load_registry_module()
+        params_schema = {
+            "type": "object",
+            "properties": {"budget": {"type": "number"}},
+            "required": ["budget"],
+        }
+        _write_assertion_fixture(
+            tmp_path,
+            stem="tone_check",
+            name="Tone Check Display Name",
+            params=params_schema,
+        )
+        index = discovery_module.AssertionScanner(tmp_path).scan()
+
+        monkeypatch.setattr(custom_module, "_PARAM_SCHEMAS", {}, raising=False)
+        monkeypatch.setattr(
+            registry_module,
+            "_build_adapter_class",
+            lambda **kwargs: type("ToneCheckAdapter", (), {"type": "custom:tone_check"}),
+            raising=False,
+        )
+
+        registry_module.register_custom_assertions(index)
+
+        assert custom_module._PARAM_SCHEMAS == {"tone_check": params_schema}
 
 
 class TestAssertionScannerDuplicateStem:

--- a/packages/core/tests/test_run800_custom_assertion_eval_e2e.py
+++ b/packages/core/tests/test_run800_custom_assertion_eval_e2e.py
@@ -1,0 +1,235 @@
+"""RUN-800: end-to-end custom assertion coverage for offline eval runner."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+from typing import Any
+
+import pytest
+import runsight_core.assertions.deterministic  # noqa: F401
+import yaml
+from runsight_core.eval.runner import run_eval
+
+
+def _write_yaml(path: Path, data: dict[str, Any]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+    return path
+
+
+def _write_assertion(
+    base_dir: Path,
+    *,
+    stem: str,
+    returns: str,
+    code: str,
+    params: dict[str, Any] | None = None,
+) -> None:
+    assertions_dir = base_dir / "custom" / "assertions"
+    assertions_dir.mkdir(parents=True, exist_ok=True)
+    manifest = {
+        "version": "1.0",
+        "name": stem.replace("_", " ").title(),
+        "description": f"Custom assertion {stem}",
+        "returns": returns,
+        "source": f"{stem}.py",
+    }
+    if params is not None:
+        manifest["params"] = params
+    _write_yaml(assertions_dir / f"{stem}.yaml", manifest)
+    (assertions_dir / f"{stem}.py").write_text(dedent(code), encoding="utf-8")
+
+
+def _write_eval_workflow(
+    base_dir: Path,
+    *,
+    expected_assertions: list[dict[str, Any]],
+    fixture_output: str = "calm response",
+) -> Path:
+    workflow = {
+        "version": "1.0",
+        "config": {"model_name": "gpt-4o"},
+        "blocks": {
+            "analyze": {
+                "type": "code",
+                "code": "def main(data):\n    return 'unused in fixture mode'\n",
+            }
+        },
+        "workflow": {
+            "name": "run800_eval_flow",
+            "entry": "analyze",
+            "transitions": [{"from": "analyze", "to": None}],
+        },
+        "eval": {
+            "threshold": 0.5,
+            "cases": [
+                {
+                    "id": "custom_case",
+                    "fixtures": {"analyze": fixture_output},
+                    "expected": {"analyze": expected_assertions},
+                }
+            ],
+        },
+    }
+    return _write_yaml(base_dir / "workflow.yaml", workflow)
+
+
+class TestRunEvalCustomAssertionsE2E:
+    @pytest.mark.asyncio
+    async def test_run_eval_path_discovers_promptfoo_custom_assertion_with_config_and_builtin(
+        self, tmp_path: Path
+    ):
+        _write_assertion(
+            tmp_path,
+            stem="tone_check",
+            returns="grading_result",
+            code="""
+            def get_assert(output, context):
+                config = context.get("config", {})
+                return {
+                    "pass": output.startswith(config.get("prefix", "")),
+                    "score": 0.9,
+                    "reason": f"prefix={config.get('prefix', '')}",
+                }
+            """,
+        )
+        workflow_path = _write_eval_workflow(
+            tmp_path,
+            expected_assertions=[
+                {
+                    "type": "custom:tone_check",
+                    "config": {"prefix": "calm"},
+                },
+                {
+                    "type": "contains",
+                    "value": "response",
+                },
+            ],
+        )
+
+        result = await run_eval(str(workflow_path))
+
+        assert result.passed is True
+        analyze_results = result.case_results[0].block_results["analyze"].results
+        assert len(analyze_results) == 2
+        assert analyze_results[0].assertion_type == "custom:tone_check"
+        assert analyze_results[0].passed is True
+        assert analyze_results[0].score == pytest.approx(0.9)
+        assert analyze_results[1].passed is True
+
+    @pytest.mark.asyncio
+    async def test_run_eval_supports_not_prefixed_custom_assertions(self, tmp_path: Path):
+        _write_assertion(
+            tmp_path,
+            stem="blocked_word",
+            returns="bool",
+            code="""
+            def get_assert(output, context):
+                config = context.get("config", {})
+                return config.get("blocked") in output
+            """,
+        )
+        workflow_path = _write_eval_workflow(
+            tmp_path,
+            expected_assertions=[
+                {
+                    "type": "not-custom:blocked_word",
+                    "config": {"blocked": "storm"},
+                }
+            ],
+            fixture_output="calm response",
+        )
+
+        result = await run_eval(str(workflow_path))
+
+        grading = result.case_results[0].block_results["analyze"].results[0]
+        assert grading.passed is True
+        assert grading.score == pytest.approx(1.0)
+        assert grading.assertion_type == "custom:blocked_word"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("stem", "returns", "code", "config", "params", "reason_fragment"),
+        [
+            (
+                "explodes",
+                "bool",
+                """
+                def get_assert(output, context):
+                    raise RuntimeError("plugin exploded")
+                """,
+                {"mode": "strict"},
+                None,
+                "plugin exploded",
+            ),
+            (
+                "wrong_shape",
+                "bool",
+                """
+                def get_assert(output, context):
+                    return {"pass": True, "score": 0.9}
+                """,
+                {"mode": "strict"},
+                None,
+                "declares returns: bool",
+            ),
+            (
+                "config_guard",
+                "bool",
+                """
+                def get_assert(output, context):
+                    return True
+                """,
+                {},
+                {
+                    "type": "object",
+                    "properties": {"budget": {"type": "number"}},
+                    "required": ["budget"],
+                },
+                "Config validation failed:",
+            ),
+            (
+                "llm_auth_guard",
+                "bool",
+                """
+                def get_assert(output, context):
+                    cfg = context.get("config", {})
+                    if not cfg.get("api_key"):
+                        raise RuntimeError("401 Unauthorized: OPENAI_API_KEY missing")
+                    return True
+                """,
+                {},
+                None,
+                "OPENAI_API_KEY missing",
+            ),
+        ],
+    )
+    async def test_run_eval_returns_failing_grading_result_for_custom_error_paths(
+        self,
+        tmp_path: Path,
+        stem: str,
+        returns: str,
+        code: str,
+        config: dict[str, Any],
+        params: dict[str, Any] | None,
+        reason_fragment: str,
+    ):
+        _write_assertion(
+            tmp_path,
+            stem=stem,
+            returns=returns,
+            code=code,
+            params=params,
+        )
+        workflow_path = _write_eval_workflow(
+            tmp_path,
+            expected_assertions=[{"type": f"custom:{stem}", "config": config}],
+        )
+
+        result = await run_eval(str(workflow_path))
+
+        grading = result.case_results[0].block_results["analyze"].results[0]
+        assert grading.passed is False
+        assert grading.score == pytest.approx(0.0)
+        assert reason_fragment in grading.reason

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runsight-workspace"
-version = "0.1.11"
+version = "0.1.12"
 requires-python = ">=3.11"
 dependencies = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runsight-workspace"
-version = "0.1.19"
+version = "0.1.20"
 requires-python = ">=3.11"
 dependencies = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runsight-workspace"
-version = "0.1.16"
+version = "0.1.17"
 requires-python = ">=3.11"
 dependencies = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runsight-workspace"
-version = "0.1.14"
+version = "0.1.15"
 requires-python = ">=3.11"
 dependencies = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runsight-workspace"
-version = "0.1.17"
+version = "0.1.18"
 requires-python = ">=3.11"
 dependencies = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runsight-workspace"
-version = "0.1.15"
+version = "0.1.16"
 requires-python = ">=3.11"
 dependencies = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runsight-workspace"
-version = "0.1.18"
+version = "0.1.19"
 requires-python = ">=3.11"
 dependencies = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runsight-workspace"
-version = "0.1.13"
+version = "0.1.14"
 requires-python = ">=3.11"
 dependencies = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runsight-workspace"
-version = "0.1.12"
+version = "0.1.13"
 requires-python = ">=3.11"
 dependencies = []
 

--- a/uv.lock
+++ b/uv.lock
@@ -2092,7 +2092,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "runsight-workspace"
-version = "0.1.10"
+version = "0.1.20"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- add scanner-based custom assertion discovery and registration for `custom:{file_stem}` plugins
- implement promptfoo-compatible custom assertion adapters, config plumbing, schema validation, and eval observer integration
- document custom assertions across the evaluation docs and add the dedicated docs page
- make `equals` string-only by default and require `config: {mode: json}` for JSON deep-equality
- bump the root package version to `0.1.20`

## Validation
- `uv run ruff check packages/core/src/runsight_core/assertions packages/core/src/runsight_core/yaml/discovery/_assertion.py packages/core/src/runsight_core/eval/runner.py packages/core/src/runsight_core/yaml/parser.py apps/api/src/runsight_api/logic/observers/eval_observer.py apps/api/src/runsight_api/logic/services/execution_service.py pyproject.toml`
- `uv run pytest packages/core/tests/assertions/test_string_assertions.py packages/core/tests/assertions/test_run795_custom_return_validators.py packages/core/tests/assertions/test_run796_custom_adapter.py packages/core/tests/test_run794_assertion_scanner.py packages/core/tests/assertions/test_registry.py packages/core/tests/test_run800_custom_assertion_eval_e2e.py -q`
- `uv run pytest apps/api/tests/logic/test_run800_eval_observer_custom_assertion.py -q`
- `pnpm -C apps/site build`