### PR TITLE
fix(RUN-821): harden Docker deployment — non-root user, resource limits, cap_drop

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,10 +66,10 @@ RUN groupadd --gid 1000 runsight && \
     mkdir -p /workspace && \
     chown runsight:runsight /workspace
 
-# Configure git safe directory so the runsight user can operate on /workspace
-RUN git config --global --add safe.directory /workspace
-
 USER runsight
+
+# Configure git safe directory (must run AFTER USER runsight so it writes to /home/runsight/.gitconfig)
+RUN git config --global --add safe.directory /workspace
 
 ENV RUNSIGHT_BASE_PATH=/workspace \
     RUNSIGHT_STATIC_DIR=/app/static \

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,17 @@ COPY --from=frontend-build /app/apps/gui/dist /app/static
 COPY docker-entrypoint.sh /app/
 RUN chmod +x /app/docker-entrypoint.sh
 
+# Create non-root user and workspace directory
+RUN groupadd --gid 1000 runsight && \
+    useradd --uid 1000 --gid runsight --shell /bin/sh --create-home runsight && \
+    mkdir -p /workspace && \
+    chown runsight:runsight /workspace
+
+# Configure git safe directory so the runsight user can operate on /workspace
+RUN git config --global --add safe.directory /workspace
+
+USER runsight
+
 ENV RUNSIGHT_BASE_PATH=/workspace \
     RUNSIGHT_STATIC_DIR=/app/static \
     RUNSIGHT_LOG_FORMAT=text

--- a/apps/site/public/diagrams/layered-defense.svg
+++ b/apps/site/public/diagrams/layered-defense.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 700 400" font-family="Inter, system-ui, sans-serif">
-  <rect width="700" height="400" rx="12" fill="#141210"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 700 410" font-family="'Satoshi', Inter, system-ui, sans-serif">
+  <rect width="700" height="410" rx="12" fill="#141210"/>
 
   <!-- Layer 1 (outermost) -->
   <rect x="30" y="30" width="640" height="280" rx="12" fill="#1a2018" stroke="#4c8a4c" stroke-width="2"/>
@@ -29,8 +29,8 @@
   <text x="120" y="240" fill="#a07cc8" font-size="12" font-weight="700">Layer 3: Nested Subprocess</text>
   <text x="120" y="258" fill="#6b5080" font-size="10">CodeBlock + simple assertions run in further-isolated subprocess with minimal env</text>
 
-  <!-- Layer 4 (future) — below Layer 1, not overlapping -->
-  <rect x="30" y="340" width="640" height="45" rx="8" fill="#1e1a15" stroke="#6b5c3e" stroke-width="1.5" stroke-dasharray="8,4"/>
-  <text x="60" y="365" fill="#a08a60" font-size="12" font-weight="600">Layer 4 (future): OS-Level Sandboxing</text>
-  <text x="60" y="380" fill="#6b5c3e" font-size="10">seccomp, containers, network namespaces — not currently implemented</text>
+  <!-- Layer 4 — Container Hardening (active) -->
+  <rect x="30" y="330" width="640" height="60" rx="8" fill="#1a1508" stroke="#c08a2a" stroke-width="2"/>
+  <text x="60" y="355" fill="#d4952e" font-size="12" font-weight="700">Layer 4: Container Hardening</text>
+  <text x="60" y="373" fill="#8a7a50" font-size="10">non-root user (UID 1000) · cap_drop: ALL · no-new-privileges · cgroup limits (mem, cpu) · tini PID 1</text>
 </svg>

--- a/apps/site/public/diagrams/layered-defense.svg
+++ b/apps/site/public/diagrams/layered-defense.svg
@@ -1,36 +1,40 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 700 410" font-family="'Satoshi', Inter, system-ui, sans-serif">
-  <rect width="700" height="410" rx="12" fill="#141210"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 740 440" font-family="'Satoshi', Inter, system-ui, sans-serif">
+  <rect width="740" height="440" rx="12" fill="#141210"/>
 
-  <!-- Layer 1 (outermost) -->
-  <rect x="30" y="30" width="640" height="280" rx="12" fill="#1a2018" stroke="#4c8a4c" stroke-width="2"/>
-  <text x="60" y="58" fill="#6bc060" font-size="13" font-weight="700">Layer 1: Process Isolation</text>
-  <text x="60" y="76" fill="#4c8a4c" font-size="10">Separate process — no shared memory, no API keys, no credentials</text>
+  <!-- Layer 1 (outermost) — Container Hardening -->
+  <rect x="15" y="15" width="710" height="410" rx="14" fill="#1a1508" stroke="#c08a2a" stroke-width="2"/>
+  <text x="40" y="42" fill="#d4952e" font-size="13" font-weight="700">Layer 1: Container Hardening</text>
+  <text x="40" y="60" fill="#8a7a50" font-size="10">Unprivileged user · all capabilities dropped · privilege escalation blocked · memory and CPU bounded</text>
 
-  <!-- Layer 2 -->
-  <rect x="60" y="95" width="580" height="200" rx="10" fill="#2a2318" stroke="#c0892a" stroke-width="1.5"/>
-  <text x="90" y="120" fill="#d4952e" font-size="12" font-weight="700">Layer 2: IPC Mediation</text>
-  <text x="90" y="138" fill="#8a7a60" font-size="10">Every engine interaction passes through interceptor chain</text>
+  <!-- Layer 2 — Process Isolation -->
+  <rect x="40" y="75" width="660" height="280" rx="12" fill="#1a2018" stroke="#4c8a4c" stroke-width="2"/>
+  <text x="70" y="103" fill="#6bc060" font-size="13" font-weight="700">Layer 2: Process Isolation</text>
+  <text x="70" y="121" fill="#4c8a4c" font-size="10">Separate process — no shared memory, no API keys, no credentials</text>
 
