### PR TITLE
feat(RUN-803): migrate ToolScanner to Pydantic validation

### DIFF
--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "runsight-core"
-version = "1.1.0"
+version = "1.1.1"
 description = "Runsight Agent OS Core Engine"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/core/src/runsight_core/tools/contract.py
+++ b/packages/core/src/runsight_core/tools/contract.py
@@ -1,0 +1,4 @@
+"""Shared contract constants for custom tool plugins."""
+
+TOOL_FUNCTION_NAME = "main"
+TOOL_FUNCTION_PARAMS = ("args",)

--- a/packages/core/src/runsight_core/yaml/discovery/_tool.py
+++ b/packages/core/src/runsight_core/yaml/discovery/_tool.py
@@ -3,19 +3,50 @@ from __future__ import annotations
 import ast
 import logging
 import subprocess
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Annotated, Any, Literal
 
 import yaml
+from pydantic import BaseModel, ConfigDict, StringConstraints, ValidationError
 
+from runsight_core.tools.contract import TOOL_FUNCTION_NAME, TOOL_FUNCTION_PARAMS
 from runsight_core.yaml.discovery._base import BaseScanner, ScanIndex, ScanResult
 
 logger = logging.getLogger(__name__)
 
+NonEmptyString = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
 
-@dataclass
-class ToolMeta:
+
+class RequestConfig(BaseModel):
+    """Validated request config schema for HTTP-backed tools."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    method: str = "GET"
+    url: NonEmptyString
+    headers: dict[str, str] | None = None
+    body_template: str | None = None
+    response_path: str | None = None
+
+
+class ToolManifest(BaseModel):
+    """Validated custom tool manifest schema."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    version: NonEmptyString
+    type: Literal["custom"]
+    executor: NonEmptyString
+    name: NonEmptyString
+    description: NonEmptyString
+    parameters: dict[str, Any]
+    code: str | None = None
+    code_file: str | None = None
+    request: RequestConfig | None = None
+    timeout_seconds: int | None = None
+
+
+class ToolMeta(BaseModel):
     """Metadata for a discovered custom tool definition file."""
 
     tool_id: str
@@ -39,6 +70,11 @@ def _fail_tool_file(yaml_file: Path, message: str) -> ValueError:
     return ValueError(f"{yaml_file.name}: {message}")
 
 
+def _tool_signature() -> str:
+    params = ", ".join(TOOL_FUNCTION_PARAMS)
+    return f"def {TOOL_FUNCTION_NAME}({params})"
+
+
 def _validate_tool_main_contract(code: str) -> None:
     """Require a ``def main(args)`` function in custom tool code."""
     try:
@@ -47,27 +83,19 @@ def _validate_tool_main_contract(code: str) -> None:
         raise ValueError(f"Tool code has a syntax error: {exc}") from exc
 
     for node in ast.walk(tree):
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == "main":
+        if (
+            isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name == TOOL_FUNCTION_NAME
+        ):
             args = node.args.args
-            if len(args) != 1 or args[0].arg != "args":
-                raise ValueError("Tool code must define 'def main(args)'")
+            if (
+                len(args) != len(TOOL_FUNCTION_PARAMS)
+                or tuple(a.arg for a in args) != TOOL_FUNCTION_PARAMS
+            ):
+                raise ValueError(f"Tool code must define '{_tool_signature()}'")
             return
 
-    raise ValueError("Tool code must define 'def main(args)'")
-
-
-def _require_string(raw: dict[str, Any], key: str, *, yaml_file: Path) -> str:
-    value = raw.get(key)
-    if not isinstance(value, str) or not value.strip():
-        raise _fail_tool_file(yaml_file, f"missing or invalid {key!r}")
-    return value
-
-
-def _require_mapping(raw: dict[str, Any], key: str, *, yaml_file: Path) -> dict[str, Any]:
-    value = raw.get(key)
-    if not isinstance(value, dict):
-        raise _fail_tool_file(yaml_file, f"missing or invalid {key!r}")
-    return value
+    raise ValueError(f"Tool code must define '{_tool_signature()}'")
 
 
 def _read_tool_code_file(yaml_file: Path, code_file: str) -> str:
@@ -83,42 +111,6 @@ def _read_tool_code_file(yaml_file: Path, code_file: str) -> str:
         raise _fail_tool_file(
             yaml_file, f"referenced code_file is not readable: {code_file}"
         ) from exc
