### PR TITLE
fix(ci): remove parser project-root shim

### DIFF
--- a/packages/core/src/runsight_core/yaml/parser.py
+++ b/packages/core/src/runsight_core/yaml/parser.py
@@ -51,11 +51,6 @@ _UNSET_RUNNER_MODEL_NAME = "__runsight_explicit_model_required__"
 logger = logging.getLogger(__name__)
 
 
-def _find_project_root(start: str | Path) -> str:
-    """Backward-compatible alias for shared discovery base-dir resolution."""
-    return resolve_discovery_base_dir(Path(start))
-
-
 def _bootstrap_runner_model_name(souls_map: Dict[str, Soul]) -> str:
     """Choose an explicit bootstrap model for parser-owned runner construction."""
     for soul in souls_map.values():

--- a/packages/core/tests/test_run569_project_root_resolution.py
+++ b/packages/core/tests/test_run569_project_root_resolution.py
@@ -14,7 +14,8 @@ import textwrap
 from pathlib import Path
 
 import pytest
-from runsight_core.yaml.parser import _find_project_root, parse_workflow_yaml
+from runsight_core.yaml.discovery import resolve_discovery_base_dir
+from runsight_core.yaml.parser import parse_workflow_yaml
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -44,7 +45,7 @@ def _setup_project(tmp_path: Path) -> Path:
 
 
 # ===========================================================================
-# _find_project_root
+# resolve_discovery_base_dir
 # ===========================================================================
 
 
@@ -54,7 +55,7 @@ class TestFindProjectRoot:
         workflows_dir = root / "custom" / "workflows"
         workflows_dir.mkdir(parents=True, exist_ok=True)
 
-        result = Path(_find_project_root(workflows_dir)).resolve()
+        result = Path(resolve_discovery_base_dir(workflows_dir)).resolve()
 
         assert result == root.resolve()
 
@@ -63,7 +64,7 @@ class TestFindProjectRoot:
         deep = root / "custom" / "workflows" / "nested" / "deep"
         deep.mkdir(parents=True, exist_ok=True)
 
-        result = Path(_find_project_root(deep)).resolve()
+        result = Path(resolve_discovery_base_dir(deep)).resolve()
 
         assert result == root.resolve()
 
@@ -72,7 +73,7 @@ class TestFindProjectRoot:
         bare = tmp_path / "isolated" / "no_custom_here"
         bare.mkdir(parents=True)
 
-        result = Path(_find_project_root(bare)).resolve()
+        result = Path(resolve_discovery_base_dir(bare)).resolve()
 
         # Result must be start or an ancestor of start, never a child
         assert bare.resolve().is_relative_to(result) or result == bare.resolve()


### PR DESCRIPTION
## Summary
- remove the parser-local `_find_project_root()` compatibility alias added during the RUN-769 CI repair
- update the RUN-569 regression test to call the shared discovery API directly
- keep project-root resolution owned by the discovery subsystem instead of the parser

## Validation
- `uv run pytest packages/core/tests/test_run569_project_root_resolution.py -q`
- `uv run pytest packages/core/tests/test_run794_assertion_scanner.py packages/core/tests/assertions/test_registry.py packages/core/tests/test_run800_custom_assertion_eval_e2e.py apps/api/tests/logic/test_run800_eval_observer_custom_assertion.py -q`
- `uv run ruff check packages/core/src/runsight_core/yaml/parser.py packages/core/tests/test_run569_project_root_resolution.py`