-  <!-- Budget + Observer boxes inside Layer 2 -->
-  <rect x="90" y="155" width="160" height="45" rx="6" fill="#2a1a18" stroke="#8a4c4c" stroke-width="1"/>
-  <text x="170" y="178" fill="#e08080" font-size="11" font-weight="600" text-anchor="middle">Budget Enforced</text>
-  <text x="170" y="193" fill="#8a4c4c" font-size="9" text-anchor="middle">per LLM call</text>
+  <!-- Layer 3 — IPC Mediation -->
+  <rect x="70" y="140" width="600" height="200" rx="10" fill="#2a2318" stroke="#c0892a" stroke-width="1.5"/>
+  <text x="100" y="165" fill="#d4952e" font-size="12" font-weight="700">Layer 3: IPC Mediation</text>
+  <text x="100" y="183" fill="#8a7a60" font-size="10">Every engine interaction passes through interceptor chain</text>
 
-  <rect x="270" y="155" width="160" height="45" rx="6" fill="#1a2520" stroke="#4c8a6b" stroke-width="1"/>
-  <text x="350" y="178" fill="#6bc090" font-size="11" font-weight="600" text-anchor="middle">Traces Recorded</text>
-  <text x="350" y="193" fill="#4c8a6b" font-size="9" text-anchor="middle">per IPC action</text>
+  <!-- Budget + Observer boxes inside Layer 3 -->
+  <rect x="100" y="200" width="165" height="45" rx="6" fill="#2a1a18" stroke="#8a4c4c" stroke-width="1"/>
+  <text x="182" y="223" fill="#e08080" font-size="11" font-weight="600" text-anchor="middle">Budget Enforced</text>
+  <text x="182" y="238" fill="#8a4c4c" font-size="9" text-anchor="middle">per LLM call</text>
 
-  <rect x="450" y="155" width="160" height="45" rx="6" fill="#1a1828" stroke="#6b5ca0" stroke-width="1"/>
-  <text x="530" y="178" fill="#a080d0" font-size="11" font-weight="600" text-anchor="middle">Actions Validated</text>
-  <text x="530" y="193" fill="#6b5ca0" font-size="9" text-anchor="middle">RPC allowlist</text>
+  <rect x="285" y="200" width="165" height="45" rx="6" fill="#1a2520" stroke="#4c8a6b" stroke-width="1"/>
+  <text x="367" y="223" fill="#6bc090" font-size="11" font-weight="600" text-anchor="middle">Traces Recorded</text>
+  <text x="367" y="238" fill="#4c8a6b" font-size="9" text-anchor="middle">per IPC action</text>
 
-  <!-- Layer 3 (innermost) -->
-  <rect x="90" y="215" width="530" height="60" rx="8" fill="#1f1a28" stroke="#7b5ca0" stroke-width="1.5"/>
-  <text x="120" y="240" fill="#a07cc8" font-size="12" font-weight="700">Layer 3: Nested Subprocess</text>
-  <text x="120" y="258" fill="#6b5080" font-size="10">CodeBlock + simple assertions run in further-isolated subprocess with minimal env</text>
+  <rect x="470" y="200" width="165" height="45" rx="6" fill="#1a1828" stroke="#6b5ca0" stroke-width="1"/>
+  <text x="552" y="223" fill="#a080d0" font-size="11" font-weight="600" text-anchor="middle">Actions Validated</text>
+  <text x="552" y="238" fill="#6b5ca0" font-size="9" text-anchor="middle">RPC allowlist</text>
 
-  <!-- Layer 4 — Container Hardening (active) -->
-  <rect x="30" y="330" width="640" height="60" rx="8" fill="#1a1508" stroke="#c08a2a" stroke-width="2"/>
-  <text x="60" y="355" fill="#d4952e" font-size="12" font-weight="700">Layer 4: Container Hardening</text>
-  <text x="60" y="373" fill="#8a7a50" font-size="10">non-root user (UID 1000) · cap_drop: ALL · no-new-privileges · cgroup limits (mem, cpu) · tini PID 1</text>
+  <!-- Layer 4 (innermost) — Nested Subprocess -->
+  <rect x="100" y="260" width="535" height="60" rx="8" fill="#1f1a28" stroke="#7b5ca0" stroke-width="1.5"/>
+  <text x="130" y="285" fill="#a07cc8" font-size="12" font-weight="700">Layer 4: Nested Subprocess</text>
+  <text x="130" y="303" fill="#6b5080" font-size="10">CodeBlock + simple assertions run in further-isolated subprocess with minimal env</text>
+
+  <!-- Status bar -->
+  <rect x="40" y="370" width="660" height="40" rx="8" fill="#181512" stroke="#2a2520" stroke-width="1"/>
+  <text x="60" y="395" fill="#6b6050" font-size="10">Defense-in-depth: 4 active layers · credentials never cross the process boundary · every action traced</text>
 </svg>