-
-
-def _normalize_request_config(yaml_file: Path, raw_request: dict[str, Any]) -> dict[str, Any]:
-    allowed_fields = {"method", "url", "headers", "body_template", "response_path"}
-    extra_fields = sorted(set(raw_request.keys()) - allowed_fields)
-    if extra_fields:
-        joined = ", ".join(extra_fields)
-        raise _fail_tool_file(yaml_file, f"unsupported request fields: {joined}")
-
-    method = raw_request.get("method", "GET")
-    url = raw_request.get("url")
-    headers = raw_request.get("headers")
-    body_template = raw_request.get("body_template")
-    response_path = raw_request.get("response_path")
-
-    if not isinstance(method, str) or not method.strip():
-        raise _fail_tool_file(yaml_file, "missing or invalid request.method")
-    if not isinstance(url, str) or not url.strip():
-        raise _fail_tool_file(yaml_file, "missing or invalid request.url")
-    if headers is not None:
-        if not isinstance(headers, dict) or any(
-            not isinstance(key, str) or not isinstance(value, str) for key, value in headers.items()
-        ):
-            raise _fail_tool_file(yaml_file, "request.headers must be a mapping of strings")
-    if body_template is not None and not isinstance(body_template, str):
-        raise _fail_tool_file(yaml_file, "request.body_template must be a string")
-    if response_path is not None and not isinstance(response_path, str):
-        raise _fail_tool_file(yaml_file, "request.response_path must be a string")
-
-    return {
-        "method": method,
-        "url": url,
-        "headers": headers or {},
-        "body_template": body_template,
-        "response_path": response_path,
-    }
 
 
 class ToolScanner(BaseScanner[ToolMeta]):
@@ -252,57 +244,26 @@ class ToolScanner(BaseScanner[ToolMeta]):
                 f"{collision_path}",
             )
 
-        allowed_fields = {
-            "version",
-            "type",
-            "executor",
-            "name",
-            "description",
-            "parameters",
-            "code",
-            "code_file",
-            "request",
-            "timeout_seconds",
-        }
-        extra_fields = sorted(set(raw.keys()) - allowed_fields)
-        if extra_fields:
-            joined = ", ".join(extra_fields)
-            raise _fail_tool_file(yaml_file, f"unsupported fields: {joined}")
+        try:
+            manifest = ToolManifest.model_validate(raw)
+        except ValidationError as exc:
+            raise _fail_tool_file(yaml_file, str(exc)) from exc
 
-        version = _require_string(raw, "version", yaml_file=yaml_file)
-        tool_type = _require_string(raw, "type", yaml_file=yaml_file)
-        if tool_type != "custom":
-            raise _fail_tool_file(yaml_file, "type must be 'custom'")
+        if manifest.executor not in ("python", "request"):
+            raise _fail_tool_file(yaml_file, f"unknown executor {manifest.executor!r}")
 
-        executor = _require_string(raw, "executor", yaml_file=yaml_file)
-        name = _require_string(raw, "name", yaml_file=yaml_file)
-        description = _require_string(raw, "description", yaml_file=yaml_file)
-        parameters = _require_mapping(raw, "parameters", yaml_file=yaml_file)
-        code = raw.get("code")
-        code_file = raw.get("code_file")
-        request = raw.get("request")
-        timeout_seconds = raw.get("timeout_seconds")
-        if code is not None and not isinstance(code, str):
-            raise _fail_tool_file(yaml_file, "code must be a string")
-        if code_file is not None and not isinstance(code_file, str):
-            raise _fail_tool_file(yaml_file, "code_file must be a string")
-        if timeout_seconds is not None and (
-            not isinstance(timeout_seconds, int)
-            or isinstance(timeout_seconds, bool)
-            or timeout_seconds < 1
-        ):
-            raise _fail_tool_file(yaml_file, "timeout_seconds must be a positive integer")
-
+        code = manifest.code
         normalized_request: dict[str, Any] | None = None
-        if executor == "python":
-            if request is not None or timeout_seconds is not None:
+
+        if manifest.executor == "python":
+            if manifest.request is not None or manifest.timeout_seconds is not None:
                 raise _fail_tool_file(yaml_file, "python executor cannot declare request fields")
-            if code and code_file:
+            if code and manifest.code_file:
                 raise _fail_tool_file(
                     yaml_file, "python executor cannot declare both code and code_file"
                 )
