### PR TITLE
chore(release): bump version after parser follow-up

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runsight-workspace"
-version = "0.1.20"
+version = "0.1.21"
 requires-python = ">=3.11"
 dependencies = []
 


### PR DESCRIPTION
## Summary
- bump the root package version to `0.1.21` after the merged parser/discovery follow-up changed runtime code in `parser.py`
- keep the release metadata aligned with the behavior already merged via PR #16

## Notes
- this PR is version-only
- no additional code changes beyond `pyproject.toml`