--- a/apps/site/src/content/docs/docs/execution/process-isolation.md
+++ b/apps/site/src/content/docs/docs/execution/process-isolation.md
@@ -86,14 +86,14 @@ See [Custom Assertions](/docs/evaluation/custom-assertions#llm-graded-assertions
 
 ## Layered defense model
 
-Runsight uses defense-in-depth with three active layers and one planned.
+Runsight uses defense-in-depth with four active layers.
 
 ![Layered defense model](/diagrams/layered-defense.svg)
 
-- **Layer 1 — Process isolation:** The subprocess runs in a separate OS process. No shared memory, no API keys, no credentials.
-- **Layer 2 — IPC mediation:** Every engine interaction passes through the interceptor chain. Budgets enforced per call. Actions validated against an allowlist. Traces recorded automatically.
-- **Layer 3 — Nested subprocess:** Code execution (CodeBlock) and simple assertion plugins run in a further-nested subprocess with an even more restricted environment.
-- **Layer 4 — OS-level sandboxing:** Container hardening active — non-root user (UID 1000), zero Linux capabilities (cap_drop: ALL), no-new-privileges, and resource limits (mem_limit, cpus). seccomp and network namespaces are planned next steps.
+- **Layer 1 — Container hardening:** The Docker deployment runs as an unprivileged user, drops all Linux capabilities, prevents privilege escalation, and enforces memory and CPU limits. A runaway process is killed by the kernel, not the host.
+- **Layer 2 — Process isolation:** The subprocess runs in a separate OS process. No shared memory, no API keys, no credentials.
+- **Layer 3 — IPC mediation:** Every engine interaction passes through the interceptor chain. Budgets enforced per call. Actions validated against an allowlist. Traces recorded automatically.
+- **Layer 4 — Nested subprocess:** Code execution (CodeBlock) and simple assertion plugins run in a further-nested subprocess with an even more restricted environment.
 
 ## Known limitations
 

--- a/apps/site/src/content/docs/docs/execution/process-isolation.md
+++ b/apps/site/src/content/docs/docs/execution/process-isolation.md
@@ -93,7 +93,7 @@ Runsight uses defense-in-depth with three active layers and one planned.
 - **Layer 1 — Process isolation:** The subprocess runs in a separate OS process. No shared memory, no API keys, no credentials.
 - **Layer 2 — IPC mediation:** Every engine interaction passes through the interceptor chain. Budgets enforced per call. Actions validated against an allowlist. Traces recorded automatically.
 - **Layer 3 — Nested subprocess:** Code execution (CodeBlock) and simple assertion plugins run in a further-nested subprocess with an even more restricted environment.
-- **Layer 4 — OS-level sandboxing** (future): seccomp, containers, network namespaces. Not currently implemented, but the architecture supports it.
+- **Layer 4 — OS-level sandboxing:** Container hardening active — non-root user (UID 1000), zero Linux capabilities (cap_drop: ALL), no-new-privileges, and resource limits (mem_limit, cpus). seccomp and network namespaces are planned next steps.
 
 ## Known limitations
 
@@ -107,7 +107,7 @@ Process isolation is a credential boundary, not a full execution sandbox.
 | Observability | **Protected** | Every IPC action creates a trace span |
 | Network access | Not restricted | Subprocess can use Python `socket` directly (but has nothing to exfiltrate) |
 | Filesystem access | Partially restricted | IPC file handler is sandboxed; direct `open()` calls are not |
-| CPU / memory limits | Not enforced | Only wall-clock timeout and heartbeat stall detection |
+| CPU / memory limits | Container-level | mem_limit, memswap_limit, and cpus enforced via Docker cgroups |
 | Python imports | Not restricted | Subprocess can import any installed package |
 
 The isolation boundary works because the subprocess has **nothing valuable** — no API keys, no credentials, no engine state. Even if the subprocess makes direct network calls, it has nothing sensitive to send.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,15 @@
 services:
+  init-permissions:
+    image: busybox
+    user: "0"
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+    volumes:
+      - ./:/workspace
+    entrypoint: ["sh", "-c", "chown -R 1000:1000 /workspace"]
+
   runsight:
     build: .
     ports:
@@ -9,6 +20,17 @@ services:
       - RUNSIGHT_BASE_PATH=/workspace
       - RUNSIGHT_LOG_FORMAT=text
     restart: unless-stopped
+    depends_on:
+      init-permissions:
+        condition: service_completed_successfully
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    mem_limit: 4g
+    memswap_limit: 4g
+    cpus: 2
+    init: true
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
       interval: 30s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - CHOWN
     volumes:
       - ./:/workspace
-    entrypoint: ["sh", "-c", "chown -R 1000:1000 /workspace"]
+    entrypoint: ["sh", "-c", "chown 1000:1000 /workspace && if [ -d /workspace/.runsight ]; then chown -R 1000:1000 /workspace/.runsight; fi"]
 
   runsight:
     build: .

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,12 +8,11 @@ export PATH="/app/.venv/bin:$PATH"
 : "${RUNSIGHT_BASE_PATH:=/workspace}"
 export RUNSIGHT_BASE_PATH
 
-# Ensure workspace directory exists
+# Fail-fast: workspace must be pre-created and mounted by the host
 if [ ! -d "$RUNSIGHT_BASE_PATH" ]; then
-    mkdir -p "$RUNSIGHT_BASE_PATH"
-    echo "[runsight] Created workspace at $RUNSIGHT_BASE_PATH"
-    echo "[runsight] WARNING: No volume mounted — data will not persist when the container stops."
-    echo "[runsight] Mount a volume: docker run -v \$(pwd):/workspace ..."
+    echo "[runsight] ERROR: Workspace '$RUNSIGHT_BASE_PATH' does not exist." >&2
+    echo "[runsight] Mount a volume: docker run -v \$(pwd):/workspace ..." >&2
+    exit 1
 fi
 
 # Warn if workspace is empty

--- a/packages/core/tests/test_run_821_docker_hardening.py
+++ b/packages/core/tests/test_run_821_docker_hardening.py
@@ -438,48 +438,47 @@ class TestEntrypointBehavior:
 
 
 # ===========================================================================
-# SECTION 4 — process-isolation.md: Layer 4 updated, limitations table updated
+# SECTION 4 — process-isolation.md: Container hardening is Layer 1, active
 # ===========================================================================
 
 
 class TestProcessIsolationDocsUpdated:
-    """AC3 / AC2 — Documentation must reflect container hardening as an active layer."""
+    """AC3 / AC2 — Documentation must reflect container hardening as Layer 1."""
 
-    def test_layer_4_does_not_say_future(self):
-        """Layer 4 description must not contain 'future' — it is now implemented."""
+    def test_container_hardening_is_layer_1(self):
+        """Container hardening must be Layer 1 (outermost defense layer)."""
         md = _read_process_isolation_md()
-        # Find the Layer 4 line.
-        layer4_lines = [ln for ln in md.splitlines() if "Layer 4" in ln]
-        assert layer4_lines, "No 'Layer 4' line found in process-isolation.md."
-        layer4_text = " ".join(layer4_lines).lower()
-        assert "future" not in layer4_text, (
-            f"Layer 4 description still contains 'future': {layer4_lines}. "
-            "Green must update Layer 4 to reflect that container hardening is active."
+        layer1_lines = [ln for ln in md.splitlines() if "Layer 1" in ln]
+        assert layer1_lines, "No 'Layer 1' line found in process-isolation.md."
+        layer1_text = " ".join(layer1_lines).lower()
+        assert "container" in layer1_text or "hardening" in layer1_text, (
+            f"Layer 1 does not mention container hardening: {layer1_lines}. "
+            "Container hardening must be the outermost layer (Layer 1)."
         )
 
-    def test_layer_4_does_not_say_not_currently_implemented(self):
-        """Layer 4 description must not say 'Not currently implemented'."""
+    def test_layer_1_does_not_say_future(self):
+        """Container hardening layer must not contain 'future' — it is active."""
         md = _read_process_isolation_md()
-        layer4_lines = [ln for ln in md.splitlines() if "Layer 4" in ln]
-        assert layer4_lines, "No 'Layer 4' line found in process-isolation.md."
-        layer4_text = " ".join(layer4_lines).lower()
-        assert "not currently implemented" not in layer4_text, (
-            f"Layer 4 still says 'Not currently implemented': {layer4_lines}. Green must update it."
+        layer1_lines = [ln for ln in md.splitlines() if "Layer 1" in ln]
+        assert layer1_lines, "No 'Layer 1' line found in process-isolation.md."
+        layer1_text = " ".join(layer1_lines).lower()
+        assert "future" not in layer1_text, (
+            f"Layer 1 description still contains 'future': {layer1_lines}. "
+            "Container hardening is active, not future."
         )
 
-    def test_layer_4_mentions_non_root_user_specifically(self):
+    def test_layer_1_mentions_unprivileged_user(self):
         """
-        Layer 4 description must explicitly mention 'non-root' (the UID 1000 user),
-        not just 'containers' generically as the current text does when discussing
-        network namespaces as a future direction.
+        Container hardening layer must mention the unprivileged user,
+        using human-readable language.
         """
         md = _read_process_isolation_md()
-        layer4_lines = [ln for ln in md.splitlines() if "Layer 4" in ln]
-        assert layer4_lines, "No 'Layer 4' line found in process-isolation.md."
-        layer4_text = " ".join(layer4_lines).lower()
-        assert "non-root" in layer4_text, (
-            f"Layer 4 does not mention 'non-root': {layer4_lines}. "
-            "Green must update Layer 4 to explicitly reference the non-root container user."
+        layer1_lines = [ln for ln in md.splitlines() if "Layer 1" in ln]
+        assert layer1_lines, "No 'Layer 1' line found in process-isolation.md."
+        layer1_text = " ".join(layer1_lines).lower()
+        assert "unprivileged" in layer1_text or "non-root" in layer1_text, (
+            f"Layer 1 does not mention unprivileged/non-root user: {layer1_lines}. "
+            "Container hardening layer must reference the unprivileged container user."
         )
 
     def test_cpu_memory_limits_row_not_unenforced(self):

--- a/packages/core/tests/test_run_821_docker_hardening.py
+++ b/packages/core/tests/test_run_821_docker_hardening.py
@@ -1,0 +1,514 @@
+"""
+RUN-821 — Docker hardening tests.
+
+These tests are RED-phase: they assert on security posture that does not yet exist.
+Every test here is expected to FAIL until Green implements:
+
+1. Dockerfile — runsight user (UID/GID 1000), git safe.directory, USER directive
+2. docker-compose.yml — init-permissions service, cap_drop, no-new-privileges,
+   mem_limit, cpus, init: true, depends_on
+3. docker-entrypoint.sh — fail-fast when workspace is absent (no mkdir)
+4. process-isolation.md — Layer 4 updated to reflect container hardening
+
+Acceptance Criteria coverage:
+- AC1: Process runs as UID 1000 (runsight), not root
+- AC2: Memory limits via cgroup OOM (mem_limit / memswap_limit in compose)
+- AC3: Zero Linux capabilities (cap_drop: ALL, no cap_add)
+- AC4: no-new-privileges security_opt
+- AC5: init-permissions service owns /workspace before main service
+- AC6: git safe.directory configured at build time
+- AC7: zombie reaping via tini (init: true in compose)
+"""
+
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+# Resolve repo root: packages/core/tests/ is 3 levels deep from root.
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+DOCKERFILE = REPO_ROOT / "Dockerfile"
+COMPOSE_FILE = REPO_ROOT / "docker-compose.yml"
+ENTRYPOINT = REPO_ROOT / "docker-entrypoint.sh"
+PROCESS_ISOLATION_MD = (
+    REPO_ROOT
+    / "apps"
+    / "site"
+    / "src"
+    / "content"
+    / "docs"
+    / "docs"
+    / "execution"
+    / "process-isolation.md"
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_dockerfile() -> str:
+    return DOCKERFILE.read_text()
+
+
+def _load_compose() -> dict:
+    return yaml.safe_load(COMPOSE_FILE.read_text())
+
+
+def _read_entrypoint() -> str:
+    return ENTRYPOINT.read_text()
+
+
+def _read_process_isolation_md() -> str:
+    return PROCESS_ISOLATION_MD.read_text()
+
+
+def _runtime_stage_lines(dockerfile_text: str) -> list[str]:
+    """Return lines that belong to the runtime stage (after 'AS runtime')."""
+    lines = dockerfile_text.splitlines()
+    in_runtime = False
+    result = []
+    for line in lines:
+        if re.search(r"FROM\s+\S+\s+AS\s+runtime", line, re.IGNORECASE):
+            in_runtime = True
+            continue
+        if in_runtime and re.match(r"FROM\s+", line, re.IGNORECASE):
+            # Next FROM stage — stop collecting.
+            break
+        if in_runtime:
+            result.append(line)
+    return result
+
+
+# ===========================================================================
+# SECTION 1 — Dockerfile: non-root user, UID 1000, git safe.directory
+# ===========================================================================
+
+
+class TestDockerfileNonRootUser:
+    """AC1 / AC6 — Dockerfile must create and switch to UID 1000 user."""
+
+    def test_user_directive_exists_in_runtime_stage(self):
+        """A USER directive must be present in the runtime stage."""
+        runtime_lines = _runtime_stage_lines(_read_dockerfile())
+        user_directives = [ln for ln in runtime_lines if re.match(r"^\s*USER\s+", ln)]
+        assert user_directives, (
+            "No USER directive found in the runtime stage. "
+            "Green must add 'USER runsight' (or USER 1000) to the runtime stage."
+        )
+
+    def test_user_directive_names_runsight(self):
+        """The USER directive must reference the runsight user (not root, not numeric root)."""
+        runtime_lines = _runtime_stage_lines(_read_dockerfile())
+        user_directives = [ln for ln in runtime_lines if re.match(r"^\s*USER\s+", ln)]
+        assert user_directives, (
+            "No USER directive found in the runtime stage — cannot verify it names 'runsight'. "
+            "Green must add 'USER runsight' to the runtime stage."
+        )
+        for line in user_directives:
+            m = re.match(r"^\s*USER\s+(\S+)", line)
+            if m:
+                user_value = m.group(1).lower()
+                assert "runsight" in user_value or user_value == "1000", (
+                    f"USER directive is '{m.group(1)}', expected 'runsight' or '1000'. "
+                    "Green must use the named runsight user."
+                )
+
+    def test_groupadd_creates_gid_1000(self):
+        """groupadd must create the runsight group with GID 1000."""
+        dockerfile_text = _read_dockerfile()
+        runtime_lines = _runtime_stage_lines(dockerfile_text)
+        runtime_block = "\n".join(runtime_lines)
+        assert re.search(r"groupadd\b.*--gid\s+1000", runtime_block) or re.search(
+            r"groupadd\b.*-g\s+1000", runtime_block
+        ), (
+            "No groupadd with GID 1000 found in runtime stage. "
+            "Green must add: groupadd --gid 1000 runsight"
+        )
+
+    def test_useradd_creates_uid_1000(self):
+        """useradd must create the runsight user with UID 1000."""
+        runtime_block = "\n".join(_runtime_stage_lines(_read_dockerfile()))
+        assert re.search(r"useradd\b.*--uid\s+1000", runtime_block) or re.search(
+            r"useradd\b.*-u\s+1000", runtime_block
+        ), (
+            "No useradd with UID 1000 found in runtime stage. "
+            "Green must add: useradd --uid 1000 --gid 1000 runsight"
+        )
+
+    def test_useradd_references_runsight(self):
+        """useradd must create a user named 'runsight'."""
+        runtime_block = "\n".join(_runtime_stage_lines(_read_dockerfile()))
+        assert re.search(r"useradd\b.*runsight", runtime_block), (
+            "No 'useradd ... runsight' found in runtime stage. Green must name the user 'runsight'."
+        )
+
+    def test_git_safe_directory_configured(self):
+        """git config safe.directory /workspace must be set at build time."""
+        runtime_block = "\n".join(_runtime_stage_lines(_read_dockerfile()))
+        assert re.search(
+            r"git\s+config\s+--global\s+--add\s+safe\.directory\s+/workspace", runtime_block
+        ), (
+            "git safe.directory /workspace not configured in the Dockerfile runtime stage. "
+            "Green must add: RUN git config --global --add safe.directory /workspace"
+        )
+
+    def test_workspace_dir_created_with_correct_ownership(self):
+        """
+        /workspace must be pre-created and chowned to the runsight user
+        in the Dockerfile so the non-root user can write to it.
+        """
+        runtime_block = "\n".join(_runtime_stage_lines(_read_dockerfile()))
+        # Accept either explicit mkdir+chown or combined form.
+        has_mkdir = re.search(r"mkdir\s+-p\s+/workspace", runtime_block)
+        has_chown = re.search(
+            r"chown\s+.*runsight.*:.*runsight.*\s+/workspace", runtime_block
+        ) or re.search(r"chown\s+1000:1000\s+/workspace", runtime_block)
+        assert has_mkdir and has_chown, (
+            "Dockerfile runtime stage must mkdir /workspace and chown it to runsight:runsight (1000:1000). "
+            f"mkdir found: {bool(has_mkdir)}, chown found: {bool(has_chown)}"
+        )
+
+
+# ===========================================================================
+# SECTION 2 — docker-compose.yml: security settings
+# ===========================================================================
+
+
+class TestDockerComposeInitPermissions:
+    """AC5 — init-permissions service must set up /workspace before main service."""
+
+    def test_init_permissions_service_exists(self):
+        """An 'init-permissions' service must exist in docker-compose.yml."""
+        compose = _load_compose()
+        services = compose.get("services", {})
+        assert "init-permissions" in services, (
+            "No 'init-permissions' service found in docker-compose.yml. "
+            "Green must add a service that chowns /workspace to UID 1000."
+        )
+
+    def test_init_permissions_uses_busybox(self):
+        """init-permissions service must use a minimal image (busybox)."""
+        compose = _load_compose()
+        svc = compose.get("services", {}).get("init-permissions", {})
+        image = svc.get("image", "")
+        assert "busybox" in image.lower(), (
+            f"init-permissions uses image '{image}', expected a busybox-based image. "
+            "Green must use 'busybox' for the init-permissions service."
+        )
+
+    def test_init_permissions_runs_as_root(self):
+        """init-permissions service must run as root (user: '0') to chown files."""
+        compose = _load_compose()
+        svc = compose.get("services", {}).get("init-permissions", {})
+        user = str(svc.get("user", ""))
+        assert user == "0", (
+            f"init-permissions service user is '{user}', expected '0' (root). "
+            "Green must set user: '0' so it can chown /workspace."
+        )
+
+    def test_init_permissions_has_cap_drop_all(self):
+        """init-permissions service must drop all capabilities."""
+        compose = _load_compose()
+        svc = compose.get("services", {}).get("init-permissions", {})
+        cap_drop = svc.get("cap_drop", [])
+        assert "ALL" in cap_drop, (
+            f"init-permissions cap_drop is {cap_drop}, expected ['ALL']. "
+            "Green must add cap_drop: [ALL] to the init-permissions service."
+        )
+
+    def test_init_permissions_has_cap_add_chown_only(self):
+        """init-permissions must add back only CAP_CHOWN."""
+        compose = _load_compose()
+        svc = compose.get("services", {}).get("init-permissions", {})
+        cap_add = svc.get("cap_add", [])
+        assert cap_add == ["CHOWN"], (
+            f"init-permissions cap_add is {cap_add}, expected ['CHOWN']. "
+            "Green must add cap_add: [CHOWN] only."
+        )
+
+
+class TestDockerComposeRunsightServiceSecurity:
+    """AC2 / AC3 / AC4 / AC7 — runsight service must be locked down."""
+
+    def test_runsight_has_cap_drop_all(self):
+        """runsight service must drop ALL Linux capabilities."""
+        compose = _load_compose()
+        svc = compose.get("services", {}).get("runsight", {})
+        cap_drop = svc.get("cap_drop", [])
+        assert "ALL" in cap_drop, (
+            f"runsight cap_drop is {cap_drop}, expected ['ALL']. "
+            "Green must add cap_drop: [ALL] to the runsight service."
+        )
+
+    def test_runsight_has_no_cap_add(self):
+        """
+        runsight service must NOT have a cap_add directive.
+        This test also verifies cap_drop: ALL is already present (otherwise
+        'no cap_add' is trivially true for any unconfigured service).
+        """
+        compose = _load_compose()
+        svc = compose.get("services", {}).get("runsight", {})
+        # First check cap_drop is configured — makes this test load-bearing.
+        cap_drop = svc.get("cap_drop", [])
+        assert "ALL" in cap_drop, (
+            f"runsight cap_drop is {cap_drop}. "
+            "Green must add cap_drop: [ALL] before the no-cap_add assertion is meaningful."
+        )
+        cap_add = svc.get("cap_add")
+        assert cap_add is None or cap_add == [], (
+            f"runsight has cap_add: {cap_add}. "
+            "Green must not add any capabilities back to the runsight service."
+        )
+
+    def test_runsight_has_no_new_privileges(self):
+        """runsight service must set security_opt: no-new-privileges:true."""
+        compose = _load_compose()
+        svc = compose.get("services", {}).get("runsight", {})
+        security_opt = svc.get("security_opt", [])
+        assert "no-new-privileges:true" in security_opt, (
+            f"runsight security_opt is {security_opt}, "
+            "expected 'no-new-privileges:true'. "
+            "Green must add security_opt: [no-new-privileges:true]."
+        )
+
+    def test_runsight_has_mem_limit(self):
+        """runsight service must have a mem_limit set (4g or equivalent)."""
+        compose = _load_compose()
+        svc = compose.get("services", {}).get("runsight", {})
+        mem_limit = svc.get("mem_limit")
+        assert mem_limit is not None, (
+            "runsight service has no mem_limit. Green must add mem_limit: 4g to cap memory usage."
+        )
+        assert str(mem_limit).lower() in ("4g", "4096m", "4294967296"), (
+            f"runsight mem_limit is '{mem_limit}', expected '4g'. Green must set mem_limit: 4g."
+        )
+
+    def test_runsight_has_memswap_limit(self):
+        """runsight service must have memswap_limit equal to mem_limit to prevent swap usage."""
+        compose = _load_compose()
+        svc = compose.get("services", {}).get("runsight", {})
+        memswap = svc.get("memswap_limit")
+        assert memswap is not None, (
+            "runsight service has no memswap_limit. "
+            "Green must add memswap_limit: 4g to prevent OOM evasion via swap."
+        )
+        assert str(memswap).lower() in ("4g", "4096m", "4294967296"), (
+            f"runsight memswap_limit is '{memswap}', expected '4g'. "
+            "Green must set memswap_limit: 4g."
+        )
+
+    def test_runsight_has_cpus_limit(self):
+        """runsight service must have a cpus limit."""
+        compose = _load_compose()
+        svc = compose.get("services", {}).get("runsight", {})
+        cpus = svc.get("cpus")
+        assert cpus is not None, (
+            "runsight service has no cpus limit. Green must add cpus: 2 to cap CPU usage."
+        )
+        assert float(cpus) == 2.0, f"runsight cpus is {cpus}, expected 2. Green must set cpus: 2."
+
+    def test_runsight_has_init_true(self):
+        """runsight service must use init: true so tini (PID 1) reaps zombie processes."""
+        compose = _load_compose()
+        svc = compose.get("services", {}).get("runsight", {})
+        init_flag = svc.get("init")
+        assert init_flag is True, (
+            f"runsight 'init' flag is {init_flag!r}, expected True. "
+            "Green must add init: true so Docker injects tini as PID 1."
+        )
+
+    def test_runsight_depends_on_init_permissions(self):
+        """runsight service must depend on init-permissions completing successfully."""
+        compose = _load_compose()
+        svc = compose.get("services", {}).get("runsight", {})
+        depends_on = svc.get("depends_on", {})
+
+        # depends_on can be a list or dict form.
+        if isinstance(depends_on, list):
+            assert "init-permissions" in depends_on, (
+                f"runsight depends_on is {depends_on}. "
+                "Green must add init-permissions to depends_on."
+            )
+        elif isinstance(depends_on, dict):
+            assert "init-permissions" in depends_on, (
+                f"runsight depends_on keys are {list(depends_on.keys())}. "
+                "Green must add init-permissions to depends_on."
+            )
+            condition = depends_on["init-permissions"].get("condition")
+            assert condition == "service_completed_successfully", (
+                f"init-permissions condition is '{condition}', "
+                "expected 'service_completed_successfully'. "
+                "Green must use condition: service_completed_successfully."
+            )
+        else:
+            pytest.fail(
+                f"runsight depends_on is missing or malformed: {depends_on!r}. "
+                "Green must add depends_on: init-permissions with condition: service_completed_successfully."
+            )
+
+
+# ===========================================================================
+# SECTION 3 — docker-entrypoint.sh: fail-fast, no mkdir
+# ===========================================================================
+
+
+class TestEntrypointBehavior:
+    """AC1 / AC5 — Entrypoint must fail-fast when workspace absent; no mkdir."""
+
+    def test_entrypoint_has_no_mkdir(self):
+        """
+        The updated entrypoint must NOT contain mkdir.
+        Non-root containers cannot create root-owned directories at runtime.
+        """
+        entrypoint_text = _read_entrypoint()
+        assert "mkdir" not in entrypoint_text, (
+            "docker-entrypoint.sh still contains 'mkdir'. "
+            "Green must remove all mkdir calls — init-permissions handles ownership, "
+            "and the container runs as non-root."
+        )
+
+    def test_entrypoint_exits_nonzero_when_workspace_missing(self):
+        """
+        When RUNSIGHT_BASE_PATH does not exist the entrypoint must exit with
+        a non-zero status code and a meaningful error message.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            missing_path = str(Path(tmp) / "nonexistent-workspace")
+            result = subprocess.run(
+                ["sh", str(ENTRYPOINT), "true"],
+                env={
+                    "PATH": "/app/.venv/bin:/usr/local/bin:/usr/bin:/bin",
+                    "RUNSIGHT_BASE_PATH": missing_path,
+                },
+                capture_output=True,
+                text=True,
+            )
+        assert result.returncode != 0, (
+            f"Entrypoint exited with code {result.returncode} (expected non-zero) "
+            f"when workspace '{missing_path}' does not exist. "
+            "Green must add a fail-fast check: if workspace is absent, exit 1."
+        )
+
+    def test_entrypoint_succeeds_when_workspace_exists(self):
+        """
+        When RUNSIGHT_BASE_PATH exists the entrypoint must exit with code 0
+        and pass through to exec.
+        """
+        with tempfile.TemporaryDirectory() as workspace:
+            result = subprocess.run(
+                ["sh", str(ENTRYPOINT), "true"],
+                env={
+                    "PATH": "/app/.venv/bin:/usr/local/bin:/usr/bin:/bin",
+                    "RUNSIGHT_BASE_PATH": workspace,
+                },
+                capture_output=True,
+                text=True,
+            )
+        assert result.returncode == 0, (
+            f"Entrypoint exited with code {result.returncode} when workspace exists. "
+            f"stdout: {result.stdout!r}, stderr: {result.stderr!r}"
+        )
+
+    def test_entrypoint_prints_scaffold_message_for_empty_workspace(self):
+        """
+        When the workspace exists but is empty the entrypoint should print a
+        message indicating Runsight will scaffold a new project.
+        """
+        with tempfile.TemporaryDirectory() as workspace:
+            result = subprocess.run(
+                ["sh", str(ENTRYPOINT), "true"],
+                env={
+                    "PATH": "/app/.venv/bin:/usr/local/bin:/usr/bin:/bin",
+                    "RUNSIGHT_BASE_PATH": workspace,
+                },
+                capture_output=True,
+                text=True,
+            )
+        combined = result.stdout + result.stderr
+        assert "scaffold" in combined.lower(), (
+            "Entrypoint did not print a scaffolding message for an empty workspace. "
+            f"Output was: {combined!r}"
+        )
+
+
+# ===========================================================================
+# SECTION 4 — process-isolation.md: Layer 4 updated, limitations table updated
+# ===========================================================================
+
+
+class TestProcessIsolationDocsUpdated:
+    """AC3 / AC2 — Documentation must reflect container hardening as an active layer."""
+
+    def test_layer_4_does_not_say_future(self):
+        """Layer 4 description must not contain 'future' — it is now implemented."""
+        md = _read_process_isolation_md()
+        # Find the Layer 4 line.
+        layer4_lines = [ln for ln in md.splitlines() if "Layer 4" in ln]
+        assert layer4_lines, "No 'Layer 4' line found in process-isolation.md."
+        layer4_text = " ".join(layer4_lines).lower()
+        assert "future" not in layer4_text, (
+            f"Layer 4 description still contains 'future': {layer4_lines}. "
+            "Green must update Layer 4 to reflect that container hardening is active."
+        )
+
+    def test_layer_4_does_not_say_not_currently_implemented(self):
+        """Layer 4 description must not say 'Not currently implemented'."""
+        md = _read_process_isolation_md()
+        layer4_lines = [ln for ln in md.splitlines() if "Layer 4" in ln]
+        assert layer4_lines, "No 'Layer 4' line found in process-isolation.md."
+        layer4_text = " ".join(layer4_lines).lower()
+        assert "not currently implemented" not in layer4_text, (
+            f"Layer 4 still says 'Not currently implemented': {layer4_lines}. Green must update it."
+        )
+
+    def test_layer_4_mentions_non_root_user_specifically(self):
+        """
+        Layer 4 description must explicitly mention 'non-root' (the UID 1000 user),
+        not just 'containers' generically as the current text does when discussing
+        network namespaces as a future direction.
+        """
+        md = _read_process_isolation_md()
+        layer4_lines = [ln for ln in md.splitlines() if "Layer 4" in ln]
+        assert layer4_lines, "No 'Layer 4' line found in process-isolation.md."
+        layer4_text = " ".join(layer4_lines).lower()
+        assert "non-root" in layer4_text, (
+            f"Layer 4 does not mention 'non-root': {layer4_lines}. "
+            "Green must update Layer 4 to explicitly reference the non-root container user."
+        )
+
+    def test_cpu_memory_limits_row_not_unenforced(self):
+        """
+        The CPU / memory limits row in the Known Limitations table must no longer
+        say 'Not enforced' — it should reflect container-level enforcement.
+        """
+        md = _read_process_isolation_md()
+        lines = md.splitlines()
+        cpu_mem_lines = [ln for ln in lines if "cpu" in ln.lower() and "memory" in ln.lower()]
+        assert cpu_mem_lines, (
+            "No CPU / memory row found in process-isolation.md Known Limitations table."
+        )
+        for line in cpu_mem_lines:
+            assert "Not enforced" not in line, (
+                f"CPU / memory limits row still says 'Not enforced': {line!r}. "
+                "Green must update this to 'Container-level' enforcement."
+            )
+
+    def test_cpu_memory_limits_row_mentions_container_level(self):
+        """CPU / memory row must mention 'Container-level' enforcement."""
+        md = _read_process_isolation_md()
+        lines = md.splitlines()
+        cpu_mem_lines = [ln for ln in lines if "cpu" in ln.lower() and "memory" in ln.lower()]
+        assert cpu_mem_lines, (
+            "No CPU / memory row found in process-isolation.md Known Limitations table."
+        )
+        found = any("container" in ln.lower() for ln in cpu_mem_lines)
+        assert found, (
+            f"CPU / memory row does not mention 'Container-level': {cpu_mem_lines}. "
+            "Green must update the row to reflect container-level enforcement."
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runsight-workspace"
-version = "0.2.1"
+version = "0.2.2"
 requires-python = ">=3.11"
 dependencies = []
 

--- a/uv.lock
+++ b/uv.lock
@@ -2054,7 +2054,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "runsight-core"
-version = "1.1.0"
+version = "1.1.1"
 source = { editable = "packages/core" }
 dependencies = [
     { name = "editdistance" },
@@ -2092,7 +2092,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "runsight-workspace"
-version = "0.1.23"
+version = "0.2.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

- Adds non-root user (UID 1000) to Dockerfile with `USER` directive
- Adds `init-permissions` service (busybox, CHOWN-only cap) to fix workspace volume ownership before main service starts
- Drops all Linux capabilities (`cap_drop: ALL`), enables `no-new-privileges`, enforces 4GB memory / 2 CPU limits, adds tini via `init: true`
- Updates `docker-entrypoint.sh` to fail-fast on missing workspace (no more `mkdir` as non-root)
- Renumbers defense layers: Container Hardening is now Layer 1 (outermost), wrapping Process Isolation → IPC Mediation → Nested Subprocess
- Updates `process-isolation.md` and `layered-defense.svg` to reflect active Layer 1

## Architecture

Follows the **Grafana / Argo CD pattern** (validated against 7 competitor repos). No gosu — incompatible with `no-new-privileges`.

## Test plan

- [x] 29 pytest tests covering Dockerfile, docker-compose.yml, entrypoint behavior, and docs content
- [x] RGB TDD pipeline: Red → Blue → Green → Blue → Yellow (1 rejection cycle — git config ordering) → Amber (CLEAN) → Crimson (PASS, 4 advisory findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes RUN-821