-            if code_file:
-                code = _read_tool_code_file(yaml_file, code_file)
+            if manifest.code_file:
+                code = _read_tool_code_file(yaml_file, manifest.code_file)
             elif not code:
                 raise _fail_tool_file(yaml_file, "python executor requires code or code_file")
 
@@ -310,26 +271,26 @@ class ToolScanner(BaseScanner[ToolMeta]):
                 _validate_tool_main_contract(code)
             except ValueError as exc:
                 raise _fail_tool_file(yaml_file, str(exc)) from exc
-        elif executor == "request":
-            if code is not None or code_file is not None:
+        elif manifest.executor == "request":
+            if code is not None or manifest.code_file is not None:
                 raise _fail_tool_file(yaml_file, "request executor cannot declare python fields")
-            if not isinstance(request, dict):
+            if manifest.request is None:
                 raise _fail_tool_file(yaml_file, "request executor requires a request mapping")
-            normalized_request = _normalize_request_config(yaml_file, request)
-        else:
-            raise _fail_tool_file(yaml_file, f"unknown executor {executor!r}")
+            normalized_request = manifest.request.model_dump()
+            if normalized_request.get("headers") is None:
+                normalized_request["headers"] = {}
 
         return ToolMeta(
             tool_id=tool_id,
             file_path=yaml_file,
-            version=version,
-            type=tool_type,
-            executor=executor,
-            name=name,
-            description=description,
-            parameters=parameters,
+            version=manifest.version,
+            type=manifest.type,
+            executor=manifest.executor,
+            name=manifest.name,
+            description=manifest.description,
+            parameters=manifest.parameters,
             code=code,
-            code_file=code_file,
+            code_file=manifest.code_file,
             request=normalized_request,
-            timeout_seconds=timeout_seconds,
+            timeout_seconds=manifest.timeout_seconds,
         )

--- a/packages/core/tests/test_run803_tool_pydantic_validation.py
+++ b/packages/core/tests/test_run803_tool_pydantic_validation.py
@@ -1,0 +1,540 @@
+"""
+RUN-803: ToolScanner Pydantic migration — failing tests.
+
+These tests verify that:
+- ToolManifest and RequestConfig are Pydantic BaseModels with extra="forbid"
+- ToolMeta is converted from @dataclass to Pydantic BaseModel
+- runsight_core/tools/contract.py exists with TOOL_FUNCTION_NAME / TOOL_FUNCTION_PARAMS
+- _validate_tool_main_contract references the shared constants
+- End-to-end ToolScanner raises Pydantic ValidationError for invalid YAML
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _valid_tool_dict() -> dict:
+    """Minimal valid tool YAML dict (python executor)."""
+    return {
+        "version": "1.0",
+        "type": "custom",
+        "executor": "python",
+        "name": "My Tool",
+        "description": "Does a thing.",
+        "parameters": {"type": "object"},
+        "code": "def main(args):\n    return args\n",
+    }
+
+
+def _valid_request_dict() -> dict:
+    """Minimal valid request config dict."""
+    return {
+        "method": "GET",
+        "url": "https://example.com/api",
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1. ToolManifest exists and is a Pydantic BaseModel with extra="forbid"
+# ---------------------------------------------------------------------------
+
+
+class TestToolManifestIsABaseModel:
+    """ToolManifest must be a Pydantic BaseModel with extra='forbid'."""
+
+    def test_tool_manifest_is_importable(self):
+        from runsight_core.yaml.discovery._tool import ToolManifest  # noqa: F401
+
+    def test_tool_manifest_is_pydantic_base_model(self):
+        from pydantic import BaseModel
+        from runsight_core.yaml.discovery._tool import ToolManifest
+
+        assert issubclass(ToolManifest, BaseModel)
+
+    def test_tool_manifest_has_extra_forbid(self):
+        from runsight_core.yaml.discovery._tool import ToolManifest
+
+        config = ToolManifest.model_config
+        assert config.get("extra") == "forbid", "ToolManifest.model_config must have extra='forbid'"
+
+
+# ---------------------------------------------------------------------------
+# 2. ToolManifest rejects extra fields with ValidationError (not ValueError)
+# ---------------------------------------------------------------------------
+
+
+class TestToolManifestRejectsExtraFields:
+    """Extra top-level fields must raise pydantic.ValidationError, not ValueError."""
+
+    def test_extra_field_raises_validation_error(self):
+        import pydantic
+        from runsight_core.yaml.discovery._tool import ToolManifest
+
+        data = _valid_tool_dict()
+        data["bogus"] = "should not be here"
+
+        with pytest.raises(pydantic.ValidationError):
+            ToolManifest(**data)
+
+    def test_extra_field_does_not_raise_value_error(self):
+        """Ensure the old hand-rolled allowlist path is gone."""
+        import pydantic
+        from runsight_core.yaml.discovery._tool import ToolManifest
+
+        data = _valid_tool_dict()
+        data["unexpected_field"] = True
+
+        try:
+            ToolManifest(**data)
+            pytest.fail("Expected ValidationError but no exception was raised")
+        except pydantic.ValidationError:
+            pass  # correct
+        except ValueError as exc:
+            pytest.fail(
+                f"Got ValueError instead of ValidationError — "
+                f"hand-rolled check still in place: {exc}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# 3. ToolManifest rejects missing required fields with ValidationError
+# ---------------------------------------------------------------------------
+
+
+class TestToolManifestRejectsMissingFields:
+    """Missing required fields must raise pydantic.ValidationError, not ValueError."""
+
+    def test_missing_name_raises_validation_error(self):
+        import pydantic
+        from runsight_core.yaml.discovery._tool import ToolManifest
+
+        data = _valid_tool_dict()
+        del data["name"]
+
+        with pytest.raises(pydantic.ValidationError):
+            ToolManifest(**data)
+
+    def test_missing_description_raises_validation_error(self):
+        import pydantic
+        from runsight_core.yaml.discovery._tool import ToolManifest
+
+        data = _valid_tool_dict()
+        del data["description"]
+
+        with pytest.raises(pydantic.ValidationError):
+            ToolManifest(**data)
+
+    def test_missing_executor_raises_validation_error(self):
+        import pydantic
+        from runsight_core.yaml.discovery._tool import ToolManifest
+
+        data = _valid_tool_dict()
+        del data["executor"]
+
+        with pytest.raises(pydantic.ValidationError):
+            ToolManifest(**data)
+
+    def test_missing_required_field_is_not_value_error(self):
+        """Old _require_string raised ValueError — must be gone."""
+        import pydantic
+        from runsight_core.yaml.discovery._tool import ToolManifest
+
+        data = _valid_tool_dict()
+        del data["version"]
+
+        try:
+            ToolManifest(**data)
+            pytest.fail("Expected ValidationError but no exception was raised")
+        except pydantic.ValidationError:
+            pass  # correct
+        except ValueError as exc:
+            pytest.fail(
+                f"Got ValueError instead of ValidationError — _require_string still in use: {exc}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# 4. RequestConfig exists and is a Pydantic BaseModel with extra="forbid"
+# ---------------------------------------------------------------------------
+
+
+class TestRequestConfigIsABaseModel:
+    """RequestConfig must be a Pydantic BaseModel with extra='forbid'."""
+
+    def test_request_config_is_importable(self):
+        from runsight_core.yaml.discovery._tool import RequestConfig  # noqa: F401
+
+    def test_request_config_is_pydantic_base_model(self):
+        from pydantic import BaseModel
+        from runsight_core.yaml.discovery._tool import RequestConfig
+
+        assert issubclass(RequestConfig, BaseModel)
+
+    def test_request_config_has_extra_forbid(self):
+        from runsight_core.yaml.discovery._tool import RequestConfig
+
+        config = RequestConfig.model_config
+        assert config.get("extra") == "forbid", (
+            "RequestConfig.model_config must have extra='forbid'"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 5. RequestConfig rejects extra request fields with ValidationError
+# ---------------------------------------------------------------------------
+
+
+class TestRequestConfigRejectsExtraFields:
+    """Extra fields inside a request config must raise pydantic.ValidationError."""
+
+    def test_extra_request_field_raises_validation_error(self):
+        import pydantic
+        from runsight_core.yaml.discovery._tool import RequestConfig
+
+        data = _valid_request_dict()
+        data["not_a_valid_field"] = "oops"
+
+        with pytest.raises(pydantic.ValidationError):
+            RequestConfig(**data)
+
+    def test_extra_request_field_does_not_raise_value_error(self):
+        """Old _normalize_request_config raised ValueError — must be gone."""
+        import pydantic
+        from runsight_core.yaml.discovery._tool import RequestConfig
+
+        data = _valid_request_dict()
+        data["extra_key"] = "surprise"
+
+        try:
+            RequestConfig(**data)
+            pytest.fail("Expected ValidationError but no exception was raised")
+        except pydantic.ValidationError:
+            pass  # correct
+        except ValueError as exc:
+            pytest.fail(
+                f"Got ValueError instead of ValidationError — "
+                f"_normalize_request_config still in use: {exc}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# 6. ToolMeta is a Pydantic BaseModel, not a dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestToolMetaIsBaseModel:
+    """ToolMeta must be a Pydantic BaseModel and must NOT be a dataclass."""
+
+    def test_tool_meta_is_importable(self):
+        from runsight_core.yaml.discovery import ToolMeta  # noqa: F401
+
+    def test_tool_meta_is_pydantic_base_model(self):
+        from pydantic import BaseModel
+        from runsight_core.yaml.discovery import ToolMeta
+
+        assert issubclass(ToolMeta, BaseModel), (
+            "ToolMeta must be a Pydantic BaseModel, not a dataclass"
+        )
+
+    def test_tool_meta_is_not_a_dataclass(self):
+        from runsight_core.yaml.discovery import ToolMeta
+
+        assert not hasattr(ToolMeta, "__dataclass_fields__"), (
+            "ToolMeta still has __dataclass_fields__ — it has not been migrated from @dataclass"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 7. Shared contract constants exist
+# ---------------------------------------------------------------------------
+
+
+class TestToolContractConstants:
+    """runsight_core.tools.contract must export TOOL_FUNCTION_NAME and TOOL_FUNCTION_PARAMS."""
+
+    def test_contract_module_is_importable(self):
+        import runsight_core.tools.contract  # noqa: F401
+
+    def test_tool_function_name_constant(self):
+        from runsight_core.tools.contract import TOOL_FUNCTION_NAME
+
+        assert TOOL_FUNCTION_NAME == "main", (
+            f"TOOL_FUNCTION_NAME must be 'main', got {TOOL_FUNCTION_NAME!r}"
+        )
+
+    def test_tool_function_params_constant(self):
+        from runsight_core.tools.contract import TOOL_FUNCTION_PARAMS
+
+        assert TOOL_FUNCTION_PARAMS == ("args",), (
+            f"TOOL_FUNCTION_PARAMS must be ('args',), got {TOOL_FUNCTION_PARAMS!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 8. _validate_tool_main_contract uses shared constants
+# ---------------------------------------------------------------------------
+
+
+class TestValidateToolMainContractUsesConstants:
+    """_validate_tool_main_contract must validate against TOOL_FUNCTION_NAME / TOOL_FUNCTION_PARAMS."""
+
+    def test_valid_code_passes(self):
+        from runsight_core.yaml.discovery._tool import _validate_tool_main_contract
+
+        _validate_tool_main_contract("def main(args):\n    return args\n")
+
+    def test_wrong_function_name_fails(self):
+        from runsight_core.tools.contract import TOOL_FUNCTION_NAME
+        from runsight_core.yaml.discovery._tool import _validate_tool_main_contract
+
+        bad_code = "def run(args):\n    return args\n"
+        with pytest.raises((ValueError, Exception)) as exc_info:
+            _validate_tool_main_contract(bad_code)
+
+        # The error message should reference the expected function name from the constant
+        assert TOOL_FUNCTION_NAME in str(exc_info.value), (
+            f"Error message should reference constant TOOL_FUNCTION_NAME={TOOL_FUNCTION_NAME!r}"
+        )
+
+    def test_wrong_param_name_fails(self):
+        from runsight_core.tools.contract import TOOL_FUNCTION_PARAMS
+        from runsight_core.yaml.discovery._tool import _validate_tool_main_contract
+
+        bad_code = "def main(context):\n    return context\n"
+        with pytest.raises((ValueError, Exception)) as exc_info:
+            _validate_tool_main_contract(bad_code)
+
+        # The error message should reference the expected param from the constant
+        expected_param = TOOL_FUNCTION_PARAMS[0]
+        assert expected_param in str(exc_info.value), (
+            f"Error message should reference constant TOOL_FUNCTION_PARAMS param {expected_param!r}"
+        )
+
+    def test_validate_tool_main_contract_imports_from_contract_module(self):
+        """_tool.py must import TOOL_FUNCTION_NAME / TOOL_FUNCTION_PARAMS from tools/contract.py."""
+        import ast
+        import inspect
+
+        # Read the source of _tool.py
+        import runsight_core.yaml.discovery._tool as tool_module
+
+        source_file = inspect.getfile(tool_module)
+        source = Path(source_file).read_text(encoding="utf-8")
+        tree = ast.parse(source)
+
+        # Look for any import of TOOL_FUNCTION_NAME from runsight_core.tools.contract
+        found_import = False
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom):
+                module = node.module or ""
+                names = [alias.name for alias in node.names]
+                if "tools.contract" in module and "TOOL_FUNCTION_NAME" in names:
+                    found_import = True
+                    break
+
+        assert found_import, (
+            "_tool.py must import TOOL_FUNCTION_NAME from runsight_core.tools.contract"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 9. End-to-end: ToolScanner raises errors originating from Pydantic validation
+# ---------------------------------------------------------------------------
+
+
+class TestToolScannerUsesPydanticValidation:
+    """ToolScanner must delegate field validation to Pydantic, not hand-rolled checks."""
+
+    def test_scan_extra_field_raises_pydantic_validation_error(self):
+        """A tool YAML with an extra field should produce an error rooted in ValidationError."""
+        import pydantic
+        from runsight_core.yaml.discovery import ToolScanner
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base_dir = Path(tmpdir)
+            tools_dir = base_dir / "custom" / "tools"
+            tools_dir.mkdir(parents=True)
+
+            tool_yaml = tools_dir / "my_tool.yaml"
+            tool_yaml.write_text(
+                dedent("""
+                version: "1.0"
+                type: custom
+                executor: python
+                name: My Tool
+                description: Does a thing.
+                parameters:
+                  type: object
+                code: |
+                  def main(args):
+                      return args
+                bogus_extra_field: should_fail
+                """).lstrip()
+            )
+
+            with pytest.raises(Exception) as exc_info:
+                ToolScanner(base_dir).scan()
+
+            # The exception chain must include a Pydantic ValidationError
+            exc = exc_info.value
+            chain = []
+            while exc is not None:
+                chain.append(exc)
+                exc = exc.__cause__ or exc.__context__
+
+            assert any(isinstance(e, pydantic.ValidationError) for e in chain), (
+                "Expected a pydantic.ValidationError somewhere in the exception chain, "
+                f"got: {[type(e).__name__ for e in chain]}"
+            )
+
+    def test_scan_missing_required_field_raises_pydantic_validation_error(self):
+        """A tool YAML missing a required field should produce an error rooted in ValidationError."""
+        import pydantic
+        from runsight_core.yaml.discovery import ToolScanner
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base_dir = Path(tmpdir)
+            tools_dir = base_dir / "custom" / "tools"
+            tools_dir.mkdir(parents=True)
+
+            tool_yaml = tools_dir / "bad_tool.yaml"
+            tool_yaml.write_text(
+                dedent("""
+                version: "1.0"
+                type: custom
+                executor: python
+                description: Missing name field.
+                parameters:
+                  type: object
+                code: |
+                  def main(args):
+                      return args
+                """).lstrip()
+            )
+
+            with pytest.raises(Exception) as exc_info:
+                ToolScanner(base_dir).scan()
+
+            exc = exc_info.value
+            chain = []
+            while exc is not None:
+                chain.append(exc)
+                exc = exc.__cause__ or exc.__context__
+
+            assert any(isinstance(e, pydantic.ValidationError) for e in chain), (
+                "Expected a pydantic.ValidationError somewhere in the exception chain, "
+                f"got: {[type(e).__name__ for e in chain]}"
+            )
+
+    def test_scan_extra_request_field_raises_pydantic_validation_error(self):
+        """A request config with extra fields should produce an error rooted in ValidationError."""
+        import pydantic
+        from runsight_core.yaml.discovery import ToolScanner
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base_dir = Path(tmpdir)
+            tools_dir = base_dir / "custom" / "tools"
+            tools_dir.mkdir(parents=True)
+
+            tool_yaml = tools_dir / "http_tool.yaml"
+            tool_yaml.write_text(
+                dedent("""
+                version: "1.0"
+                type: custom
+                executor: request
+                name: HTTP Tool
+                description: Fetches something.
+                parameters:
+                  type: object
+                request:
+                  method: GET
+                  url: https://example.com/api
+                  unsupported_extra: oops
+                """).lstrip()
+            )
+
+            with pytest.raises(Exception) as exc_info:
+                ToolScanner(base_dir).scan()
+
+            exc = exc_info.value
+            chain = []
+            while exc is not None:
+                chain.append(exc)
+                exc = exc.__cause__ or exc.__context__
+
+            assert any(isinstance(e, pydantic.ValidationError) for e in chain), (
+                "Expected a pydantic.ValidationError somewhere in the exception chain, "
+                f"got: {[type(e).__name__ for e in chain]}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# 10. ToolMeta attribute access unchanged for consumers
+# ---------------------------------------------------------------------------
+
+
+class TestToolMetaAttributeAccess:
+    """ToolMeta constructed with keyword args must expose all expected attributes."""
+
+    def test_tool_meta_python_executor_attribute_access(self):
+        from runsight_core.yaml.discovery import ToolMeta
+
+        meta = ToolMeta(
+            tool_id="lookup_profile",
+            file_path=Path("/tmp/lookup_profile.yaml"),
+            version="1.0",
+            type="custom",
+            executor="python",
+            name="Lookup Profile",
+            description="Look up a profile.",
+            parameters={"type": "object"},
+            code="def main(args):\n    return args\n",
+        )
+
+        assert meta.tool_id == "lookup_profile"
+        assert meta.file_path == Path("/tmp/lookup_profile.yaml")
+        assert meta.executor == "python"
+        assert meta.name == "Lookup Profile"
+        assert meta.description == "Look up a profile."
+        assert meta.parameters == {"type": "object"}
+        assert meta.code == "def main(args):\n    return args\n"
+        assert meta.request is None
+        assert meta.timeout_seconds is None
+
+    def test_tool_meta_request_executor_attribute_access(self):
+        from runsight_core.yaml.discovery import ToolMeta
+
+        meta = ToolMeta(
+            tool_id="fetch_profile",
+            file_path=Path("/tmp/fetch_profile.yaml"),
+            version="1.0",
+            type="custom",
+            executor="request",
+            name="Fetch Profile",
+            description="Fetch a remote profile.",
+            parameters={"type": "object"},
+            request={
+                "method": "GET",
+                "url": "https://example.com/profiles/{{ profile_id }}",
+                "headers": {},
+                "body_template": None,
+                "response_path": "data.profile",
+            },
+            timeout_seconds=9,
+        )
+
+        assert meta.tool_id == "fetch_profile"
+        assert meta.executor == "request"
+        assert meta.request is not None
+        assert meta.request["method"] == "GET"
+        assert meta.timeout_seconds == 9
+        assert meta.code is None

--- a/packages/core/tests/unit/test_parser_tool_validation.py
+++ b/packages/core/tests/unit/test_parser_tool_validation.py
@@ -913,7 +913,7 @@ souls:
                 version: "1.0"
                 type: http
                 """,
-                r"legacy_http.*type.*custom|legacy_http.*unsupported",
+                r"(?s)(?:legacy_http.*type.*custom|legacy_http.*unsupported)",
             ),
             (
                 "missing_request_url",
@@ -928,7 +928,7 @@ souls:
                 request:
                   method: GET
                 """,
-                r"missing_request_url.*url",
+                r"(?s)missing_request_url.*url",
             ),
             (
                 "python_with_request",

--- a/uv.lock
+++ b/uv.lock
@@ -2092,7 +2092,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "runsight-workspace"
-version = "0.1.20"
+version = "0.1.22"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- Migrated `ToolScanner` from hand-rolled validation to Pydantic models, following the assertion scanner pattern
- Created `ToolManifest(BaseModel, extra="forbid")` and `RequestConfig(BaseModel, extra="forbid")` replacing manual allowlist checks, `_require_string`, `_require_mapping`, and `_normalize_request_config`
- Converted `ToolMeta` from `@dataclass` to Pydantic `BaseModel`
- Created `runsight_core/tools/contract.py` with shared `TOOL_FUNCTION_NAME` / `TOOL_FUNCTION_PARAMS` constants (same pattern as `assertions/contract.py`)
- Updated `_validate_tool_main_contract` to reference shared constants

## Test plan
- [x] 29 new tests for Pydantic validation behavior (extra fields, missing fields, request config, contract constants, ToolMeta attribute access)
- [x] 25 existing discovery tests pass
- [x] 5 caller tests pass
- [x] 37 parser tool validation tests pass (2 regex patterns updated for multiline Pydantic errors)
- [x] 5 unified scanner integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)