### PR TITLE
Core cleanup compatibility debt hardening

### DIFF
--- a/apps/api/src/runsight_api/core/project.py
+++ b/apps/api/src/runsight_api/core/project.py
@@ -1,6 +1,7 @@
 """Project detection: resolve base_path from marker file or directory structure."""
 
 import logging
+import shutil
 import subprocess
 from pathlib import Path
 from typing import Optional
@@ -110,26 +111,46 @@ def scaffold_project(base_path: Path) -> None:
 
     # Git init if no repo exists
     if not (base_path / ".git").is_dir():
-        subprocess.run(["git", "init"], cwd=base_path, capture_output=True, check=True)
-        subprocess.run(
-            ["git", "config", "user.email", "runsight@localhost"],
-            cwd=base_path,
-            capture_output=True,
-            check=True,
-        )
-        subprocess.run(
-            ["git", "config", "user.name", "Runsight"],
-            cwd=base_path,
-            capture_output=True,
-            check=True,
-        )
-        subprocess.run(["git", "add", "."], cwd=base_path, capture_output=True, check=True)
-        subprocess.run(
-            ["git", "commit", "-m", "Initial Runsight project"],
-            cwd=base_path,
-            capture_output=True,
-            check=True,
-        )
+        if shutil.which("git") is None:
+            logger.warning(
+                "Git executable is unavailable; GitOps disabled for project at %s",
+                base_path,
+            )
+        else:
+            try:
+                subprocess.run(["git", "init"], cwd=base_path, capture_output=True, check=True)
+                subprocess.run(
+                    ["git", "config", "user.email", "runsight@localhost"],
+                    cwd=base_path,
+                    capture_output=True,
+                    check=True,
+                )
+                subprocess.run(
+                    ["git", "config", "user.name", "Runsight"],
+                    cwd=base_path,
+                    capture_output=True,
+                    check=True,
+                )
+                subprocess.run(["git", "add", "."], cwd=base_path, capture_output=True, check=True)
+                subprocess.run(
+                    ["git", "commit", "-m", "Initial Runsight project"],
+                    cwd=base_path,
+                    capture_output=True,
+                    check=True,
+                )
+            except FileNotFoundError:
+                logger.warning(
+                    "Git executable is unavailable; GitOps disabled for project at %s",
+                    base_path,
+                    exc_info=True,
+                )
+            except subprocess.CalledProcessError as exc:
+                detail = (exc.stderr or exc.stdout or str(exc)).strip()
+                logger.warning(
+                    "Git initialization failed; GitOps disabled for project at %s: %s",
+                    base_path,
+                    detail,
+                )
 
     if is_new:
         logger.info("Created new Runsight project at %s", base_path)

--- a/apps/api/src/runsight_api/data/filesystem/_base_yaml_repo.py
+++ b/apps/api/src/runsight_api/data/filesystem/_base_yaml_repo.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, Generic, List, Optional, Type, TypeVar
 from urllib.parse import unquote
 
 import yaml
+from pydantic import ValidationError
 
 from ...domain.errors import RunsightError
 
@@ -75,9 +76,16 @@ class BaseYamlRepository(Generic[T]):
             try:
                 with open(file, "r") as f:
                     data = yaml.safe_load(f) or {}
+            except yaml.YAMLError as e:
+                logger.warning(f"Failed to load {self.entity_label.lower()} file {file}: {e}")
+                continue
+
+            try:
                 if "id" not in data:
                     data["id"] = file.stem
                 entities.append(self.entity_type(**data))
+            except ValidationError:
+                raise
             except Exception as e:
                 logger.warning(f"Failed to load {self.entity_label.lower()} file {file}: {e}")
         return entities
@@ -97,18 +105,20 @@ class BaseYamlRepository(Generic[T]):
             raise ValueError(f"{self.entity_label} must have an id")
         self._validate_id(data["id"])
         file_path = self.entity_dir / f"{data['id']}.yaml"
+        entity = self.entity_type(**data)
         with open(file_path, "w") as f:
             yaml.safe_dump(data, f, sort_keys=False)
-        return self.entity_type(**data)
+        return entity
 
     def update(self, id: str, data: Dict[str, Any]) -> T:
         file_path = self._resolve_existing_path(id)
         if not file_path.exists():
             raise self.not_found_error(f"{self.entity_label} {id} not found")
         data["id"] = id
+        entity = self.entity_type(**data)
         with open(file_path, "w") as f:
             yaml.safe_dump(data, f, sort_keys=False)
-        return self.entity_type(**data)
+        return entity
 
     def delete(self, id: str) -> bool:
         file_path = self._resolve_existing_path(id)

--- a/apps/api/src/runsight_api/data/filesystem/provider_repo.py
+++ b/apps/api/src/runsight_api/data/filesystem/provider_repo.py
@@ -93,6 +93,10 @@ class FileSystemProviderRepo:
         entity_data["id"] = stem
         return ProviderEntity(**entity_data)
 
+    def _validate_entity_data(self, data: Dict[str, Any], stem: str) -> None:
+        """Validate provider YAML before merging update fields."""
+        self._build_entity(data, stem)
+
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
@@ -160,7 +164,7 @@ class FileSystemProviderRepo:
             raise ProviderNotFound(f"Provider {provider_id} not found")
 
         existing = self._read_yaml(yaml_path) or {}
-        self._build_entity(existing, provider_id)
+        self._validate_entity_data(existing, provider_id)
 
         # Merge: new data overwrites existing fields (exclude meta fields)
         update_fields = {k: v for k, v in data.items() if k not in _META_FIELDS}

--- a/apps/api/src/runsight_api/data/filesystem/provider_repo.py
+++ b/apps/api/src/runsight_api/data/filesystem/provider_repo.py
@@ -107,9 +107,10 @@ class FileSystemProviderRepo:
             try:
                 with open(file, "r") as f:
                     data = yaml.safe_load(f) or {}
-                providers.append(self._build_entity(data, file.stem))
-            except Exception as e:
+            except yaml.YAMLError as e:
                 logger.warning("Failed to load provider file %s: %s", file, e)
+                continue
+            providers.append(self._build_entity(data, file.stem))
         return providers
 
     def get_by_id(self, provider_id: str) -> Optional[ProviderEntity]:
@@ -141,11 +142,12 @@ class FileSystemProviderRepo:
 
         # Build YAML data — exclude 'id' (ADR D3)
         yaml_data = {k: v for k, v in data.items() if k not in _META_FIELDS}
+        entity = self._build_entity(yaml_data, slug)
         yaml_content = yaml.dump(yaml_data, sort_keys=False, default_flow_style=False)
 
         atomic_write(yaml_path, yaml_content)
 
-        return self._build_entity(yaml_data, slug)
+        return entity
 
     def update(self, provider_id: str, data: Dict[str, Any]) -> ProviderEntity:
         """Update an existing provider file.
@@ -158,15 +160,17 @@ class FileSystemProviderRepo:
             raise ProviderNotFound(f"Provider {provider_id} not found")
 
         existing = self._read_yaml(yaml_path) or {}
+        self._build_entity(existing, provider_id)
 
         # Merge: new data overwrites existing fields (exclude meta fields)
         update_fields = {k: v for k, v in data.items() if k not in _META_FIELDS}
         merged = {**existing, **update_fields}
+        entity = self._build_entity(merged, provider_id)
 
         yaml_content = yaml.dump(merged, sort_keys=False, default_flow_style=False)
         atomic_write(yaml_path, yaml_content)
 
-        return self._build_entity(merged, provider_id)
+        return entity
 
     def delete(self, provider_id: str) -> bool:
         """Delete a provider YAML file.

--- a/apps/api/src/runsight_api/data/filesystem/settings_repo.py
+++ b/apps/api/src/runsight_api/data/filesystem/settings_repo.py
@@ -88,6 +88,13 @@ class FileSystemSettingsRepo:
                 raise ValueError(f"Invalid fallback_map[{index}]: {e}") from e
         return entries
 
+    def _validate_app_settings(self, data: dict[str, Any]) -> AppSettingsConfig:
+        flat = {key: data.get(key) for key in _APP_SETTINGS_KEYS if key in data}
+        try:
+            return AppSettingsConfig(**flat)
+        except Exception as e:
+            raise ValueError(f"Invalid app settings values: {e}") from e
+
     def _load_yaml(self) -> dict[str, Any] | None:
         """Read and validate settings YAML against the current schema."""
         data = self._read_yaml()
@@ -100,6 +107,7 @@ class FileSystemSettingsRepo:
 
         if "fallback_map" in data:
             self._validate_fallback_map(data["fallback_map"])
+        self._validate_app_settings(data)
 
         return data
 
@@ -112,8 +120,7 @@ class FileSystemSettingsRepo:
         data = self._load_yaml()
         if data is None:
             return AppSettingsConfig()
-        flat = {k: data.get(k) for k in _APP_SETTINGS_KEYS if k in data}
-        return AppSettingsConfig(**flat)
+        return self._validate_app_settings(data)
 
     def update_settings(self, updates: dict[str, Any]) -> AppSettingsConfig:
         """Merge partial updates into flat settings (shallow merge).
@@ -132,9 +139,9 @@ class FileSystemSettingsRepo:
         if "fallback_map" in data:
             self._validate_fallback_map(data["fallback_map"])
 
+        settings_config = self._validate_app_settings(data)
         self._write_yaml(data)
-        flat = {k: data.get(k) for k in _APP_SETTINGS_KEYS if k in data}
-        return AppSettingsConfig(**flat)
+        return settings_config
 
     # ------------------------------------------------------------------
     # Public API: fallback map

--- a/apps/api/src/runsight_api/data/filesystem/settings_repo.py
+++ b/apps/api/src/runsight_api/data/filesystem/settings_repo.py
@@ -18,12 +18,12 @@ from ._utils import atomic_write
 
 logger = logging.getLogger(__name__)
 
-# Flat setting keys that live at the top level of the YAML file
-_FLAT_KEYS = {
-    "auto_save",
+# Flat app settings keys that live at the top level of the YAML file
+_APP_SETTINGS_KEYS = {
     "onboarding_completed",
     "fallback_enabled",
 }
+_ALLOWED_TOP_LEVEL_KEYS = _APP_SETTINGS_KEYS | {"fallback_map"}
 
 
 class FileSystemSettingsRepo:
@@ -45,56 +45,95 @@ class FileSystemSettingsRepo:
     def _read_yaml(self) -> dict[str, Any] | None:
         """Read and parse the settings YAML file.
 
-        Returns None on missing file or parse failure.
+        Returns None when file is missing.
         """
         if not self._settings_file.exists():
             return None
         try:
             with open(self._settings_file, "r") as f:
                 data = yaml.safe_load(f)
-            # yaml.safe_load returns None for empty files
-            if data is None:
-                return {}
-            if not isinstance(data, dict):
-                logger.warning("Settings file is not a YAML mapping: %s", self._settings_file)
-                return None
-            return data
-        except Exception as e:
-            logger.warning("Failed to read settings file %s: %s", self._settings_file, e)
-            return None
+        except yaml.YAMLError as e:
+            message = f"Invalid settings YAML at {self._settings_file}: {e}"
+            logger.warning(message)
+            raise ValueError(message) from e
+        except OSError as e:
+            message = f"Failed to read settings file {self._settings_file}: {e}"
+            logger.warning(message)
+            raise ValueError(message) from e
+        # yaml.safe_load returns None for empty files
+        if data is None:
+            return {}
+        if not isinstance(data, dict):
+            raise ValueError(f"Settings file must be a YAML mapping: {self._settings_file}")
+        return data
 
     def _write_yaml(self, data: dict[str, Any]) -> None:
         """Write data to the settings YAML file atomically."""
         content = yaml.dump(data, sort_keys=False, default_flow_style=False)
         atomic_write(self._settings_file, content)
 
+    def _validate_fallback_map(self, raw_fallback_map: Any) -> list[FallbackTargetEntry]:
+        if raw_fallback_map is None:
+            return []
+        if not isinstance(raw_fallback_map, list):
+            raise ValueError("fallback_map must be a list")
+
+        entries: list[FallbackTargetEntry] = []
+        for index, raw_entry in enumerate(raw_fallback_map):
+            if not isinstance(raw_entry, dict):
+                raise ValueError(f"fallback_map[{index}] must be an object")
+            try:
+                entries.append(FallbackTargetEntry(**raw_entry))
+            except Exception as e:
+                raise ValueError(f"Invalid fallback_map[{index}]: {e}") from e
+        return entries
+
     def _load_yaml(self) -> dict[str, Any] | None:
-        """Read settings YAML without rewriting legacy keys."""
-        return self._read_yaml()
+        """Read and validate settings YAML against the current schema."""
+        data = self._read_yaml()
+        if data is None:
+            return None
+
+        unknown_keys = sorted(set(data.keys()) - _ALLOWED_TOP_LEVEL_KEYS)
+        if unknown_keys:
+            raise ValueError(f"Unsupported settings keys: {', '.join(unknown_keys)}")
+
+        if "fallback_map" in data:
+            self._validate_fallback_map(data["fallback_map"])
+
+        return data
 
     # ------------------------------------------------------------------
     # Public API: flat settings
     # ------------------------------------------------------------------
 
     def get_settings(self) -> AppSettingsConfig:
-        """Read flat app settings. Returns defaults if file is missing or invalid."""
+        """Read flat app settings. Returns defaults when file is missing."""
         data = self._load_yaml()
         if data is None:
             return AppSettingsConfig()
-        flat = {k: data.get(k) for k in _FLAT_KEYS if k in data}
+        flat = {k: data.get(k) for k in _APP_SETTINGS_KEYS if k in data}
         return AppSettingsConfig(**flat)
 
     def update_settings(self, updates: dict[str, Any]) -> AppSettingsConfig:
         """Merge partial updates into flat settings (shallow merge).
 
-        Only keys in _FLAT_KEYS are considered. Other sections are preserved.
+        Only keys in _APP_SETTINGS_KEYS are accepted. Other sections are preserved.
         """
         data = self._load_yaml() or {}
-        for key in _FLAT_KEYS:
+        unknown_update_keys = sorted(set(updates.keys()) - _APP_SETTINGS_KEYS)
+        if unknown_update_keys:
+            raise ValueError(f"Unsupported settings update keys: {', '.join(unknown_update_keys)}")
+
+        for key in _APP_SETTINGS_KEYS:
             if key in updates:
                 data[key] = updates[key]
+
+        if "fallback_map" in data:
+            self._validate_fallback_map(data["fallback_map"])
+
         self._write_yaml(data)
-        flat = {k: data.get(k) for k in _FLAT_KEYS if k in data}
+        flat = {k: data.get(k) for k in _APP_SETTINGS_KEYS if k in data}
         return AppSettingsConfig(**flat)
 
     # ------------------------------------------------------------------
@@ -102,21 +141,19 @@ class FileSystemSettingsRepo:
     # ------------------------------------------------------------------
 
     def get_fallback_map(self) -> list[FallbackTargetEntry]:
-        """Read the fallback map. Returns empty list if missing or invalid."""
+        """Read the fallback map. Returns empty list when the settings file is missing."""
         data = self._load_yaml()
         if data is None:
             return []
-        fallback_map_data = data.get("fallback_map")
-        if not isinstance(fallback_map_data, list):
-            return []
-        return [FallbackTargetEntry(**entry) for entry in fallback_map_data]
+        return self._validate_fallback_map(data.get("fallback_map"))
 
     def set_fallback_target(self, entry: FallbackTargetEntry) -> FallbackTargetEntry:
         """Upsert a fallback target by provider_id."""
         data = self._load_yaml() or {}
-        fallback_map_data = data.get("fallback_map")
-        if not isinstance(fallback_map_data, list):
-            fallback_map_data = []
+        fallback_map_data = [
+            existing.model_dump()
+            for existing in self._validate_fallback_map(data.get("fallback_map"))
+        ]
 
         entry_dict = entry.model_dump()
         updated = False
@@ -136,14 +173,12 @@ class FileSystemSettingsRepo:
     def remove_fallback_target(self, provider_id: str) -> bool:
         """Remove a fallback target by provider_id."""
         data = self._load_yaml() or {}
-        fallback_map_data = data.get("fallback_map")
-        if not isinstance(fallback_map_data, list):
-            return False
+        fallback_map_data = self._validate_fallback_map(data.get("fallback_map"))
 
-        filtered = [entry for entry in fallback_map_data if entry.get("provider_id") != provider_id]
+        filtered = [entry for entry in fallback_map_data if entry.provider_id != provider_id]
         if len(filtered) == len(fallback_map_data):
             return False
 
-        data["fallback_map"] = filtered
+        data["fallback_map"] = [entry.model_dump() for entry in filtered]
         self._write_yaml(data)
         return True

--- a/apps/api/src/runsight_api/data/repositories/run_repo.py
+++ b/apps/api/src/runsight_api/data/repositories/run_repo.py
@@ -47,6 +47,12 @@ class RunRepository:
     def get_run(self, run_id: str) -> Optional[Run]:
         return self.session.get(Run, run_id)
 
+    def refresh_run(self, run_id: str) -> Optional[Run]:
+        run = self.session.get(Run, run_id)
+        if run is not None:
+            self.session.refresh(run)
+        return run
+
     def list_runs(self) -> List[Run]:
         statement = select(Run).order_by(Run.created_at.desc())
         return list(self.session.exec(statement).all())

--- a/apps/api/src/runsight_api/domain/entities/settings.py
+++ b/apps/api/src/runsight_api/domain/entities/settings.py
@@ -8,7 +8,6 @@ from pydantic import BaseModel
 class AppSettingsConfig(BaseModel):
     """Flat app settings stored in .runsight/settings.yaml."""
 
-    auto_save: bool | None = None
     onboarding_completed: bool = False
     fallback_enabled: bool = False
 

--- a/apps/api/src/runsight_api/domain/entities/settings.py
+++ b/apps/api/src/runsight_api/domain/entities/settings.py
@@ -1,4 +1,5 @@
 from pydantic import BaseModel
+from pydantic import ConfigDict
 
 # ---------------------------------------------------------------------------
 # Pydantic models for filesystem-backed settings (RUN-233)
@@ -14,6 +15,8 @@ class AppSettingsConfig(BaseModel):
 
 class FallbackTargetEntry(BaseModel):
     """Single per-provider fallback target."""
+
+    model_config = ConfigDict(extra="forbid")
 
     provider_id: str
     fallback_provider_id: str

--- a/apps/api/src/runsight_api/domain/entities/settings.py
+++ b/apps/api/src/runsight_api/domain/entities/settings.py
@@ -10,6 +10,8 @@ from pydantic import StrictBool
 class AppSettingsConfig(BaseModel):
     """Flat app settings stored in .runsight/settings.yaml."""
 
+    model_config = ConfigDict(extra="forbid")
+
     onboarding_completed: StrictBool = False
     fallback_enabled: StrictBool = False
 

--- a/apps/api/src/runsight_api/domain/entities/settings.py
+++ b/apps/api/src/runsight_api/domain/entities/settings.py
@@ -1,5 +1,6 @@
-from pydantic import BaseModel
 from pydantic import ConfigDict
+from pydantic import BaseModel
+from pydantic import StrictBool
 
 # ---------------------------------------------------------------------------
 # Pydantic models for filesystem-backed settings (RUN-233)
@@ -9,8 +10,8 @@ from pydantic import ConfigDict
 class AppSettingsConfig(BaseModel):
     """Flat app settings stored in .runsight/settings.yaml."""
 
-    onboarding_completed: bool = False
-    fallback_enabled: bool = False
+    onboarding_completed: StrictBool = False
+    fallback_enabled: StrictBool = False
 
 
 class FallbackTargetEntry(BaseModel):

--- a/apps/api/src/runsight_api/domain/value_objects.py
+++ b/apps/api/src/runsight_api/domain/value_objects.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class NodeTokens(BaseModel):
@@ -51,19 +51,25 @@ class SoulEntity(BaseModel):
     avatar_color: Optional[str] = None
     workflow_count: int = Field(default=0)
     modified_at: Optional[float] = None
-    model_config = {"extra": "allow"}
+    model_config = ConfigDict(extra="forbid")
 
 
 class TaskEntity(BaseModel):
     id: str
     name: Optional[str] = None
-    model_config = {"extra": "ignore"}
+    type: str = "task"
+    path: Optional[str] = None
+    description: Optional[str] = None
+    model_config = ConfigDict(extra="forbid")
 
 
 class StepEntity(BaseModel):
     id: str
     name: Optional[str] = None
-    model_config = {"extra": "ignore"}
+    type: str = "step"
+    path: Optional[str] = None
+    description: Optional[str] = None
+    model_config = ConfigDict(extra="forbid")
 
 
 class ProviderEntity(BaseModel):
@@ -74,5 +80,8 @@ class ProviderEntity(BaseModel):
     base_url: Optional[str] = None
     is_active: bool = True
     status: Optional[str] = None
-    models: list = []
-    model_config = {"extra": "allow"}
+    models: list[str] = Field(default_factory=list)
+    created_at: Optional[float] = None
+    updated_at: Optional[float] = None
+    last_status_check: Optional[float] = None
+    model_config = ConfigDict(extra="forbid")

--- a/apps/api/src/runsight_api/logic/services/git_service.py
+++ b/apps/api/src/runsight_api/logic/services/git_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 import tempfile
 import uuid
@@ -10,6 +11,11 @@ from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
 from typing import Optional
+
+from ...domain.errors import ServiceUnavailable
+
+
+_GIT_UNAVAILABLE_MESSAGE = "Git executable is unavailable; Git operations are disabled"
 
 
 @dataclass
@@ -26,6 +32,14 @@ class GitService:
     def __init__(self, repo_path: str | Path) -> None:
         self.repo_path = Path(repo_path)
 
+    def _ensure_git_available(self, env: Optional[dict[str, str]] = None) -> None:
+        path = None
+        if env is not None:
+            path = env.get("PATH", os.defpath)
+
+        if shutil.which("git", path=path) is None:
+            raise ServiceUnavailable(_GIT_UNAVAILABLE_MESSAGE)
+
     def _run(
         self,
         *args: str,
@@ -33,15 +47,19 @@ class GitService:
         input_text: Optional[str] = None,
         env: Optional[dict[str, str]] = None,
     ) -> subprocess.CompletedProcess[str]:
-        return subprocess.run(
-            ["git", *args],
-            cwd=str(self.repo_path),
-            capture_output=True,
-            text=True,
-            check=check,
-            input=input_text,
-            env=env,
-        )
+        self._ensure_git_available(env)
+        try:
+            return subprocess.run(
+                ["git", *args],
+                cwd=str(self.repo_path),
+                capture_output=True,
+                text=True,
+                check=check,
+                input=input_text,
+                env=env,
+            )
+        except FileNotFoundError as exc:
+            raise ServiceUnavailable(_GIT_UNAVAILABLE_MESSAGE) from exc
 
     def _normalize_repo_path(self, path: str | Path) -> str:
         candidate = Path(path)

--- a/apps/api/src/runsight_api/logic/services/run_service.py
+++ b/apps/api/src/runsight_api/logic/services/run_service.py
@@ -22,6 +22,9 @@ class RunService:
     def get_run(self, run_id: str) -> Optional[Run]:
         return self.run_repo.get_run(run_id)
 
+    def refresh_run(self, run_id: str) -> Optional[Run]:
+        return self.run_repo.refresh_run(run_id)
+
     def list_runs(self) -> List[Run]:
         return self.run_repo.list_runs()
 
@@ -89,6 +92,23 @@ class RunService:
         run.completed_at = time.time()
         if run.started_at:
             run.duration_s = run.completed_at - run.started_at
+
+        return self.run_repo.update_run(run)
+
+    def fail_run(self, run_id: str, error: str) -> Run:
+        run = self.get_run(run_id)
+        if not run:
+            raise RunNotFound(f"Run {run_id} not found")
+
+        validate_transition(run.status, RunStatus.failed)
+
+        completed_at = time.time()
+        run.status = RunStatus.failed
+        run.error = error
+        run.completed_at = completed_at
+        run.updated_at = completed_at
+        if run.started_at:
+            run.duration_s = completed_at - run.started_at
 
         return self.run_repo.update_run(run)
 

--- a/apps/api/src/runsight_api/main.py
+++ b/apps/api/src/runsight_api/main.py
@@ -45,9 +45,11 @@ from .transport.routers import (
 
 
 def _recover_stale_runs(engine):
-    """Mark any runs stuck in 'running' as failed after an API restart."""
+    """Mark any runs stuck in active startup states as failed after an API restart."""
     with Session(engine) as session:
-        stale_runs = session.exec(select(Run).where(Run.status == RunStatus.running)).all()
+        stale_runs = session.exec(
+            select(Run).where(Run.status.in_([RunStatus.pending, RunStatus.running]))
+        ).all()
         for run in stale_runs:
             run.status = RunStatus.failed
             run.error = "API process restarted during execution"

--- a/apps/api/src/runsight_api/transport/routers/runs.py
+++ b/apps/api/src/runsight_api/transport/routers/runs.py
@@ -4,6 +4,8 @@ from typing import List, Optional
 
 from fastapi import APIRouter, Depends, Query
 
+from ...domain.entities.run import RunStatus
+from ...domain.errors import RunFailed, ServiceUnavailable
 from ...logic.services.eval_service import EvalService
 from ...logic.services.execution_service import ExecutionService
 from ...logic.services.run_service import RunService
@@ -65,6 +67,19 @@ def _regression_types(result) -> list[str]:
     return types
 
 
+def _refresh_launch_run(run_service: RunService, run):
+    """Read the post-launch run state when the service exposes a real repository-backed run."""
+    if not isinstance(run_service, RunService):
+        return run
+
+    latest = run_service.refresh_run(run.id)
+    if latest is None or getattr(latest, "id", None) != run.id:
+        return run
+
+    status = getattr(latest, "status", None)
+    return latest if isinstance(status, RunStatus | str) else run
+
+
 @router.post("", response_model=RunResponse)
 async def create_run(
     body: RunCreate,
@@ -73,22 +88,31 @@ async def create_run(
 ):
     source = body.source or "manual"
     branch = body.branch or "main"
+    if execution_service is None:
+        raise ServiceUnavailable("Execution runtime is unavailable")
+
     run = run_service.create_run(
         body.workflow_id,
         body.task_data,
         source=source,
         branch=branch,
     )
-    if execution_service is not None:
-        try:
-            await execution_service.launch_execution(
-                run.id,
-                run.workflow_id,
-                body.task_data,
-                branch=branch,
-            )
-        except Exception:
-            logger.exception("Failed to launch execution for run %s", run.id)
+    try:
+        await execution_service.launch_execution(
+            run.id,
+            run.workflow_id,
+            body.task_data,
+            branch=branch,
+        )
+    except Exception as exc:
+        logger.exception("Failed to launch execution for run %s", run.id)
+        run_service.fail_run(run.id, str(exc))
+        raise RunFailed("Run failed during launch", run_id=run.id) from exc
+
+    run = _refresh_launch_run(run_service, run)
+    if run.status == RunStatus.failed or run.status == RunStatus.failed.value:
+        raise RunFailed(run.error or "Run failed during launch", run_id=run.id)
+
     return RunResponse(
         id=run.id,
         workflow_id=run.workflow_id,

--- a/apps/api/src/runsight_api/transport/routers/settings.py
+++ b/apps/api/src/runsight_api/transport/routers/settings.py
@@ -97,6 +97,8 @@ class SettingsBudgetListResponse(BaseModel):
     total: int
 
 
+# Non-Optional StrictBool with a None default keeps fields optional in OpenAPI
+# while explicit null still fails validation.
 class AppSettingsOut(BaseModel):
     base_path: Optional[str] = None
     onboarding_completed: StrictBool = None

--- a/apps/api/src/runsight_api/transport/routers/settings.py
+++ b/apps/api/src/runsight_api/transport/routers/settings.py
@@ -95,15 +95,15 @@ class SettingsBudgetListResponse(BaseModel):
 
 class AppSettingsOut(BaseModel):
     base_path: Optional[str] = None
-    onboarding_completed: Optional[bool] = None
-    fallback_enabled: Optional[bool] = None
+    onboarding_completed: StrictBool = None
+    fallback_enabled: StrictBool = None
 
 
 class AppSettingsUpdate(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    onboarding_completed: Optional[StrictBool] = None
-    fallback_enabled: Optional[StrictBool] = None
+    onboarding_completed: StrictBool = None
+    fallback_enabled: StrictBool = None
 
 
 def _preview_api_key(secret: Optional[str]) -> Optional[str]:

--- a/apps/api/src/runsight_api/transport/routers/settings.py
+++ b/apps/api/src/runsight_api/transport/routers/settings.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from fastapi import APIRouter, Depends
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, StrictBool
 
 from ...data.filesystem.settings_repo import FileSystemSettingsRepo
 from ...domain.errors import ProviderNotFound
@@ -102,8 +102,8 @@ class AppSettingsOut(BaseModel):
 class AppSettingsUpdate(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    onboarding_completed: Optional[bool] = None
-    fallback_enabled: Optional[bool] = None
+    onboarding_completed: Optional[StrictBool] = None
+    fallback_enabled: Optional[StrictBool] = None
 
 
 def _preview_api_key(secret: Optional[str]) -> Optional[str]:

--- a/apps/api/src/runsight_api/transport/routers/settings.py
+++ b/apps/api/src/runsight_api/transport/routers/settings.py
@@ -13,12 +13,16 @@ router = APIRouter(prefix="/settings", tags=["Settings"])
 
 
 class ProviderCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     name: str
     api_key_env: Optional[str] = None  # Frontend sends the raw API key in this field
     base_url: Optional[str] = None
 
 
 class ProviderUpdate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     name: Optional[str] = None
     api_key_env: Optional[str] = None  # Frontend sends the raw API key in this field
     base_url: Optional[str] = None

--- a/apps/api/src/runsight_api/transport/routers/settings.py
+++ b/apps/api/src/runsight_api/transport/routers/settings.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from fastapi import APIRouter, Depends
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from ...data.filesystem.settings_repo import FileSystemSettingsRepo
 from ...domain.errors import ProviderNotFound
@@ -95,7 +95,13 @@ class SettingsBudgetListResponse(BaseModel):
 
 class AppSettingsOut(BaseModel):
     base_path: Optional[str] = None
-    auto_save: Optional[bool] = None
+    onboarding_completed: Optional[bool] = None
+    fallback_enabled: Optional[bool] = None
+
+
+class AppSettingsUpdate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     onboarding_completed: Optional[bool] = None
     fallback_enabled: Optional[bool] = None
 
@@ -254,7 +260,7 @@ async def get_app_settings(
 
 @router.put("/app", response_model=AppSettingsOut)
 async def update_app_settings(
-    data: AppSettingsOut,
+    data: AppSettingsUpdate,
     repo: FileSystemSettingsRepo = Depends(get_settings_repo),
 ):
     settings_config = repo.update_settings(data.model_dump(exclude_none=True))

--- a/apps/api/src/runsight_api/transport/schemas/runs.py
+++ b/apps/api/src/runsight_api/transport/schemas/runs.py
@@ -36,7 +36,7 @@ class RunResponse(BaseModel):
     run_number: Optional[int] = None
     eval_pass_pct: Optional[float] = None
     eval_score_avg: Optional[float] = None
-    regression_count: Optional[int] = None
+    regression_count: Optional[int] = 0
     regression_types: List[str] = Field(default_factory=list)
     node_summary: Optional[NodeSummary] = None
     parent_run_id: Optional[str] = None

--- a/apps/api/src/runsight_api/transport/schemas/steps.py
+++ b/apps/api/src/runsight_api/transport/schemas/steps.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 class StepResponse(BaseModel):
@@ -12,6 +12,8 @@ class StepResponse(BaseModel):
 
 
 class StepCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     id: Optional[str] = None
     name: str
     type: str = "step"
@@ -19,6 +21,8 @@ class StepCreate(BaseModel):
 
 
 class StepUpdate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     name: Optional[str] = None
     type: Optional[str] = None
     description: Optional[str] = None

--- a/apps/api/src/runsight_api/transport/schemas/tasks.py
+++ b/apps/api/src/runsight_api/transport/schemas/tasks.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 class TaskResponse(BaseModel):
@@ -12,6 +12,8 @@ class TaskResponse(BaseModel):
 
 
 class TaskCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     id: Optional[str] = None
     name: str
     type: str = "task"
@@ -19,6 +21,8 @@ class TaskCreate(BaseModel):
 
 
 class TaskUpdate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     name: Optional[str] = None
     type: Optional[str] = None
     description: Optional[str] = None

--- a/apps/api/tests/core/test_run767_missing_git_scaffold.py
+++ b/apps/api/tests/core/test_run767_missing_git_scaffold.py
@@ -1,0 +1,45 @@
+"""Red tests for RUN-767: scaffold_project must degrade when git is missing."""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from runsight_api.core.project import MARKER_FILE, scaffold_project
+
+
+class TestScaffoldProjectMissingGit:
+    """`scaffold_project` should still build the local project skeleton."""
+
+    def test_creates_project_files_even_when_git_is_missing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("PATH", "")
+
+        scaffold_project(tmp_path)
+
+        marker = tmp_path / MARKER_FILE
+        assert marker.is_file(), ".runsight-project marker was not created"
+        data = yaml.safe_load(marker.read_text(encoding="utf-8"))
+        assert data["base_path"] == "."
+        assert data["version"] == 1
+        assert (tmp_path / "custom" / "workflows").is_dir()
+        assert (tmp_path / "custom" / "souls").is_dir()
+        gitignore = tmp_path / ".gitignore"
+        assert gitignore.is_file()
+        assert ".canvas/" in gitignore.read_text(encoding="utf-8")
+        assert not (tmp_path / ".git").exists()
+
+    def test_logs_warning_when_git_is_unavailable(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog
+    ):
+        monkeypatch.setenv("PATH", "")
+
+        with caplog.at_level("WARNING"):
+            scaffold_project(tmp_path)
+
+        assert any(
+            "git" in message.lower()
+            and ("unavailable" in message.lower() or "disabled" in message.lower())
+            for message in caplog.messages
+        ), "Expected a warning that Git/GitOps is unavailable"

--- a/apps/api/tests/data/test_base_yaml_repository.py
+++ b/apps/api/tests/data/test_base_yaml_repository.py
@@ -214,6 +214,42 @@ class TestTaskAndStepRepoStrictness:
                 on_disk = yaml.safe_load(f)
             assert on_disk == {"id": "task-1", "name": "Task"}
 
+    def test_task_repo_get_by_id_rejects_unknown_fields_in_authored_yaml(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = TaskRepository(base_path=tmpdir)
+            task_path = repo.entity_dir / "task-1.yaml"
+            task_path.write_text(
+                yaml.safe_dump(
+                    {
+                        "id": "task-1",
+                        "name": "Task",
+                        "custom_notes": "unsupported",
+                    },
+                    sort_keys=False,
+                )
+            )
+
+            with pytest.raises(ValidationError):
+                repo.get_by_id("task-1")
+
+    def test_task_repo_list_all_rejects_unknown_fields_in_authored_yaml(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = TaskRepository(base_path=tmpdir)
+            task_path = repo.entity_dir / "task-1.yaml"
+            task_path.write_text(
+                yaml.safe_dump(
+                    {
+                        "id": "task-1",
+                        "name": "Task",
+                        "unsupported": True,
+                    },
+                    sort_keys=False,
+                )
+            )
+
+            with pytest.raises(ValidationError):
+                repo.list_all()
+
     def test_step_repo_create_rejects_unknown_fields_and_does_not_persist(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             repo = StepRepository(base_path=tmpdir)
@@ -231,6 +267,42 @@ class TestTaskAndStepRepoStrictness:
             with open(repo.entity_dir / "step-1.yaml", "r") as f:
                 on_disk = yaml.safe_load(f)
             assert on_disk == {"id": "step-1", "name": "Step"}
+
+    def test_step_repo_get_by_id_rejects_unknown_fields_in_authored_yaml(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = StepRepository(base_path=tmpdir)
+            step_path = repo.entity_dir / "step-1.yaml"
+            step_path.write_text(
+                yaml.safe_dump(
+                    {
+                        "id": "step-1",
+                        "name": "Step",
+                        "custom_notes": "unsupported",
+                    },
+                    sort_keys=False,
+                )
+            )
+
+            with pytest.raises(ValidationError):
+                repo.get_by_id("step-1")
+
+    def test_step_repo_list_all_rejects_unknown_fields_in_authored_yaml(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = StepRepository(base_path=tmpdir)
+            step_path = repo.entity_dir / "step-1.yaml"
+            step_path.write_text(
+                yaml.safe_dump(
+                    {
+                        "id": "step-1",
+                        "name": "Step",
+                        "unsupported": True,
+                    },
+                    sort_keys=False,
+                )
+            )
+
+            with pytest.raises(ValidationError):
+                repo.list_all()
 
 
 class TestDelete:

--- a/apps/api/tests/data/test_base_yaml_repository.py
+++ b/apps/api/tests/data/test_base_yaml_repository.py
@@ -4,9 +4,12 @@ import tempfile
 from typing import Optional
 
 import pytest
-from pydantic import BaseModel
+import yaml
+from pydantic import BaseModel, ValidationError
 
 from runsight_api.data.filesystem._base_yaml_repo import BaseYamlRepository
+from runsight_api.data.filesystem.step_repo import StepRepository
+from runsight_api.data.filesystem.task_repo import TaskRepository
 from runsight_api.domain.errors import RunsightError
 
 # -- Fixtures: a minimal entity and concrete repo for testing ----------------
@@ -27,6 +30,19 @@ class DummyRepository(BaseYamlRepository[DummyEntity]):
     subdir = "dummies"
     not_found_error = DummyNotFound
     entity_label = "Dummy"
+
+
+class StrictDummyEntity(BaseModel):
+    id: str
+    name: Optional[str] = None
+    model_config = {"extra": "forbid"}
+
+
+class StrictDummyRepository(BaseYamlRepository[StrictDummyEntity]):
+    entity_type = StrictDummyEntity
+    subdir = "strict-dummies"
+    not_found_error = DummyNotFound
+    entity_label = "StrictDummy"
 
 
 # -- Tests -------------------------------------------------------------------
@@ -155,6 +171,66 @@ class TestUpdate:
             repo = DummyRepository(base_path=tmpdir)
             with pytest.raises(DummyNotFound):
                 repo.update("missing", {"name": "Nope"})
+
+
+class TestStrictEntityWriteValidation:
+    def test_create_rejects_unknown_fields_without_writing_yaml(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = StrictDummyRepository(base_path=tmpdir)
+            file_path = repo.entity_dir / "d1.yaml"
+            with pytest.raises(ValidationError):
+                repo.create({"id": "d1", "name": "Test", "unsupported": "x"})
+            assert not file_path.exists()
+
+    def test_update_rejects_unknown_fields_without_mutating_yaml(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = StrictDummyRepository(base_path=tmpdir)
+            repo.create({"id": "d1", "name": "Original"})
+
+            with pytest.raises(ValidationError):
+                repo.update("d1", {"name": "Updated", "unsupported": "x"})
+
+            with open(repo.entity_dir / "d1.yaml", "r") as f:
+                on_disk = yaml.safe_load(f)
+            assert on_disk == {"id": "d1", "name": "Original"}
+
+
+class TestTaskAndStepRepoStrictness:
+    def test_task_repo_create_rejects_unknown_fields_and_does_not_persist(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = TaskRepository(base_path=tmpdir)
+            file_path = repo.entity_dir / "task-1.yaml"
+            with pytest.raises(ValidationError):
+                repo.create({"id": "task-1", "name": "Task", "unsupported": "x"})
+            assert not file_path.exists()
+
+    def test_task_repo_update_rejects_unknown_fields_and_keeps_original_yaml(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = TaskRepository(base_path=tmpdir)
+            repo.create({"id": "task-1", "name": "Task"})
+            with pytest.raises(ValidationError):
+                repo.update("task-1", {"name": "Updated", "unsupported": "x"})
+            with open(repo.entity_dir / "task-1.yaml", "r") as f:
+                on_disk = yaml.safe_load(f)
+            assert on_disk == {"id": "task-1", "name": "Task"}
+
+    def test_step_repo_create_rejects_unknown_fields_and_does_not_persist(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = StepRepository(base_path=tmpdir)
+            file_path = repo.entity_dir / "step-1.yaml"
+            with pytest.raises(ValidationError):
+                repo.create({"id": "step-1", "name": "Step", "unsupported": "x"})
+            assert not file_path.exists()
+
+    def test_step_repo_update_rejects_unknown_fields_and_keeps_original_yaml(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = StepRepository(base_path=tmpdir)
+            repo.create({"id": "step-1", "name": "Step"})
+            with pytest.raises(ValidationError):
+                repo.update("step-1", {"name": "Updated", "unsupported": "x"})
+            with open(repo.entity_dir / "step-1.yaml", "r") as f:
+                on_disk = yaml.safe_load(f)
+            assert on_disk == {"id": "step-1", "name": "Step"}
 
 
 class TestDelete:

--- a/apps/api/tests/data/test_soul_repo.py
+++ b/apps/api/tests/data/test_soul_repo.py
@@ -2,6 +2,7 @@ import tempfile
 
 import pytest
 import yaml
+from pydantic import ValidationError
 
 from runsight_api.data.filesystem.soul_repo import SoulRepository
 from runsight_api.domain.errors import SoulNotFound
@@ -56,6 +57,74 @@ def test_soul_repo():
         # Test not found
         with pytest.raises(SoulNotFound):
             repo.update("missing", {"role": "Does not exist"})
+
+
+def test_soul_repo_create_rejects_unknown_fields_and_does_not_persist():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        repo = SoulRepository(base_path=tmpdir)
+        soul_path = repo.entity_dir / "strict_soul.yaml"
+
+        with pytest.raises(ValidationError):
+            repo.create(
+                {
+                    "id": "strict_soul",
+                    "role": "Strict Soul",
+                    "system_prompt": "Prompt",
+                    "custom_notes": "unsupported",
+                }
+            )
+
+        assert not soul_path.exists()
+
+
+def test_soul_repo_update_rejects_unknown_fields_and_keeps_existing_yaml():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        repo = SoulRepository(base_path=tmpdir)
+        repo.create(
+            {
+                "id": "strict_soul",
+                "role": "Strict Soul",
+                "system_prompt": "Prompt",
+            }
+        )
+
+        with pytest.raises(ValidationError):
+            repo.update(
+                "strict_soul",
+                {
+                    "role": "Updated",
+                    "system_prompt": "Updated prompt",
+                    "custom_notes": "unsupported",
+                },
+            )
+
+        with open(repo.entity_dir / "strict_soul.yaml", "r") as f:
+            on_disk = yaml.safe_load(f)
+        assert on_disk == {
+            "id": "strict_soul",
+            "role": "Strict Soul",
+            "system_prompt": "Prompt",
+        }
+
+
+def test_soul_repo_get_by_id_rejects_unsupported_yaml_fields():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        repo = SoulRepository(base_path=tmpdir)
+        legacy_path = repo.entity_dir / "legacy.yaml"
+        legacy_path.write_text(
+            yaml.safe_dump(
+                {
+                    "id": "legacy",
+                    "role": "Legacy Soul",
+                    "system_prompt": "Prompt",
+                    "assertions": [{"type": "contains", "value": "x"}],
+                },
+                sort_keys=False,
+            )
+        )
+
+        with pytest.raises(ValidationError):
+            repo.get_by_id("legacy")
 
 
 def test_soul_repo_resolves_embedded_id_when_filename_differs():

--- a/apps/api/tests/data/test_soul_repo.py
+++ b/apps/api/tests/data/test_soul_repo.py
@@ -127,6 +127,26 @@ def test_soul_repo_get_by_id_rejects_unsupported_yaml_fields():
             repo.get_by_id("legacy")
 
 
+def test_soul_repo_list_all_rejects_unsupported_yaml_fields():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        repo = SoulRepository(base_path=tmpdir)
+        legacy_path = repo.entity_dir / "legacy.yaml"
+        legacy_path.write_text(
+            yaml.safe_dump(
+                {
+                    "id": "legacy",
+                    "role": "Legacy Soul",
+                    "system_prompt": "Prompt",
+                    "custom_notes": "unsupported",
+                },
+                sort_keys=False,
+            )
+        )
+
+        with pytest.raises(ValidationError):
+            repo.list_all()
+
+
 def test_soul_repo_resolves_embedded_id_when_filename_differs():
     with tempfile.TemporaryDirectory() as tmpdir:
         repo = SoulRepository(base_path=tmpdir)

--- a/apps/api/tests/domain/test_entity_extra_config.py
+++ b/apps/api/tests/domain/test_entity_extra_config.py
@@ -1,28 +1,33 @@
-"""Tests for entity extra field configuration.
+"""Tests for entity extra-field schema strictness."""
 
-SoulEntity and WorkflowEntity preserve extra fields. TaskEntity and StepEntity
-still use extra="ignore" — unknown fields are silently dropped.
-"""
+import pytest
+from pydantic import ValidationError
 
 from runsight_api.domain.value_objects import (
+    ProviderEntity,
     SoulEntity,
     StepEntity,
     TaskEntity,
     WorkflowEntity,
 )
 
-# ── SoulEntity ──────────────────────────────────────────────────────
 
+class TestSoulEntityRejectsExtraFields:
+    def test_unknown_field_is_rejected(self):
+        with pytest.raises(ValidationError):
+            SoulEntity(id="s1", role="Alpha", custom_notes="oops")
 
-class TestSoulEntityPreservesExtraFields:
-    def test_unknown_field_is_preserved(self):
-        soul = SoulEntity(id="s1", role="Alpha", bogus_field="oops")
-        assert soul.bogus_field == "oops"
+    def test_typo_field_is_rejected(self):
+        with pytest.raises(ValidationError):
+            SoulEntity(id="s1", naem="typo")
 
-    def test_typo_field_is_preserved(self):
-        soul = SoulEntity(id="s1", naem="typo")
-        assert soul.naem == "typo"
-        assert soul.role is None  # default kept
+    def test_legacy_assertions_field_is_rejected(self):
+        with pytest.raises(ValidationError):
+            SoulEntity(
+                id="s1",
+                role="Tester",
+                assertions=[{"type": "contains", "value": "hello"}],
+            )
 
     def test_known_fields_work(self):
         soul = SoulEntity(
@@ -30,46 +35,25 @@ class TestSoulEntityPreservesExtraFields:
             role="Alpha",
             system_prompt="Prompt",
             model_name="gpt-4o",
+            tools=["web_search"],
             max_tool_iterations=7,
         )
         assert soul.id == "s1"
         assert soul.role == "Alpha"
         assert soul.system_prompt == "Prompt"
         assert soul.model_name == "gpt-4o"
+        assert soul.tools == ["web_search"]
         assert soul.max_tool_iterations == 7
 
-    def test_declared_runtime_fields_are_preserved(self):
-        soul = SoulEntity(
-            id="s1",
-            name="Alpha",
-            role="Researcher",
-            system_prompt="You analyze things.",
-            model_name="gpt-4o",
-            models=["gpt-4o", "gpt-4o-mini"],
-            tools=["web_search"],
-            max_tool_iterations=3,
-        )
 
-        assert soul.role == "Researcher"
-        assert soul.system_prompt == "You analyze things."
-        assert soul.model_name == "gpt-4o"
-        assert soul.models == ["gpt-4o", "gpt-4o-mini"]
-        assert soul.tools == ["web_search"]
-        assert soul.max_tool_iterations == 3
+class TestTaskEntityRejectsExtraFields:
+    def test_unknown_field_is_rejected(self):
+        with pytest.raises(ValidationError):
+            TaskEntity(id="t1", name="Build", extra_stuff=42)
 
-
-# ── TaskEntity ──────────────────────────────────────────────────────
-
-
-class TestTaskEntityIgnoresExtraFields:
-    def test_unknown_field_is_ignored(self):
-        task = TaskEntity(id="t1", name="Build", extra_stuff=42)
-        assert not hasattr(task, "extra_stuff")
-
-    def test_typo_field_is_not_stored(self):
-        task = TaskEntity(id="t1", naem="typo")
-        assert not hasattr(task, "naem")
-        assert task.name is None
+    def test_typo_field_is_rejected(self):
+        with pytest.raises(ValidationError):
+            TaskEntity(id="t1", naem="typo")
 
     def test_known_fields_work(self):
         task = TaskEntity(id="t1", name="Build")
@@ -77,18 +61,14 @@ class TestTaskEntityIgnoresExtraFields:
         assert task.name == "Build"
 
 
-# ── StepEntity ──────────────────────────────────────────────────────
+class TestStepEntityRejectsExtraFields:
+    def test_unknown_field_is_rejected(self):
+        with pytest.raises(ValidationError):
+            StepEntity(id="st1", name="Compile", random_key="val")
 
-
-class TestStepEntityIgnoresExtraFields:
-    def test_unknown_field_is_ignored(self):
-        step = StepEntity(id="st1", name="Compile", random_key="val")
-        assert not hasattr(step, "random_key")
-
-    def test_typo_field_is_not_stored(self):
-        step = StepEntity(id="st1", naem="typo")
-        assert not hasattr(step, "naem")
-        assert step.name is None
+    def test_typo_field_is_rejected(self):
+        with pytest.raises(ValidationError):
+            StepEntity(id="st1", naem="typo")
 
     def test_known_fields_work(self):
         step = StepEntity(id="st1", name="Compile")
@@ -96,7 +76,35 @@ class TestStepEntityIgnoresExtraFields:
         assert step.name == "Compile"
 
 
-# ── WorkflowEntity (extra="allow" preserved) ───────────────────────
+class TestProviderEntityRejectsExtraFields:
+    def test_unknown_field_is_rejected(self):
+        with pytest.raises(ValidationError):
+            ProviderEntity(
+                id="openai",
+                name="OpenAI",
+                type="openai",
+                custom_notes="unsupported",
+            )
+
+    def test_typo_field_is_rejected(self):
+        with pytest.raises(ValidationError):
+            ProviderEntity(id="openai", name="OpenAI", tpye="openai")
+
+    def test_known_fields_work(self):
+        provider = ProviderEntity(
+            id="openai",
+            name="OpenAI",
+            type="openai",
+            api_key="${OPENAI_API_KEY}",
+            base_url="https://api.openai.com/v1",
+            is_active=True,
+            status="connected",
+            models=["gpt-4o"],
+        )
+        assert provider.id == "openai"
+        assert provider.name == "OpenAI"
+        assert provider.type == "openai"
+        assert provider.models == ["gpt-4o"]
 
 
 class TestWorkflowEntityPreservesExtraFields:

--- a/apps/api/tests/domain/test_run437_soul_schema_alignment.py
+++ b/apps/api/tests/domain/test_run437_soul_schema_alignment.py
@@ -1,3 +1,4 @@
+import pytest
 from pydantic import ValidationError
 
 
@@ -11,7 +12,6 @@ def test_soul_entity_accepts_core_fields_and_avatar_color():
         tools=["web_search", "summarize"],
         max_tool_iterations=6,
         model_name="gpt-4o",
-        custom_notes="test value",
         avatar_color="lime",
     )
 
@@ -21,19 +21,21 @@ def test_soul_entity_accepts_core_fields_and_avatar_color():
     assert soul.tools == ["web_search", "summarize"]
     assert soul.max_tool_iterations == 6
     assert soul.model_name == "gpt-4o"
-    assert soul.custom_notes == "test value"
     assert soul.avatar_color == "lime"
 
 
-def test_soul_entity_preserves_legacy_name_and_models_fields_as_extras():
+def test_soul_entity_rejects_unknown_top_level_fields():
     from runsight_api.domain.value_objects import SoulEntity
 
-    soul = SoulEntity(id="legacy", name="Legacy Soul", models=["gpt-4o"])
+    with pytest.raises(ValidationError):
+        SoulEntity(id="legacy", custom_notes="test value")
 
-    assert soul.id == "legacy"
-    assert soul.role is None
-    assert soul.name == "Legacy Soul"
-    assert soul.models == ["gpt-4o"]
+
+def test_soul_entity_rejects_legacy_name_and_models_fields():
+    from runsight_api.domain.value_objects import SoulEntity
+
+    with pytest.raises(ValidationError):
+        SoulEntity(id="legacy", name="Legacy Soul", models=["gpt-4o"])
 
 
 def test_soul_create_requires_role_and_system_prompt():

--- a/apps/api/tests/domain/test_run689_soul_assertions_shim.py
+++ b/apps/api/tests/domain/test_run689_soul_assertions_shim.py
@@ -1,38 +1,23 @@
 """
-RUN-689 — Failing tests for SoulEntity.assertions compat shim removal.
-
-SoulEntity uses ``extra="allow"`` which preserves any unknown YAML fields
-generically.  The explicit ``assertions`` field is a backward-compat shim
-that must be deleted.  These tests verify the shim is gone.
+RUN-689/RUN-823: SoulEntity should not accept legacy assertions payloads.
 """
 
 from __future__ import annotations
 
+import pytest
+from pydantic import ValidationError
+
 from runsight_api.domain.value_objects import SoulEntity
 
 
-class TestSoulEntityAssertionsShimRemoved:
-    """The explicit 'assertions' field must not exist on SoulEntity."""
-
+class TestSoulEntityAssertionsFieldRejected:
     def test_assertions_not_in_explicit_model_fields(self) -> None:
-        """SoulEntity.model_fields must not contain 'assertions'.
+        assert "assertions" not in SoulEntity.model_fields
 
-        The field was a backward-compat shim.  With extra='allow', any
-        unknown key (including 'assertions') is still preserved at runtime
-        without needing a declared field.
-        """
-        assert "assertions" not in SoulEntity.model_fields, (
-            "SoulEntity still declares an explicit 'assertions' field — "
-            "remove the compat shim; extra='allow' handles it generically"
-        )
-
-    def test_assertions_data_still_preserved_via_extra_allow(self) -> None:
-        """Even without an explicit field, passing assertions data should
-        be preserved by the extra='allow' config."""
-        soul = SoulEntity(
-            id="s1",
-            role="Tester",
-            assertions=[{"type": "contains", "value": "hello"}],
-        )
-        # The data must survive — extra="allow" keeps it
-        assert soul.assertions == [{"type": "contains", "value": "hello"}]
+    def test_assertions_data_is_rejected_as_unknown(self) -> None:
+        with pytest.raises(ValidationError):
+            SoulEntity(
+                id="s1",
+                role="Tester",
+                assertions=[{"type": "contains", "value": "hello"}],
+            )

--- a/apps/api/tests/logic/test_run376_save_commit.py
+++ b/apps/api/tests/logic/test_run376_save_commit.py
@@ -12,72 +12,22 @@ git add + git commit via GitService.  Tests verify that:
 
 from __future__ import annotations
 
-import sys
-import types
+import importlib
 from unittest.mock import Mock
 
 import pytest
 
 from runsight_api.domain.value_objects import SoulEntity, WorkflowEntity
 
-runsight_core = sys.modules.get("runsight_core")
-if runsight_core is None:
-    runsight_core = types.ModuleType("runsight_core")
-    runsight_core.__path__ = []
-    sys.modules["runsight_core"] = runsight_core
-
-llm_pkg = sys.modules.get("runsight_core.llm")
-if llm_pkg is None:
-    llm_pkg = types.ModuleType("runsight_core.llm")
-    llm_pkg.__path__ = []
-    sys.modules["runsight_core.llm"] = llm_pkg
-    runsight_core.llm = llm_pkg
-
-model_catalog_pkg = sys.modules.get("runsight_core.llm.model_catalog")
-if model_catalog_pkg is None:
-    model_catalog_pkg = types.ModuleType("runsight_core.llm.model_catalog")
-
-    class _LiteLLMModelCatalog:
-        pass
-
-    class _ModelCatalogPort:
-        pass
-
-    model_catalog_pkg.LiteLLMModelCatalog = _LiteLLMModelCatalog
-    model_catalog_pkg.ModelCatalogPort = _ModelCatalogPort
-    sys.modules["runsight_core.llm.model_catalog"] = model_catalog_pkg
-
-llm_pkg.model_catalog = model_catalog_pkg
-runsight_core.llm = llm_pkg
-
-observer_pkg = sys.modules.get("runsight_core.observer")
-if observer_pkg is None:
-    observer_pkg = types.ModuleType("runsight_core.observer")
-
-    class _CompositeObserver:
-        pass
-
-    class _LoggingObserver:
-        pass
-
-    observer_pkg.CompositeObserver = _CompositeObserver
-    observer_pkg.LoggingObserver = _LoggingObserver
-    sys.modules["runsight_core.observer"] = observer_pkg
-
-yaml_pkg = sys.modules.get("runsight_core.yaml")
-if yaml_pkg is None:
-    yaml_pkg = types.ModuleType("runsight_core.yaml")
-    yaml_pkg.__path__ = []
-    sys.modules["runsight_core.yaml"] = yaml_pkg
-    runsight_core.yaml = yaml_pkg
-
-parser_pkg = sys.modules.get("runsight_core.yaml.parser")
-if parser_pkg is None:
-    parser_pkg = types.ModuleType("runsight_core.yaml.parser")
-    parser_pkg.parse_workflow_yaml = lambda *args, **kwargs: None
-    sys.modules["runsight_core.yaml.parser"] = parser_pkg
-
-yaml_pkg.parser = parser_pkg
+for module_name in (
+    "runsight_core",
+    "runsight_core.llm",
+    "runsight_core.llm.model_catalog",
+    "runsight_core.observer",
+    "runsight_core.yaml",
+    "runsight_core.yaml.parser",
+):
+    importlib.import_module(module_name)
 
 # ---------------------------------------------------------------------------
 # Fixtures

--- a/apps/api/tests/logic/test_run470_soul_update_preservation.py
+++ b/apps/api/tests/logic/test_run470_soul_update_preservation.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 
 import yaml
+import pytest
+from pydantic import ValidationError
 
 from runsight_api.data.filesystem.soul_repo import SoulRepository
 from runsight_api.domain.value_objects import SoulEntity
@@ -24,20 +26,18 @@ def test_soul_entity_accepts_new_api_fields():
     assert soul.avatar_color == "lime"
 
 
-def test_soul_entity_preserves_unknown_fields():
-    soul = SoulEntity(
-        id="legacy",
-        role="Legacy Soul",
-        system_prompt="Keep unknown fields intact.",
-        custom_notes="test value",
-        legacy_name="Legacy Soul",
-    )
-
-    assert soul.custom_notes == "test value"
-    assert soul.legacy_name == "Legacy Soul"
+def test_soul_entity_rejects_unknown_fields():
+    with pytest.raises(ValidationError, match="custom_notes"):
+        SoulEntity(
+            id="legacy",
+            role="Legacy Soul",
+            system_prompt="Reject unknown fields.",
+            custom_notes="test value",
+            legacy_name="Legacy Soul",
+        )
 
 
-def test_update_soul_preserves_unknown_yaml_fields_on_disk(tmp_path: Path):
+def test_update_soul_rejects_unknown_yaml_fields_without_rewriting(tmp_path: Path):
     repo = SoulRepository(base_path=str(tmp_path))
     service = SoulService(repo)
     soul_path = tmp_path / "custom" / "souls" / "preserve_me.yaml"
@@ -54,23 +54,18 @@ def test_update_soul_preserves_unknown_yaml_fields_on_disk(tmp_path: Path):
             sort_keys=False,
         )
     )
+    before = soul_path.read_text()
 
-    updated = service.update_soul(
-        "preserve_me",
-        {
-            "role": "Updated",
-            "provider": "anthropic",
-        },
-    )
+    with pytest.raises(ValidationError, match="custom_notes"):
+        service.update_soul(
+            "preserve_me",
+            {
+                "role": "Updated",
+                "provider": "anthropic",
+            },
+        )
 
-    reloaded = yaml.safe_load(soul_path.read_text())
-
-    assert updated.role == "Updated"
-    assert updated.provider == "anthropic"
-    assert reloaded["role"] == "Updated"
-    assert reloaded["provider"] == "anthropic"
-    assert reloaded["custom_notes"] == "test value"
-    assert reloaded["legacy_name"] == "Legacy Soul"
+    assert soul_path.read_text() == before
 
 
 def test_update_soul_normalizes_null_max_tool_iterations_to_default(tmp_path: Path):

--- a/apps/api/tests/logic/test_run767_git_service_missing_binary.py
+++ b/apps/api/tests/logic/test_run767_git_service_missing_binary.py
@@ -1,0 +1,45 @@
+"""Red tests for RUN-767: GitService must surface ServiceUnavailable when git is missing."""
+
+from pathlib import Path
+
+import pytest
+
+from runsight_api.domain.errors import ServiceUnavailable
+from runsight_api.logic.services.git_service import GitService
+
+
+def _git(repo: Path, *args: str) -> None:
+    import subprocess
+
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test")
+    (repo / "README.md").write_text("# hello", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "initial")
+    return repo
+
+
+class TestGitServiceMissingBinary:
+    def test_current_branch_raises_service_unavailable_when_git_is_missing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        repo = _init_repo(tmp_path)
+        monkeypatch.setenv("PATH", "")
+        svc = GitService(repo_path=str(repo))
+
+        with pytest.raises(ServiceUnavailable):
+            svc.current_branch()

--- a/apps/api/tests/logic/test_run772_stale_run_recovery.py
+++ b/apps/api/tests/logic/test_run772_stale_run_recovery.py
@@ -1,0 +1,76 @@
+"""Red tests for RUN-772: stale pending runs should be failed on startup."""
+
+from __future__ import annotations
+
+import time
+import uuid
+
+import pytest
+from sqlalchemy.pool import StaticPool
+from sqlmodel import SQLModel, Session, create_engine
+
+from runsight_api.domain.entities.run import Run, RunStatus
+
+
+def _make_run(*, status: RunStatus, **overrides) -> Run:
+    defaults = dict(
+        id=f"run_{uuid.uuid4().hex[:8]}",
+        workflow_id="wf_test",
+        workflow_name="Test Workflow",
+        task_json="{}",
+        created_at=time.time(),
+        updated_at=time.time(),
+    )
+    defaults.update(overrides)
+    return Run(status=status, **defaults)
+
+
+@pytest.fixture()
+def db_engine():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SQLModel.metadata.create_all(engine)
+    return engine
+
+
+@pytest.fixture()
+def seed_runs(db_engine):
+    def _seed(runs: list[Run]) -> list[Run]:
+        with Session(db_engine) as session:
+            for run in runs:
+                session.add(run)
+            session.commit()
+            for run in runs:
+                session.refresh(run)
+        return runs
+
+    return _seed
+
+
+def _recover_stale_runs(engine):
+    from runsight_api.main import _recover_stale_runs as impl
+
+    impl(engine)
+
+
+class TestRun772StaleRunRecovery:
+    def test_pending_and_running_runs_are_failed_on_startup(self, db_engine, seed_runs):
+        runs = seed_runs(
+            [
+                _make_run(status=RunStatus.pending),
+                _make_run(status=RunStatus.running),
+            ]
+        )
+
+        _recover_stale_runs(db_engine)
+
+        with Session(db_engine) as session:
+            for run in runs:
+                recovered = session.get(Run, run.id)
+                assert recovered.status == RunStatus.failed
+                assert recovered.error == "API process restarted during execution"
+                assert recovered.completed_at is not None
+                assert abs(recovered.completed_at - time.time()) < 10

--- a/apps/api/tests/logic/test_soul_service.py
+++ b/apps/api/tests/logic/test_soul_service.py
@@ -400,7 +400,7 @@ def test_update_soul_happy_path():
         id="soul_1",
         role="Old",
         system_prompt="Keep me",
-        custom_notes="test value",
+        provider="openai",
     )
     updated = SoulEntity(id="soul_1", role="New")
     soul_repo.get_by_id.return_value = existing
@@ -416,7 +416,7 @@ def test_update_soul_happy_path():
     assert payload["id"] == "soul_1"
     assert payload["role"] == "New"
     assert payload["system_prompt"] == "Keep me"
-    assert payload["custom_notes"] == "test value"
+    assert payload["provider"] == "openai"
 
 
 def test_update_soul_not_found_raises_soul_not_found():

--- a/apps/api/tests/test_stale_run_recovery.py
+++ b/apps/api/tests/test_stale_run_recovery.py
@@ -1,11 +1,8 @@
-"""Red tests for RUN-145: Stale run recovery on API startup.
+"""Tests for stale run recovery on API startup.
 
-When the API crashes mid-execution, Run records with status=running become
+When the API crashes mid-execution, pending and running Run records become
 zombie runs. On startup the lifespan handler must scan for these stale runs
 and mark them as failed.
-
-These tests target a `_recover_stale_runs(engine)` function that does NOT
-exist yet — every test should FAIL until the implementation is written.
 """
 
 import time
@@ -123,18 +120,19 @@ class TestStaleRunRecovery:
             # Must be a recent epoch timestamp (within last 10 seconds)
             assert abs(recovered.completed_at - time.time()) < 10
 
-    # -- Non-running statuses must be untouched ----------------------------
+    # -- Terminal statuses must be untouched -------------------------------
 
-    def test_pending_run_is_not_modified(self, db_engine, seed_runs):
-        """Pending runs must remain unchanged."""
+    def test_pending_run_is_marked_failed(self, db_engine, seed_runs):
+        """Pending runs are stale after process restart and must fail closed."""
         runs = seed_runs([_make_run(status=RunStatus.pending)])
 
         _recover_stale_runs(db_engine)
 
         with Session(db_engine) as session:
             run = session.get(Run, runs[0].id)
-            assert run.status == RunStatus.pending
-            assert run.error is None
+            assert run.status == RunStatus.failed
+            assert run.error == "API process restarted during execution"
+            assert run.completed_at is not None
 
     def test_completed_run_is_not_modified(self, db_engine, seed_runs):
         """Already-completed runs must remain unchanged."""
@@ -190,11 +188,10 @@ class TestStaleRunRecovery:
                 assert recovered.error == "API process restarted during execution"
                 assert recovered.completed_at is not None
 
-    def test_no_running_runs_is_noop(self, db_engine, seed_runs):
-        """When there are no running runs, the function must not error."""
+    def test_no_stale_runs_is_noop(self, db_engine, seed_runs):
+        """When there are no pending/running runs, the function must not error."""
         seed_runs(
             [
-                _make_run(status=RunStatus.pending),
                 _make_run(status=RunStatus.completed, completed_at=time.time()),
                 _make_run(status=RunStatus.failed, error="prev", completed_at=time.time()),
             ]
@@ -207,14 +204,14 @@ class TestStaleRunRecovery:
             # Verify nothing changed
             all_runs = session.exec(select(Run)).all()
             for run in all_runs:
-                assert run.status != RunStatus.running
+                assert run.status not in (RunStatus.pending, RunStatus.running)
 
     def test_empty_database_is_noop(self, db_engine):
         """An empty database must not cause errors."""
         _recover_stale_runs(db_engine)  # should not raise
 
     def test_mixed_statuses_only_running_affected(self, db_engine, seed_runs):
-        """In a mixed set, only running runs are modified; others stay intact."""
+        """In a mixed set, only pending/running runs are modified; terminal runs stay intact."""
         pending = _make_run(status=RunStatus.pending)
         running = _make_run(status=RunStatus.running)
         completed = _make_run(status=RunStatus.completed, completed_at=time.time())
@@ -225,7 +222,8 @@ class TestStaleRunRecovery:
         _recover_stale_runs(db_engine)
 
         with Session(db_engine) as session:
-            assert session.get(Run, pending.id).status == RunStatus.pending
+            assert session.get(Run, pending.id).status == RunStatus.failed
+            assert session.get(Run, pending.id).error == "API process restarted during execution"
             assert session.get(Run, running.id).status == RunStatus.failed
             assert session.get(Run, running.id).error == "API process restarted during execution"
             assert session.get(Run, completed.id).status == RunStatus.completed

--- a/apps/api/tests/transport/test_run767_git_router_missing_binary.py
+++ b/apps/api/tests/transport/test_run767_git_router_missing_binary.py
@@ -1,0 +1,57 @@
+"""Red tests for RUN-767: git router must return SERVICE_UNAVAILABLE when git is missing."""
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from runsight_api.core.config import settings
+from runsight_api.main import app
+
+
+def _git(repo: Path, *args: str) -> None:
+    import subprocess
+
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test")
+    (repo / "README.md").write_text("# hello", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "initial")
+    return repo
+
+
+client = TestClient(app)
+
+
+class TestGitStatusMissingBinary:
+    def test_status_returns_service_unavailable_envelope_when_git_is_missing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        repo = _init_repo(tmp_path)
+        original = settings.base_path
+        settings.base_path = str(repo)
+        monkeypatch.setenv("PATH", "")
+
+        try:
+            resp = client.get("/api/git/status")
+        finally:
+            settings.base_path = original
+
+        assert resp.status_code == 503
+        body = resp.json()
+        assert body["error_code"] == "SERVICE_UNAVAILABLE"
+        assert body["status_code"] == 503

--- a/apps/api/tests/transport/test_run772_fail_closed_run_creation.py
+++ b/apps/api/tests/transport/test_run772_fail_closed_run_creation.py
@@ -1,0 +1,173 @@
+"""Red tests for RUN-772: fail closed when the execution runtime is unavailable.
+
+POST /api/runs must not create a durable pending run when the execution
+runtime is missing, and it must surface failed launch outcomes instead of
+returning the stale pending response.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.pool import StaticPool
+from sqlmodel import SQLModel, Session, create_engine, select
+
+from runsight_api.data.repositories.run_repo import RunRepository
+from runsight_api.domain.entities.run import Run, RunStatus
+from runsight_api.logic.services.run_service import RunService
+from runsight_api.main import app
+from runsight_api.transport.deps import get_execution_service, get_run_service
+
+client = TestClient(app)
+
+
+def assert_runsight_error_shape(response, expected_status: int):
+    """Verify the response uses the RunsightError envelope."""
+    assert response.status_code == expected_status
+    body = response.json()
+    assert "error" in body
+    assert "error_code" in body
+    assert "status_code" in body
+    assert "detail" not in body
+    return body
+
+
+def _make_mock_run(run_id: str = "run_772"):
+    mock_run = Mock()
+    mock_run.id = run_id
+    mock_run.workflow_id = "wf_1"
+    mock_run.workflow_name = "Test Workflow"
+    mock_run.status = RunStatus.pending
+    mock_run.error = None
+    mock_run.started_at = None
+    mock_run.completed_at = None
+    mock_run.duration_s = None
+    mock_run.total_cost_usd = 0.0
+    mock_run.total_tokens = 0
+    mock_run.created_at = 123.0
+    mock_run.branch = "main"
+    mock_run.source = "manual"
+    mock_run.commit_sha = None
+    mock_run.run_number = None
+    mock_run.eval_pass_pct = None
+    mock_run.regression_count = None
+    mock_run.parent_run_id = None
+    mock_run.root_run_id = None
+    mock_run.depth = 0
+    return mock_run
+
+
+@pytest.fixture()
+def db_engine():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SQLModel.metadata.create_all(engine)
+    return engine
+
+
+@pytest.fixture()
+def workflow_repo():
+    workflow = Mock()
+    workflow.id = "wf_1"
+    workflow.name = "Test Workflow"
+    repo = Mock()
+    repo.get_by_id.return_value = workflow
+    return repo
+
+
+@pytest.fixture()
+def run_service(db_engine, workflow_repo):
+    session = Session(db_engine)
+    service = RunService(RunRepository(session), workflow_repo)
+    try:
+        yield service
+    finally:
+        session.close()
+
+
+class TestFailClosedRunCreation:
+    def test_post_runs_without_execution_runtime_returns_service_unavailable(self):
+        """POST /api/runs must fail before creating a run when execution is unavailable."""
+        mock_run_service = Mock()
+        mock_run_service.create_run.return_value = _make_mock_run()
+
+        app.dependency_overrides[get_run_service] = lambda: mock_run_service
+        app.dependency_overrides[get_execution_service] = lambda: None
+        try:
+            response = client.post(
+                "/api/runs",
+                json={"workflow_id": "wf_1", "task_data": {"instruction": "go"}},
+            )
+
+            body = assert_runsight_error_shape(response, 503)
+            assert body["error_code"] == "SERVICE_UNAVAILABLE"
+            mock_run_service.create_run.assert_not_called()
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_post_runs_launch_exception_marks_created_run_failed(self, db_engine, run_service):
+        """A launch exception must not leave the created run pending."""
+
+        mock_exec_service = Mock()
+        mock_exec_service.launch_execution = AsyncMock(
+            side_effect=RuntimeError("launch failed after run creation")
+        )
+
+        app.dependency_overrides[get_run_service] = lambda: run_service
+        app.dependency_overrides[get_execution_service] = lambda: mock_exec_service
+        try:
+            response = client.post(
+                "/api/runs",
+                json={"workflow_id": "wf_1", "task_data": {"instruction": "go"}},
+            )
+
+            body = assert_runsight_error_shape(response, 500)
+            assert body["error_code"] == "RUN_FAILED"
+
+            with Session(db_engine) as session:
+                run = session.exec(select(Run)).one()
+                assert run.status == RunStatus.failed
+                assert run.completed_at is not None
+                assert run.error is not None
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_post_runs_detects_failed_lifecycle_outcome(self, db_engine, run_service):
+        """If launch marks the run failed without raising, the route must return a failure."""
+
+        async def _mark_failed(run_id, workflow_id, task_data, branch="main"):
+            with Session(db_engine) as session:
+                run = session.get(Run, run_id)
+                run.status = RunStatus.failed
+                run.error = "workflow failed during launch"
+                run.completed_at = time.time()
+                session.add(run)
+                session.commit()
+
+        mock_exec_service = Mock()
+        mock_exec_service.launch_execution = AsyncMock(side_effect=_mark_failed)
+
+        app.dependency_overrides[get_run_service] = lambda: run_service
+        app.dependency_overrides[get_execution_service] = lambda: mock_exec_service
+        try:
+            response = client.post(
+                "/api/runs",
+                json={"workflow_id": "wf_1", "task_data": {"instruction": "go"}},
+            )
+
+            body = assert_runsight_error_shape(response, 500)
+            assert body["error_code"] == "RUN_FAILED"
+
+            with Session(db_engine) as session:
+                run = session.exec(select(Run)).one()
+                assert run.status == RunStatus.failed
+                assert run.completed_at is not None
+                assert run.error == "workflow failed during launch"
+        finally:
+            app.dependency_overrides.clear()

--- a/apps/api/tests/transport/test_settings_router.py
+++ b/apps/api/tests/transport/test_settings_router.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from unittest.mock import AsyncMock, Mock
 
 from fastapi.testclient import TestClient
@@ -13,9 +12,6 @@ from runsight_api.transport.deps import (
 )
 
 client = TestClient(app)
-ROUTER_SOURCE = (
-    Path(__file__).resolve().parents[2] / "src/runsight_api/transport/routers/settings.py"
-)
 
 
 def _mock_provider(*, provider_id: str, name: str, models: list[str]):
@@ -327,10 +323,17 @@ def test_app_settings_put_rejects_unsupported_fields():
         app.dependency_overrides.clear()
 
 
-def test_router_source_mentions_fallback_settings_only():
-    source = ROUTER_SOURCE.read_text()
+def test_settings_openapi_exposes_fallback_routes_and_current_app_settings_shape():
+    spec = app.openapi()
 
-    assert "/fallbacks" in source
-    assert "fallback_enabled" in source
-    assert "/settings/models" not in source
-    assert "default_provider" not in source
+    assert "/api/settings/fallbacks" in spec["paths"]
+    assert "/api/settings/fallbacks/{provider_id}" in spec["paths"]
+    assert "/api/settings/models" not in spec["paths"]
+    assert "/api/settings/models/{model_id}" not in spec["paths"]
+
+    app_settings_props = spec["components"]["schemas"]["AppSettingsOut"]["properties"]
+    assert "fallback_enabled" in app_settings_props
+    assert "onboarding_completed" in app_settings_props
+    assert "auto_save" not in app_settings_props
+    assert "default_provider" not in app_settings_props
+    assert "fallback_chain_enabled" not in app_settings_props

--- a/apps/api/tests/transport/test_settings_router.py
+++ b/apps/api/tests/transport/test_settings_router.py
@@ -109,6 +109,30 @@ def test_settings_providers_post_422():
     assert response.status_code == 422
 
 
+def test_settings_providers_post_rejects_unknown_fields():
+    mock_service = Mock()
+    mock_service.create_provider.return_value = _mock_provider(
+        provider_id="openai",
+        name="OpenAI",
+        models=[],
+    )
+    app.dependency_overrides[get_provider_service] = lambda: mock_service
+
+    try:
+        response = client.post(
+            "/api/settings/providers",
+            json={
+                "name": "OpenAI",
+                "api_key_env": "sk-xxx",
+                "custom_notes": "unsupported",
+            },
+        )
+        assert response.status_code == 422
+        mock_service.create_provider.assert_not_called()
+    finally:
+        app.dependency_overrides.clear()
+
+
 def test_settings_providers_put_404():
     mock_service = Mock()
     mock_service.update_provider.return_value = None
@@ -117,6 +141,26 @@ def test_settings_providers_put_404():
     response = client.put("/api/settings/providers/missing", json={"name": "Updated"})
     assert response.status_code == 404
     app.dependency_overrides.clear()
+
+
+def test_settings_providers_put_rejects_unknown_fields():
+    mock_service = Mock()
+    mock_service.update_provider.return_value = _mock_provider(
+        provider_id="openai",
+        name="OpenAI",
+        models=[],
+    )
+    app.dependency_overrides[get_provider_service] = lambda: mock_service
+
+    try:
+        response = client.put(
+            "/api/settings/providers/openai",
+            json={"name": "Updated", "custom_notes": "unsupported"},
+        )
+        assert response.status_code == 422
+        mock_service.update_provider.assert_not_called()
+    finally:
+        app.dependency_overrides.clear()
 
 
 def test_settings_providers_delete_404():

--- a/apps/api/tests/transport/test_settings_router.py
+++ b/apps/api/tests/transport/test_settings_router.py
@@ -308,7 +308,6 @@ def test_settings_fallbacks_put_allows_clearing_with_empty_strings():
 def test_app_settings_get_omits_auto_save_and_keeps_fallback_enabled():
     mock_repo = Mock(spec=FileSystemSettingsRepo)
     mock_repo.get_settings.return_value = AppSettingsConfig(
-        auto_save=True,
         onboarding_completed=True,
         fallback_enabled=False,
     )
@@ -327,7 +326,6 @@ def test_app_settings_get_omits_auto_save_and_keeps_fallback_enabled():
 def test_app_settings_put_keeps_fallback_settings_without_auto_save():
     mock_repo = Mock(spec=FileSystemSettingsRepo)
     mock_repo.update_settings.return_value = AppSettingsConfig(
-        auto_save=True,
         onboarding_completed=True,
         fallback_enabled=False,
     )

--- a/apps/api/tests/transport/test_settings_router.py
+++ b/apps/api/tests/transport/test_settings_router.py
@@ -264,7 +264,7 @@ def test_settings_fallbacks_put_allows_clearing_with_empty_strings():
         app.dependency_overrides.clear()
 
 
-def test_app_settings_get_returns_fallback_enabled_without_default_provider():
+def test_app_settings_get_omits_auto_save_and_keeps_fallback_enabled():
     mock_repo = Mock(spec=FileSystemSettingsRepo)
     mock_repo.get_settings.return_value = AppSettingsConfig(
         auto_save=True,
@@ -276,14 +276,14 @@ def test_app_settings_get_returns_fallback_enabled_without_default_provider():
     try:
         response = client.get("/api/settings/app")
         assert response.status_code == 200
-        assert response.json()["auto_save"] is True
+        assert "auto_save" not in response.json()
         assert response.json()["fallback_enabled"] is False
         assert "default_provider" not in response.json()
     finally:
         app.dependency_overrides.clear()
 
 
-def test_app_settings_put_updates_fallback_enabled_without_default_provider():
+def test_app_settings_put_keeps_fallback_settings_without_auto_save():
     mock_repo = Mock(spec=FileSystemSettingsRepo)
     mock_repo.update_settings.return_value = AppSettingsConfig(
         auto_save=True,
@@ -295,14 +295,34 @@ def test_app_settings_put_updates_fallback_enabled_without_default_provider():
     try:
         response = client.put(
             "/api/settings/app",
-            json={"auto_save": True, "fallback_enabled": False},
+            json={"onboarding_completed": True, "fallback_enabled": False},
         )
         assert response.status_code == 200
         assert response.json()["fallback_enabled"] is False
+        assert "auto_save" not in response.json()
         assert "default_provider" not in response.json()
         mock_repo.update_settings.assert_called_once_with(
-            {"auto_save": True, "fallback_enabled": False}
+            {"onboarding_completed": True, "fallback_enabled": False}
         )
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_app_settings_put_rejects_unsupported_fields():
+    mock_repo = Mock(spec=FileSystemSettingsRepo)
+    mock_repo.update_settings.return_value = AppSettingsConfig(
+        onboarding_completed=True,
+        fallback_enabled=False,
+    )
+    app.dependency_overrides[get_settings_repo] = lambda: mock_repo
+
+    try:
+        response = client.put(
+            "/api/settings/app",
+            json={"default_provider": "openai"},
+        )
+        assert response.status_code == 422
+        mock_repo.update_settings.assert_not_called()
     finally:
         app.dependency_overrides.clear()
 

--- a/apps/api/tests/transport/test_settings_router.py
+++ b/apps/api/tests/transport/test_settings_router.py
@@ -329,9 +329,11 @@ def test_app_settings_put_rejects_unsupported_fields():
     [
         {"onboarding_completed": "yes"},
         {"fallback_enabled": 1},
+        {"onboarding_completed": None},
+        {"fallback_enabled": None},
     ],
 )
-def test_app_settings_put_rejects_coercible_non_boolean_values(payload):
+def test_app_settings_put_rejects_non_boolean_values(payload):
     mock_repo = Mock(spec=FileSystemSettingsRepo)
     mock_repo.update_settings.return_value = AppSettingsConfig(
         onboarding_completed=False,
@@ -361,3 +363,13 @@ def test_settings_openapi_exposes_fallback_routes_and_current_app_settings_shape
     assert "auto_save" not in app_settings_props
     assert "default_provider" not in app_settings_props
     assert "fallback_chain_enabled" not in app_settings_props
+
+    app_settings_update_props = spec["components"]["schemas"]["AppSettingsUpdate"]["properties"]
+    assert app_settings_update_props["onboarding_completed"] == {
+        "type": "boolean",
+        "title": "Onboarding Completed",
+    }
+    assert app_settings_update_props["fallback_enabled"] == {
+        "type": "boolean",
+        "title": "Fallback Enabled",
+    }

--- a/apps/api/tests/transport/test_settings_router.py
+++ b/apps/api/tests/transport/test_settings_router.py
@@ -1,5 +1,6 @@
 from unittest.mock import AsyncMock, Mock
 
+import pytest
 from fastapi.testclient import TestClient
 
 from runsight_api.data.filesystem.settings_repo import FileSystemSettingsRepo
@@ -317,6 +318,29 @@ def test_app_settings_put_rejects_unsupported_fields():
             "/api/settings/app",
             json={"default_provider": "openai"},
         )
+        assert response.status_code == 422
+        mock_repo.update_settings.assert_not_called()
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"onboarding_completed": "yes"},
+        {"fallback_enabled": 1},
+    ],
+)
+def test_app_settings_put_rejects_coercible_non_boolean_values(payload):
+    mock_repo = Mock(spec=FileSystemSettingsRepo)
+    mock_repo.update_settings.return_value = AppSettingsConfig(
+        onboarding_completed=False,
+        fallback_enabled=False,
+    )
+    app.dependency_overrides[get_settings_repo] = lambda: mock_repo
+
+    try:
+        response = client.put("/api/settings/app", json=payload)
         assert response.status_code == 422
         mock_repo.update_settings.assert_not_called()
     finally:

--- a/apps/api/tests/transport/test_souls_router.py
+++ b/apps/api/tests/transport/test_souls_router.py
@@ -93,7 +93,7 @@ def test_souls_post():
 
 def test_souls_post_requires_role():
     mock_service = Mock()
-    mock_service.create_soul.return_value = SoulEntity(id="unexpected", name="Unexpected")
+    mock_service.create_soul.return_value = SoulEntity(id="unexpected", role="Unexpected")
     app.dependency_overrides[get_soul_service] = lambda: mock_service
     response = client.post(
         "/api/souls",

--- a/apps/api/tests/transport/test_souls_router.py
+++ b/apps/api/tests/transport/test_souls_router.py
@@ -117,6 +117,24 @@ def test_souls_post_requires_system_prompt():
     app.dependency_overrides.clear()
 
 
+def test_souls_post_rejects_unknown_fields():
+    mock_service = Mock()
+    mock_service.create_soul.return_value = SoulEntity(id="unexpected", role="Unexpected")
+    app.dependency_overrides[get_soul_service] = lambda: mock_service
+
+    response = client.post(
+        "/api/souls",
+        json={
+            "role": "New Soul",
+            "system_prompt": "Create the soul",
+            "custom_notes": "unsupported",
+        },
+    )
+    assert response.status_code == 422
+    mock_service.create_soul.assert_not_called()
+    app.dependency_overrides.clear()
+
+
 def test_souls_put():
     mock_service = Mock()
     mock_soul = SoulEntity(
@@ -139,6 +157,28 @@ def test_souls_put():
     assert response.status_code == 200
     assert response.json()["role"] == "Updated Soul"
     assert response.json()["model_name"] == "claude-sonnet"
+    app.dependency_overrides.clear()
+
+
+def test_souls_put_rejects_unknown_fields():
+    mock_service = Mock()
+    mock_service.update_soul.return_value = SoulEntity(
+        id="sl_1",
+        role="Updated Soul",
+        system_prompt="Updated prompt",
+        model_name="claude-sonnet",
+    )
+    app.dependency_overrides[get_soul_service] = lambda: mock_service
+
+    response = client.put(
+        "/api/souls/sl_1",
+        json={
+            "role": "Updated Soul",
+            "custom_notes": "unsupported",
+        },
+    )
+    assert response.status_code == 422
+    mock_service.update_soul.assert_not_called()
     app.dependency_overrides.clear()
 
 

--- a/apps/api/tests/transport/test_steps_router.py
+++ b/apps/api/tests/transport/test_steps_router.py
@@ -68,6 +68,31 @@ def test_steps_post_422():
     assert response.status_code == 422
 
 
+def test_steps_post_rejects_unknown_fields():
+    mock_registry = Mock()
+    mock_repo = Mock()
+    mock_entity = Mock()
+    mock_entity.model_dump.return_value = {
+        "id": "st_new",
+        "name": "New Step",
+        "type": "step",
+        "path": "/path/to/st_new",
+        "description": None,
+    }
+    mock_repo.create.return_value = mock_entity
+    mock_repo._get_path.return_value = "/path/to/st_new"
+    app.dependency_overrides[get_registry_service] = lambda: mock_registry
+    app.dependency_overrides[get_step_repo] = lambda: mock_repo
+
+    response = client.post(
+        "/api/steps",
+        json={"name": "New Step", "type": "step", "custom_notes": "unsupported"},
+    )
+    assert response.status_code == 422
+    mock_repo.create.assert_not_called()
+    app.dependency_overrides.clear()
+
+
 def test_steps_put_404():
     mock_registry = Mock()
     mock_registry.discover_steps.return_value = []
@@ -78,6 +103,33 @@ def test_steps_put_404():
 
     response = client.put("/api/steps/missing", json={"name": "Updated"})
     assert response.status_code == 404
+    app.dependency_overrides.clear()
+
+
+def test_steps_put_rejects_unknown_fields():
+    mock_registry = Mock()
+    mock_repo = Mock()
+    mock_entity = Mock()
+    mock_entity.model_dump.return_value = {
+        "id": "st_1",
+        "name": "Step",
+        "type": "step",
+        "path": "/path/to/st_1",
+        "description": None,
+    }
+    mock_repo.get_by_id.return_value = mock_entity
+    mock_repo.update.return_value = mock_entity
+    mock_repo._get_path.return_value = "/path/to/st_1"
+    app.dependency_overrides[get_registry_service] = lambda: mock_registry
+    app.dependency_overrides[get_step_repo] = lambda: mock_repo
+
+    response = client.put(
+        "/api/steps/st_1",
+        json={"name": "Updated", "custom_notes": "unsupported"},
+    )
+    assert response.status_code == 422
+    mock_repo.get_by_id.assert_not_called()
+    mock_repo.update.assert_not_called()
     app.dependency_overrides.clear()
 
 

--- a/apps/api/tests/transport/test_tasks_router.py
+++ b/apps/api/tests/transport/test_tasks_router.py
@@ -68,6 +68,31 @@ def test_tasks_post_422():
     assert response.status_code == 422
 
 
+def test_tasks_post_rejects_unknown_fields():
+    mock_registry = Mock()
+    mock_repo = Mock()
+    mock_entity = Mock()
+    mock_entity.model_dump.return_value = {
+        "id": "tk_new",
+        "name": "New Task",
+        "type": "task",
+        "path": "/path/to/tk_new",
+        "description": None,
+    }
+    mock_repo.create.return_value = mock_entity
+    mock_repo._get_path.return_value = "/path/to/tk_new"
+    app.dependency_overrides[get_registry_service] = lambda: mock_registry
+    app.dependency_overrides[get_task_repo] = lambda: mock_repo
+
+    response = client.post(
+        "/api/tasks",
+        json={"name": "New Task", "type": "task", "custom_notes": "unsupported"},
+    )
+    assert response.status_code == 422
+    mock_repo.create.assert_not_called()
+    app.dependency_overrides.clear()
+
+
 def test_tasks_put_404():
     mock_registry = Mock()
     mock_registry.discover_tasks.return_value = []
@@ -78,6 +103,33 @@ def test_tasks_put_404():
 
     response = client.put("/api/tasks/missing", json={"name": "Updated"})
     assert response.status_code == 404
+    app.dependency_overrides.clear()
+
+
+def test_tasks_put_rejects_unknown_fields():
+    mock_registry = Mock()
+    mock_repo = Mock()
+    mock_entity = Mock()
+    mock_entity.model_dump.return_value = {
+        "id": "tk_1",
+        "name": "Task",
+        "type": "task",
+        "path": "/path/to/tk_1",
+        "description": None,
+    }
+    mock_repo.get_by_id.return_value = mock_entity
+    mock_repo.update.return_value = mock_entity
+    mock_repo._get_path.return_value = "/path/to/tk_1"
+    app.dependency_overrides[get_registry_service] = lambda: mock_registry
+    app.dependency_overrides[get_task_repo] = lambda: mock_repo
+
+    response = client.put(
+        "/api/tasks/tk_1",
+        json={"name": "Updated", "custom_notes": "unsupported"},
+    )
+    assert response.status_code == 422
+    mock_repo.get_by_id.assert_not_called()
+    mock_repo.update.assert_not_called()
     app.dependency_overrides.clear()
 
 

--- a/apps/api/tests/unit/data/filesystem/test_provider_repo.py
+++ b/apps/api/tests/unit/data/filesystem/test_provider_repo.py
@@ -311,6 +311,22 @@ class TestReadValidation:
         with pytest.raises(ValidationError):
             repo.get_by_id("openai")
 
+    def test_list_all_rejects_provider_yaml_with_unsupported_fields(self, repo, providers_dir):
+        yaml_path = providers_dir / "openai.yaml"
+        yaml_path.write_text(
+            yaml.safe_dump(
+                {
+                    "name": "OpenAI",
+                    "type": "openai",
+                    "api_key": "${OPENAI_API_KEY}",
+                    "custom_notes": "unsupported",
+                }
+            )
+        )
+
+        with pytest.raises(ValidationError):
+            repo.list_all()
+
 
 class TestDelete:
     def test_delete_removes_yaml_file(self, repo, providers_dir):

--- a/apps/api/tests/unit/data/filesystem/test_provider_repo.py
+++ b/apps/api/tests/unit/data/filesystem/test_provider_repo.py
@@ -22,6 +22,7 @@ import os
 
 import pytest
 import yaml
+from pydantic import ValidationError
 
 from runsight_api.data.filesystem.provider_repo import FileSystemProviderRepo
 from runsight_api.domain.errors import ProviderNotFound
@@ -141,6 +142,14 @@ class TestCreate:
         """An empty name should still produce a usable slug."""
         entity = repo.create(_make_provider_data(name=""))
         assert entity.id  # must not be empty
+
+    def test_create_rejects_unknown_fields_and_does_not_persist_yaml(self, repo, providers_dir):
+        data = _make_provider_data(custom_notes="unsupported")
+
+        with pytest.raises(ValidationError):
+            repo.create(data)
+
+        assert not (providers_dir / "openai.yaml").exists()
 
 
 class TestCreateDuplicates:
@@ -272,6 +281,35 @@ class TestUpdate:
         created = repo.create(_make_provider_data(name="OpenAI"))
         updated = repo.update(created.id, {"status": "offline"})
         assert updated.id == created.id
+
+    def test_update_rejects_unknown_fields_and_keeps_existing_yaml(self, repo, providers_dir):
+        created = repo.create(_make_provider_data(name="OpenAI"))
+        yaml_path = providers_dir / f"{created.id}.yaml"
+
+        before = yaml.safe_load(yaml_path.read_text())
+        with pytest.raises(ValidationError):
+            repo.update(created.id, {"custom_notes": "unsupported"})
+        after = yaml.safe_load(yaml_path.read_text())
+
+        assert after == before
+
+
+class TestReadValidation:
+    def test_get_by_id_rejects_provider_yaml_with_unsupported_fields(self, repo, providers_dir):
+        yaml_path = providers_dir / "openai.yaml"
+        yaml_path.write_text(
+            yaml.safe_dump(
+                {
+                    "name": "OpenAI",
+                    "type": "openai",
+                    "api_key": "${OPENAI_API_KEY}",
+                    "custom_notes": "unsupported",
+                }
+            )
+        )
+
+        with pytest.raises(ValidationError):
+            repo.get_by_id("openai")
 
 
 class TestDelete:

--- a/apps/api/tests/unit/data/filesystem/test_settings_repo.py
+++ b/apps/api/tests/unit/data/filesystem/test_settings_repo.py
@@ -231,6 +231,31 @@ class TestStrictSchemaValidation:
         with pytest.raises(Exception, match="fallback_map|YAML|parse|invalid"):
             repo.get_settings()
 
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [
+            ("fallback_enabled", 1),
+            ("onboarding_completed", "yes"),
+        ],
+    )
+    def test_get_settings_rejects_wrong_type_for_supported_bool_fields(
+        self, repo, settings_file, field, value
+    ):
+        settings_file.parent.mkdir(parents=True, exist_ok=True)
+        settings_file.write_text(
+            yaml.safe_dump(
+                {
+                    "onboarding_completed": False,
+                    "fallback_enabled": False,
+                    field: value,
+                },
+                sort_keys=False,
+            )
+        )
+
+        with pytest.raises(Exception, match=field):
+            repo.get_settings()
+
     def test_get_fallback_map_rejects_non_list_fallback_map(self, repo, settings_file):
         settings_file.parent.mkdir(parents=True, exist_ok=True)
         settings_file.write_text(
@@ -345,4 +370,44 @@ class TestStrictSettingsWrites:
         with pytest.raises(Exception, match="auto_save"):
             repo.update_settings({"onboarding_completed": True})
 
+        write_mock.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("updates", "field"),
+        [
+            ({"onboarding_completed": "yes"}, "onboarding_completed"),
+            ({"fallback_enabled": 1}, "fallback_enabled"),
+        ],
+    )
+    def test_update_settings_rejects_wrong_type_without_creating_settings_file(
+        self, repo, settings_file, updates, field
+    ):
+        assert not settings_file.exists()
+
+        with pytest.raises(Exception, match=field):
+            repo.update_settings(updates)
+
+        assert not settings_file.exists()
+
+    def test_update_settings_rejects_wrong_type_without_rewriting_existing_file(
+        self, repo, settings_file, monkeypatch
+    ):
+        settings_file.parent.mkdir(parents=True, exist_ok=True)
+        settings_file.write_text(
+            yaml.safe_dump(
+                {
+                    "onboarding_completed": False,
+                    "fallback_enabled": True,
+                },
+                sort_keys=False,
+            )
+        )
+        before = settings_file.read_text()
+        write_mock = Mock(wraps=repo._write_yaml)
+        monkeypatch.setattr(repo, "_write_yaml", write_mock)
+
+        with pytest.raises(Exception, match="fallback_enabled"):
+            repo.update_settings({"fallback_enabled": 1})
+
+        assert settings_file.read_text() == before
         write_mock.assert_not_called()

--- a/apps/api/tests/unit/data/filesystem/test_settings_repo.py
+++ b/apps/api/tests/unit/data/filesystem/test_settings_repo.py
@@ -170,6 +170,41 @@ class TestStrictSchemaValidation:
         with pytest.raises(Exception, match="fallback_map"):
             repo.get_fallback_map()
 
+    @pytest.mark.parametrize(
+        ("missing_key", "entry"),
+        [
+            (
+                "provider_id",
+                {
+                    "fallback_provider_id": "anthropic",
+                    "fallback_model_id": "claude-sonnet-4",
+                },
+            ),
+            (
+                "fallback_provider_id",
+                {
+                    "provider_id": "openai",
+                    "fallback_model_id": "claude-sonnet-4",
+                },
+            ),
+            (
+                "fallback_model_id",
+                {
+                    "provider_id": "openai",
+                    "fallback_provider_id": "anthropic",
+                },
+            ),
+        ],
+    )
+    def test_get_settings_rejects_fallback_map_entries_missing_required_fields(
+        self, repo, settings_file, missing_key, entry
+    ):
+        settings_file.parent.mkdir(parents=True, exist_ok=True)
+        settings_file.write_text(yaml.safe_dump({"fallback_map": [entry]}, sort_keys=False))
+
+        with pytest.raises(Exception, match=missing_key):
+            repo.get_settings()
+
 
 class TestStrictSettingsWrites:
     def test_update_settings_preserves_fallback_map_but_removes_auto_save(

--- a/apps/api/tests/unit/data/filesystem/test_settings_repo.py
+++ b/apps/api/tests/unit/data/filesystem/test_settings_repo.py
@@ -118,22 +118,75 @@ class TestFallbackMapPersistence:
         assert repo.remove_fallback_target("missing-provider") is False
 
 
-class TestCleanSchemaOnly:
-    def test_get_settings_ignores_legacy_keys_without_rewriting_yaml(self, repo, settings_file):
+class TestStrictSchemaValidation:
+    @pytest.mark.parametrize(
+        ("key", "value"),
+        [
+            ("auto_save", True),
+            ("default_provider", "openai"),
+            ("fallback_chain_enabled", True),
+            ("fallback_chain", [{"provider_id": "openai", "model_id": "gpt-4o"}]),
+            (
+                "model_defaults",
+                [
+                    {
+                        "provider_id": "openai",
+                        "model_id": "gpt-4o",
+                        "is_default": True,
+                    }
+                ],
+            ),
+        ],
+    )
+    def test_get_settings_rejects_dead_top_level_keys(self, repo, settings_file, key, value):
+        settings_file.parent.mkdir(parents=True, exist_ok=True)
+        settings_file.write_text(yaml.safe_dump({key: value}, sort_keys=False))
+
+        with pytest.raises(Exception, match=key):
+            repo.get_settings()
+
+    def test_get_settings_rejects_malformed_yaml(self, repo, settings_file):
+        settings_file.parent.mkdir(parents=True, exist_ok=True)
+        settings_file.write_text("onboarding_completed: true\nfallback_map: [")
+
+        with pytest.raises(Exception, match="fallback_map|YAML|parse|invalid"):
+            repo.get_settings()
+
+    def test_get_fallback_map_rejects_non_list_fallback_map(self, repo, settings_file):
         settings_file.parent.mkdir(parents=True, exist_ok=True)
         settings_file.write_text(
             yaml.safe_dump(
                 {
-                    "default_provider": "openai",
-                    "fallback_chain_enabled": True,
-                    "fallback_chain": [
-                        {"provider_id": "openai", "model_id": "gpt-4o"},
-                    ],
-                    "model_defaults": [
+                    "fallback_map": {
+                        "provider_id": "openai",
+                        "fallback_provider_id": "anthropic",
+                        "fallback_model_id": "claude-sonnet-4",
+                    }
+                },
+                sort_keys=False,
+            )
+        )
+
+        with pytest.raises(Exception, match="fallback_map"):
+            repo.get_fallback_map()
+
+
+class TestStrictSettingsWrites:
+    def test_update_settings_preserves_fallback_map_but_removes_auto_save(
+        self, repo, settings_file
+    ):
+        settings_file.parent.mkdir(parents=True, exist_ok=True)
+        settings_file.write_text(
+            yaml.safe_dump(
+                {
+                    "auto_save": True,
+                    "onboarding_completed": False,
+                    "fallback_enabled": True,
+                    "fallback_map": [
                         {
                             "provider_id": "openai",
-                            "model_id": "gpt-4o",
-                            "is_default": True,
+                            "fallback_provider_id": "anthropic",
+                            "fallback_model_id": "claude-sonnet-4",
                         }
                     ],
                 },
@@ -141,41 +194,19 @@ class TestCleanSchemaOnly:
             )
         )
 
-        settings = repo.get_settings()
+        updated = repo.update_settings({"onboarding_completed": True})
 
-        assert settings.fallback_enabled is False
+        assert updated.onboarding_completed is True
+        assert updated.fallback_enabled is True
 
         on_disk = yaml.safe_load(settings_file.read_text())
-        assert on_disk["fallback_chain_enabled"] is True
-        assert on_disk["fallback_chain"] == [{"provider_id": "openai", "model_id": "gpt-4o"}]
-        assert on_disk["model_defaults"] == [
+        assert on_disk["onboarding_completed"] is True
+        assert on_disk["fallback_enabled"] is True
+        assert on_disk["fallback_map"] == [
             {
                 "provider_id": "openai",
-                "model_id": "gpt-4o",
-                "is_default": True,
+                "fallback_provider_id": "anthropic",
+                "fallback_model_id": "claude-sonnet-4",
             }
         ]
-        assert repo.get_fallback_map() == []
-
-    def test_get_settings_defaults_fallback_enabled_false_when_only_legacy_chain_exists(
-        self, repo, settings_file
-    ):
-        settings_file.parent.mkdir(parents=True, exist_ok=True)
-        settings_file.write_text(
-            yaml.safe_dump(
-                {
-                    "fallback_chain": [
-                        {"provider_id": "openai", "model_id": "gpt-4o"},
-                    ],
-                },
-                sort_keys=False,
-            )
-        )
-
-        settings = repo.get_settings()
-
-        assert settings.fallback_enabled is False
-
-        on_disk = yaml.safe_load(settings_file.read_text())
-        assert "fallback_enabled" not in on_disk
-        assert on_disk["fallback_chain"] == [{"provider_id": "openai", "model_id": "gpt-4o"}]
+        assert "auto_save" not in on_disk

--- a/apps/api/tests/unit/data/filesystem/test_settings_repo.py
+++ b/apps/api/tests/unit/data/filesystem/test_settings_repo.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+from unittest.mock import Mock
 
 import pytest
 import yaml
@@ -114,8 +115,24 @@ class TestFallbackMapPersistence:
         assert removed is True
         assert repo.get_fallback_map() == []
 
-    def test_remove_fallback_target_returns_false_when_provider_is_missing(self, repo):
+    def test_remove_fallback_target_is_side_effect_free_for_missing_provider(
+        self, repo, settings_file, monkeypatch
+    ):
+        entry_cls = getattr(_settings_module(), "FallbackTargetEntry")
+        repo.set_fallback_target(
+            entry_cls(
+                provider_id="openai",
+                fallback_provider_id="anthropic",
+                fallback_model_id="claude-sonnet-4",
+            )
+        )
+        before = settings_file.read_text()
+        write_mock = Mock()
+        monkeypatch.setattr(repo, "_write_yaml", write_mock)
+
         assert repo.remove_fallback_target("missing-provider") is False
+        assert settings_file.read_text() == before
+        write_mock.assert_not_called()
 
 
 class TestStrictSchemaValidation:
@@ -207,14 +224,13 @@ class TestStrictSchemaValidation:
 
 
 class TestStrictSettingsWrites:
-    def test_update_settings_preserves_fallback_map_but_removes_auto_save(
-        self, repo, settings_file
+    def test_update_settings_does_not_rewrite_valid_settings_on_no_op_update(
+        self, repo, settings_file, monkeypatch
     ):
         settings_file.parent.mkdir(parents=True, exist_ok=True)
         settings_file.write_text(
             yaml.safe_dump(
                 {
-                    "auto_save": True,
                     "onboarding_completed": False,
                     "fallback_enabled": True,
                     "fallback_map": [
@@ -228,14 +244,18 @@ class TestStrictSettingsWrites:
                 sort_keys=False,
             )
         )
+        before = settings_file.read_text()
+        write_mock = Mock(wraps=repo._write_yaml)
+        monkeypatch.setattr(repo, "_write_yaml", write_mock)
 
-        updated = repo.update_settings({"onboarding_completed": True})
+        updated = repo.update_settings({})
 
-        assert updated.onboarding_completed is True
+        assert updated.onboarding_completed is False
         assert updated.fallback_enabled is True
 
         on_disk = yaml.safe_load(settings_file.read_text())
-        assert on_disk["onboarding_completed"] is True
+        assert settings_file.read_text() == before
+        assert on_disk["onboarding_completed"] is False
         assert on_disk["fallback_enabled"] is True
         assert on_disk["fallback_map"] == [
             {
@@ -244,4 +264,26 @@ class TestStrictSettingsWrites:
                 "fallback_model_id": "claude-sonnet-4",
             }
         ]
-        assert "auto_save" not in on_disk
+        write_mock.assert_not_called()
+
+    def test_update_settings_rejects_auto_save_before_rewriting(
+        self, repo, settings_file, monkeypatch
+    ):
+        settings_file.parent.mkdir(parents=True, exist_ok=True)
+        settings_file.write_text(
+            yaml.safe_dump(
+                {
+                    "auto_save": True,
+                    "onboarding_completed": False,
+                    "fallback_enabled": True,
+                },
+                sort_keys=False,
+            )
+        )
+        write_mock = Mock(wraps=repo._write_yaml)
+        monkeypatch.setattr(repo, "_write_yaml", write_mock)
+
+        with pytest.raises(Exception, match="auto_save"):
+            repo.update_settings({"onboarding_completed": True})
+
+        write_mock.assert_not_called()

--- a/apps/api/tests/unit/data/filesystem/test_settings_repo.py
+++ b/apps/api/tests/unit/data/filesystem/test_settings_repo.py
@@ -61,6 +61,25 @@ class TestFreshInstallDefaults:
         assert isinstance(settings, AppSettingsConfig)
         assert settings.fallback_enabled is False
 
+    def test_present_settings_file_without_fallback_map_is_valid(self, repo, settings_file):
+        settings_file.parent.mkdir(parents=True, exist_ok=True)
+        settings_file.write_text(
+            yaml.safe_dump(
+                {
+                    "onboarding_completed": True,
+                    "fallback_enabled": True,
+                },
+                sort_keys=False,
+            )
+        )
+
+        settings = repo.get_settings()
+
+        assert isinstance(settings, AppSettingsConfig)
+        assert settings.onboarding_completed is True
+        assert settings.fallback_enabled is True
+        assert repo.get_fallback_map() == []
+
     def test_legacy_fallback_repo_methods_are_removed(self, repo):
         assert not hasattr(repo, "get_fallback_chain")
         assert not hasattr(repo, "update_fallback_chain")
@@ -133,6 +152,49 @@ class TestFallbackMapPersistence:
         assert repo.remove_fallback_target("missing-provider") is False
         assert settings_file.read_text() == before
         write_mock.assert_not_called()
+
+    def test_set_fallback_target_preserves_app_settings_buckets(self, repo, settings_file):
+        settings_file.parent.mkdir(parents=True, exist_ok=True)
+        settings_file.write_text(
+            yaml.safe_dump(
+                {
+                    "onboarding_completed": True,
+                    "fallback_enabled": True,
+                    "fallback_map": [
+                        {
+                            "provider_id": "openai",
+                            "fallback_provider_id": "anthropic",
+                            "fallback_model_id": "claude-sonnet-4",
+                        }
+                    ],
+                },
+                sort_keys=False,
+            )
+        )
+        entry_cls = getattr(_settings_module(), "FallbackTargetEntry")
+
+        updated = repo.set_fallback_target(
+            entry_cls(
+                provider_id="openai",
+                fallback_provider_id="google",
+                fallback_model_id="gemini-2.5-pro",
+            )
+        )
+
+        assert updated.provider_id == "openai"
+        assert updated.fallback_provider_id == "google"
+        assert updated.fallback_model_id == "gemini-2.5-pro"
+
+        on_disk = yaml.safe_load(settings_file.read_text())
+        assert on_disk["onboarding_completed"] is True
+        assert on_disk["fallback_enabled"] is True
+        assert on_disk["fallback_map"] == [
+            {
+                "provider_id": "openai",
+                "fallback_provider_id": "google",
+                "fallback_model_id": "gemini-2.5-pro",
+            }
+        ]
 
 
 class TestStrictSchemaValidation:
@@ -224,8 +286,8 @@ class TestStrictSchemaValidation:
 
 
 class TestStrictSettingsWrites:
-    def test_update_settings_does_not_rewrite_valid_settings_on_no_op_update(
-        self, repo, settings_file, monkeypatch
+    def test_update_settings_preserves_valid_fallback_data_when_mutating_app_settings(
+        self, repo, settings_file
     ):
         settings_file.parent.mkdir(parents=True, exist_ok=True)
         settings_file.write_text(
@@ -245,17 +307,15 @@ class TestStrictSettingsWrites:
             )
         )
         before = settings_file.read_text()
-        write_mock = Mock(wraps=repo._write_yaml)
-        monkeypatch.setattr(repo, "_write_yaml", write_mock)
 
-        updated = repo.update_settings({})
+        updated = repo.update_settings({"onboarding_completed": True})
 
-        assert updated.onboarding_completed is False
+        assert updated.onboarding_completed is True
         assert updated.fallback_enabled is True
 
         on_disk = yaml.safe_load(settings_file.read_text())
-        assert settings_file.read_text() == before
-        assert on_disk["onboarding_completed"] is False
+        assert settings_file.read_text() != before
+        assert on_disk["onboarding_completed"] is True
         assert on_disk["fallback_enabled"] is True
         assert on_disk["fallback_map"] == [
             {
@@ -264,7 +324,6 @@ class TestStrictSettingsWrites:
                 "fallback_model_id": "claude-sonnet-4",
             }
         ]
-        write_mock.assert_not_called()
 
     def test_update_settings_rejects_auto_save_before_rewriting(
         self, repo, settings_file, monkeypatch

--- a/apps/api/tests/unit/data/filesystem/test_settings_repo.py
+++ b/apps/api/tests/unit/data/filesystem/test_settings_repo.py
@@ -53,6 +53,10 @@ class TestDomainFoundation:
         assert not hasattr(settings, "default_provider")
         assert not hasattr(settings, "fallback_chain_enabled")
 
+    def test_app_settings_config_rejects_unknown_fields(self):
+        with pytest.raises(Exception, match="auto_save"):
+            AppSettingsConfig(auto_save=True)
+
 
 class TestFreshInstallDefaults:
     def test_get_settings_returns_defaults_for_new_install(self, repo):

--- a/apps/gui/src/api/__tests__/settingsSharedContracts.test.ts
+++ b/apps/gui/src/api/__tests__/settingsSharedContracts.test.ts
@@ -225,7 +225,6 @@ const budgetItemPayload = {
 
 const appSettingsPayload = {
   base_path: "/workspace",
-  auto_save: true,
   onboarding_completed: true,
   fallback_enabled: false,
 };

--- a/apps/gui/src/api/__tests__/settingsSharedContracts.test.ts
+++ b/apps/gui/src/api/__tests__/settingsSharedContracts.test.ts
@@ -520,6 +520,7 @@ describe("RUN-512 settings API canonical shared contracts", () => {
       invoke: (settingsApi) => settingsApi.getAppSettings(),
       assertResult: (result) => {
         expect(result).toEqual(expect.objectContaining(appSettingsPayload));
+        expect(result).not.toHaveProperty("auto_save");
       },
     },
     {
@@ -535,6 +536,7 @@ describe("RUN-512 settings API canonical shared contracts", () => {
         }),
       assertResult: (result) => {
         expect(result).toEqual(expect.objectContaining(appSettingsPayload));
+        expect(result).not.toHaveProperty("auto_save");
       },
     },
     {

--- a/apps/gui/src/components/shared/PriorityBanner.tsx
+++ b/apps/gui/src/components/shared/PriorityBanner.tsx
@@ -34,12 +34,12 @@ function getStoredExploreDismissed() {
     return false;
   }
 
-  const storage = globalThis.localStorage;
-  if (!storage || typeof storage.getItem !== "function") {
+  const localStorage = globalThis.localStorage;
+  if (!localStorage || typeof localStorage.getItem !== "function") {
     return false;
   }
 
-  return storage.getItem(EXPLORE_DISMISS_KEY) === "true";
+  return localStorage.getItem(EXPLORE_DISMISS_KEY) === "true";
 }
 
 function persistExploreDismissed() {
@@ -47,15 +47,15 @@ function persistExploreDismissed() {
     return;
   }
 
-  const storage = globalThis.localStorage;
-  if (!storage || typeof storage.setItem !== "function") {
+  const localStorage = globalThis.localStorage;
+  if (!localStorage || typeof localStorage.setItem !== "function") {
     return;
   }
 
-  storage.setItem(EXPLORE_DISMISS_KEY, "true");
+  localStorage.setItem(EXPLORE_DISMISS_KEY, "true");
 }
 
-  /** Style mapping: explore -> info tokens, uncommitted/regressions -> warning tokens. */
+/** Style mapping: explore -> info tokens, uncommitted/regressions -> warning tokens. */
 const STYLE_MAP: Record<
   BannerCondition["type"],
   { bg: string; border: string; text: string }

--- a/apps/gui/src/features/e2e-audit/__tests__/run742-skip-reduction.test.ts
+++ b/apps/gui/src/features/e2e-audit/__tests__/run742-skip-reduction.test.ts
@@ -143,6 +143,7 @@ describe("AC3 — key files use beforeAll for test data setup", () => {
     const fixtureCreatesViaApi =
       /fetch\(.*\/workflows.*POST/s.test(beforeAllBlock) ||
       /method.*POST[\s\S]*?\/workflows/s.test(beforeAllBlock) ||
+      /apiPost(?:<[^>]+>)?\s*\(\s*["']\/workflows["']/s.test(beforeAllBlock) ||
       // Accept any beforeAll that does a POST (may use a helper)
       /POST/.test(beforeAllBlock);
 

--- a/apps/gui/src/features/runs/RunsPage.tsx
+++ b/apps/gui/src/features/runs/RunsPage.tsx
@@ -96,7 +96,7 @@ export function Component() {
       <PageHeader
         title={getRunsPageTitle({
           workflowFilter,
-          workflowName,
+          workflowName: workflowName ?? undefined,
           attentionOnly,
           activeOnly,
         })}

--- a/apps/gui/src/features/surface/SurfaceBottomPanel.tsx
+++ b/apps/gui/src/features/surface/SurfaceBottomPanel.tsx
@@ -7,6 +7,7 @@ import { useNavigate } from "react-router";
 import { formatRegressionTooltip } from "../workflows/regressionBadge.utils";
 import { RegressionTooltipBody } from "@/components/shared/RegressionTooltipBody";
 import { SurfaceRunsTable } from "./SurfaceRunsTable";
+import type { WorkflowRegression } from "@/types/schemas/regressions";
 
 interface LogEntry {
   timestamp: string | number;
@@ -26,7 +27,7 @@ interface SurfaceBottomPanelProps {
 
 type RegressionsData = {
   count?: number;
-  issues?: Array<Record<string, unknown>>;
+  issues?: WorkflowRegression[];
 };
 
 type SurfaceBottomPanelContentProps = SurfaceBottomPanelProps & {

--- a/apps/gui/src/features/surface/WorkflowSurface.tsx
+++ b/apps/gui/src/features/surface/WorkflowSurface.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { Link } from "react-router";
 import { useQueryClient } from "@tanstack/react-query";
+import type { Node } from "@xyflow/react";
 import type { WorkflowSurfaceProps, WorkflowSurfaceMode } from "./surfaceContract";
 import { getContractForMode, getCanvasYamlToggleVisibility, getSaveButtonState, getActionButton, isEditable } from "./surfaceContract";
 import { SurfaceTopbar } from "./SurfaceTopbar";
@@ -17,7 +18,9 @@ import { EmptyState } from "@runsight/ui/empty-state";
 import { Card } from "@runsight/ui/card";
 import { Button } from "@runsight/ui/button";
 import { LayoutGrid } from "lucide-react";
-import { useCanvasStore } from "@/store/canvas";
+import { useCanvasStore, type PersistedCanvasState } from "@/store/canvas";
+import type { StepNodeData } from "@/types/schemas/canvas";
+import type { WorkflowCanvasState } from "@runsight/shared/zod";
 import {
   useRun,
   useRunNodes,
@@ -29,6 +32,53 @@ import { PriorityBanner } from "@/components/shared";
 import { mapRunStatus } from "./surfaceUtils";
 import { SurfaceInspectorPanel } from "./SurfaceInspectorPanel";
 import { buildWorkflowLayout, hasRenderableCanvasState } from "./workflowLayout";
+
+type RuntimeStepNodeData = StepNodeData & {
+  model?: string;
+  duration?: number;
+  tokens?: { input?: number; output?: number; total?: number };
+  error?: string | null;
+};
+
+const DEFAULT_CANVAS_VIEWPORT = { x: 0, y: 0, zoom: 1 };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizePersistedCanvasState(
+  canvasState: WorkflowCanvasState | PersistedCanvasState | Record<string, unknown> | null | undefined,
+): PersistedCanvasState | null {
+  if (!isRecord(canvasState)) {
+    return null;
+  }
+
+  const viewport = isRecord(canvasState.viewport)
+    && typeof canvasState.viewport.x === "number"
+    && typeof canvasState.viewport.y === "number"
+    && typeof canvasState.viewport.zoom === "number"
+    ? {
+        x: canvasState.viewport.x,
+        y: canvasState.viewport.y,
+        zoom: canvasState.viewport.zoom,
+      }
+    : DEFAULT_CANVAS_VIEWPORT;
+
+  return {
+    nodes: Array.isArray(canvasState.nodes)
+      ? canvasState.nodes.filter(isRecord)
+      : [],
+    edges: Array.isArray(canvasState.edges)
+      ? canvasState.edges.filter(isRecord)
+      : [],
+    viewport,
+    selected_node_id:
+      typeof canvasState.selected_node_id === "string"
+        ? canvasState.selected_node_id
+        : null,
+    canvas_mode: canvasState.canvas_mode === "state-machine" ? "state-machine" : "dag",
+  };
+}
 
 function RunGraphErrorCard({
   message,
@@ -253,7 +303,8 @@ export function WorkflowSurface({ mode: initialMode, workflowId: initialWorkflow
 
     setYamlContent(preferredYaml);
 
-    const renderableCanvasState = hasRenderableCanvasState(workflow?.canvas_state);
+    const persistedCanvasState = normalizePersistedCanvasState(workflow?.canvas_state);
+    const renderableCanvasState = hasRenderableCanvasState(persistedCanvasState);
     const hydrationKind = renderableCanvasState ? "persisted" : "computed";
     const yamlKind =
       mode === "readonly"
@@ -272,16 +323,9 @@ export function WorkflowSurface({ mode: initialMode, workflowId: initialWorkflow
     }
 
     if (renderableCanvasState) {
-      hydrateFromPersisted({
-        nodes: workflow.canvas_state.nodes ?? [],
-        edges: workflow.canvas_state.edges ?? [],
-        viewport: workflow.canvas_state.viewport ?? { x: 0, y: 0, zoom: 1 },
-        selected_node_id: workflow.canvas_state.selected_node_id ?? null,
-        canvas_mode:
-          workflow.canvas_state.canvas_mode === "state-machine" ? "state-machine" : "dag",
-      });
+      hydrateFromPersisted(persistedCanvasState);
     } else {
-      hydrateFromPersisted(buildWorkflowLayout(preferredYaml, workflow?.canvas_state ?? null));
+      hydrateFromPersisted(buildWorkflowLayout(preferredYaml, persistedCanvasState));
     }
 
     setCanvasHydrationRevision((revision) => revision + 1);
@@ -366,7 +410,7 @@ export function WorkflowSurface({ mode: initialMode, workflowId: initialWorkflow
   }, [canvasHydrationRevision, mode, nodes.length, runNodes, setNodeStatus]);
 
   const selectedNode = inspectedNodeId
-    ? (nodes.find((node) => node.id === inspectedNodeId) ?? null)
+    ? ((nodes.find((node) => node.id === inspectedNodeId) as Node<RuntimeStepNodeData> | undefined) ?? null)
     : null;
   const showRunGraphError =
     mode === "readonly" && activeTab === "canvas" && Boolean(isRunNodesError);
@@ -416,9 +460,12 @@ export function WorkflowSurface({ mode: initialMode, workflowId: initialWorkflow
   const actionButton = mode === "edit" ? undefined : getActionButton(mode);
 
   const canvasStoreState = useCanvasStore.getState();
+  const draftCanvasState = editable ? toPersistedState() : undefined;
   const currentDraft = {
     yaml: canvasStoreState.yamlContent,
-    canvas_state: editable ? toPersistedState() : undefined,
+    canvas_state: draftCanvasState
+      ? (draftCanvasState as unknown as Record<string, unknown>)
+      : undefined,
   };
   const currentFiles: { path: string; status: string }[] = [
     { path: `custom/workflows/${resolvedWorkflowId}.yaml`, status: "modified" },

--- a/apps/gui/src/features/surface/nodes/SoulNode.tsx
+++ b/apps/gui/src/features/surface/nodes/SoulNode.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { memo, type NodeProps } from "react";
-import type { Node } from "@xyflow/react";
+import { memo } from "react";
+import type { Node, NodeProps } from "@xyflow/react";
 import type { StepNodeData } from "@/types/schemas/canvas";
 import { SurfaceNodeCard } from "./SurfaceNodeCard";
 

--- a/apps/gui/src/features/surface/nodes/StartNode.tsx
+++ b/apps/gui/src/features/surface/nodes/StartNode.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { memo, type NodeProps } from "react";
-import type { Node } from "@xyflow/react";
+import { memo } from "react";
+import type { Node, NodeProps } from "@xyflow/react";
 import type { StepNodeData } from "@/types/schemas/canvas";
 import { SurfaceNodeCard } from "./SurfaceNodeCard";
 

--- a/apps/gui/src/features/surface/nodes/SurfaceNodeCard.tsx
+++ b/apps/gui/src/features/surface/nodes/SurfaceNodeCard.tsx
@@ -1,20 +1,21 @@
 "use client";
 
 import { memo, useCallback } from "react";
-import { Handle, Position, type NodeProps } from "@xyflow/react";
+import { Handle, Position } from "@xyflow/react";
 import { Layers, Layers2, Mail, Server, User } from "lucide-react";
 
 import { StatusBadge } from "@/components/shared/StatusBadge";
 import { useCanvasStore } from "@/store/canvas";
 import { cn } from "@runsight/ui/utils";
-import type { Node } from "@xyflow/react";
 import type { StepNodeData } from "@/types/schemas/canvas";
 import { getIconForBlockType } from "../surfaceUtils";
 
 type SurfaceNodeKind = "start" | "task" | "soul";
-type SurfaceNodeType = Node<StepNodeData, SurfaceNodeKind>;
 
-interface SurfaceNodeCardProps extends NodeProps<SurfaceNodeType> {
+interface SurfaceNodeCardProps {
+  id: string;
+  data: StepNodeData;
+  selected?: boolean;
   kind: SurfaceNodeKind;
 }
 
@@ -110,6 +111,10 @@ function SurfaceNodeCardComponent({
   const { variant, label } = mapNodeStatus(status);
   const icon = getNodeIcon(getIconForBlockType(String(data.stepType ?? kind)));
   const title = String(data.name ?? data.stepId ?? "Untitled");
+  const tokens =
+    typeof data.tokens === "object" && data.tokens !== null
+      ? (data.tokens as { total?: number })
+      : undefined;
 
   return (
     <div
@@ -182,12 +187,12 @@ function SurfaceNodeCardComponent({
         </div>
       </div>
 
-      {(typeof data.duration === "number" || data.tokens) && (
+      {(typeof data.duration === "number" || tokens) && (
         <div className="border-t border-[var(--border-default)] px-3 py-1.5 text-xs text-[var(--text-muted)]">
           {typeof data.duration === "number" ? `${data.duration.toFixed(1)}s` : ""}
-          {typeof data.duration === "number" && data.tokens ? " • " : ""}
-          {typeof data.tokens?.total === "number"
-            ? `${data.tokens.total.toLocaleString()} tokens`
+          {typeof data.duration === "number" && tokens ? " • " : ""}
+          {typeof tokens?.total === "number"
+            ? `${tokens.total.toLocaleString()} tokens`
             : ""}
         </div>
       )}

--- a/apps/gui/src/features/surface/nodes/TaskNode.tsx
+++ b/apps/gui/src/features/surface/nodes/TaskNode.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { memo, type NodeProps } from "react";
-import type { Node } from "@xyflow/react";
+import { memo } from "react";
+import type { Node, NodeProps } from "@xyflow/react";
 import type { StepNodeData } from "@/types/schemas/canvas";
 import { SurfaceNodeCard } from "./SurfaceNodeCard";
 

--- a/apps/site/src/content/docs/docs/configuration/settings.md
+++ b/apps/site/src/content/docs/docs/configuration/settings.md
@@ -11,7 +11,6 @@ Application settings are stored in `.runsight/settings.yaml`. This file is creat
 |-------|------|---------|-------------|
 | `onboarding_completed` | `bool` | `false` | Whether the first-time setup flow has been completed. Controls whether the app redirects to the setup screen. |
 | `fallback_enabled` | `bool` | `false` | Whether runtime fallback is active. See [Fallback](/docs/configuration/fallback). |
-| `auto_save` | `bool \| null` | `null` | Auto-save preference (reserved for future use). |
 
 ## Fallback map
 

--- a/openapi.json
+++ b/openapi.json
@@ -2136,7 +2136,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/AppSettingsOut"
+                "$ref": "#/components/schemas/AppSettingsUpdate"
               }
             }
           },
@@ -2644,6 +2644,59 @@
           }
         }
       }
+    },
+    "/runsight.svg": {
+      "get": {
+        "summary": " Favicon",
+        "operationId": "_favicon_runsight_svg_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/{full_path}": {
+      "get": {
+        "summary": " Spa Catch All",
+        "operationId": "_spa_catch_all__full_path__get",
+        "parameters": [
+          {
+            "name": "full_path",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Full Path"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -2660,17 +2713,6 @@
               }
             ],
             "title": "Base Path"
-          },
-          "auto_save": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Auto Save"
           },
           "onboarding_completed": {
             "anyOf": [
@@ -2697,6 +2739,35 @@
         },
         "type": "object",
         "title": "AppSettingsOut"
+      },
+      "AppSettingsUpdate": {
+        "properties": {
+          "onboarding_completed": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Onboarding Completed"
+          },
+          "fallback_enabled": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fallback Enabled"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "title": "AppSettingsUpdate"
       },
       "AttentionItem": {
         "properties": {

--- a/openapi.json
+++ b/openapi.json
@@ -3966,7 +3966,8 @@
                 "type": "null"
               }
             ],
-            "title": "Regression Count"
+            "title": "Regression Count",
+            "default": 0
           },
           "regression_types": {
             "items": {

--- a/openapi.json
+++ b/openapi.json
@@ -2715,25 +2715,11 @@
             "title": "Base Path"
           },
           "onboarding_completed": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "type": "boolean",
             "title": "Onboarding Completed"
           },
           "fallback_enabled": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "type": "boolean",
             "title": "Fallback Enabled"
           }
         },
@@ -2743,25 +2729,11 @@
       "AppSettingsUpdate": {
         "properties": {
           "onboarding_completed": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "type": "boolean",
             "title": "Onboarding Completed"
           },
           "fallback_enabled": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "type": "boolean",
             "title": "Fallback Enabled"
           }
         },

--- a/openapi.json
+++ b/openapi.json
@@ -3354,6 +3354,7 @@
             "title": "Base Url"
           }
         },
+        "additionalProperties": false,
         "type": "object",
         "required": [
           "name"
@@ -3532,6 +3533,7 @@
             "title": "Is Active"
           }
         },
+        "additionalProperties": false,
         "type": "object",
         "title": "ProviderUpdate"
       },
@@ -4869,6 +4871,7 @@
             "title": "Description"
           }
         },
+        "additionalProperties": false,
         "type": "object",
         "required": [
           "name"
@@ -4971,6 +4974,7 @@
             "title": "Description"
           }
         },
+        "additionalProperties": false,
         "type": "object",
         "title": "StepUpdate"
       },
@@ -5008,6 +5012,7 @@
             "title": "Description"
           }
         },
+        "additionalProperties": false,
         "type": "object",
         "required": [
           "name"
@@ -5110,6 +5115,7 @@
             "title": "Description"
           }
         },
+        "additionalProperties": false,
         "type": "object",
         "title": "TaskUpdate"
       },

--- a/packages/core/src/runsight_core/blocks/_registry.py
+++ b/packages/core/src/runsight_core/blocks/_registry.py
@@ -33,7 +33,16 @@ def register_block_def(block_type: str, def_cls: Type["Any"]) -> None:
 
 
 def register_block_builder(block_type: str, builder: Callable) -> None:
-    """Register a builder callable for *block_type*."""
+    """Register a builder callable for *block_type*.
+
+    Raises ``ValueError`` if *block_type* is already registered with a
+    **different** callable (re-registering the same callable is idempotent).
+    """
+    existing = BLOCK_BUILDER_REGISTRY.get(block_type)
+    if existing is not None and existing is not builder:
+        raise ValueError(
+            f"Duplicate block-builder registration for '{block_type}': {existing!r} vs {builder!r}"
+        )
     BLOCK_BUILDER_REGISTRY[block_type] = builder
 
 

--- a/packages/core/src/runsight_core/blocks/code.py
+++ b/packages/core/src/runsight_core/blocks/code.py
@@ -334,6 +334,7 @@ def build(
     souls_map: Dict[str, Any],
     runner: Any,
     all_blocks: Dict[str, Any],
+    **_: Any,
 ) -> CodeBlock:
     """Build a CodeBlock from a block definition."""
     if not block_def.code:

--- a/packages/core/src/runsight_core/blocks/dispatch.py
+++ b/packages/core/src/runsight_core/blocks/dispatch.py
@@ -219,6 +219,7 @@ def build(
     souls_map: Dict[str, Any],
     runner: Any,
     all_blocks: Dict[str, Any],
+    **_: Any,
 ) -> DispatchBlock:
     """Build a DispatchBlock from a block definition."""
     if not block_def.exits:

--- a/packages/core/src/runsight_core/blocks/gate.py
+++ b/packages/core/src/runsight_core/blocks/gate.py
@@ -169,6 +169,7 @@ def build(
     souls_map: Dict[str, Any],
     runner: Any,
     all_blocks: Dict[str, Any],
+    **_: Any,
 ) -> GateBlock:
     """Build a GateBlock from a block definition."""
     if block_def.soul_ref is None:

--- a/packages/core/src/runsight_core/blocks/linear.py
+++ b/packages/core/src/runsight_core/blocks/linear.py
@@ -112,6 +112,7 @@ def build(
     souls_map: Dict[str, Any],
     runner: Any,
     all_blocks: Dict[str, Any],
+    **_: Any,
 ) -> LinearBlock:
     """Build a LinearBlock from a block definition."""
     if block_def.soul_ref is None:

--- a/packages/core/src/runsight_core/blocks/loop.py
+++ b/packages/core/src/runsight_core/blocks/loop.py
@@ -294,6 +294,7 @@ def build(
     souls_map: Dict[str, Any],
     runner: Any,
     all_blocks: Dict[str, Any],
+    **_: Any,
 ) -> LoopBlock:
     """Build a LoopBlock from a block definition."""
     break_condition = None

--- a/packages/core/src/runsight_core/blocks/synthesize.py
+++ b/packages/core/src/runsight_core/blocks/synthesize.py
@@ -119,6 +119,7 @@ def build(
     souls_map: Dict[str, Any],
     runner: Any,
     all_blocks: Dict[str, Any],
+    **_: Any,
 ) -> SynthesizeBlock:
     """Build a SynthesizeBlock from a block definition."""
     if block_def.soul_ref is None:

--- a/packages/core/src/runsight_core/blocks/workflow_block.py
+++ b/packages/core/src/runsight_core/blocks/workflow_block.py
@@ -401,17 +401,54 @@ def build(
     souls_map: Dict[str, Any],
     runner: Any,
     all_blocks: Dict[str, Any],
+    *,
+    workflow_registry: "WorkflowRegistry" | None = None,
+    api_keys: Dict[str, str] | None = None,
+    workflow_base_dir: str = ".",
+    parent_file_def: Any | None = None,
+    **_: Any,
 ) -> WorkflowBlock:
-    """Build a WorkflowBlock from a block definition.
+    """Build a WorkflowBlock from a block definition."""
+    if getattr(block_def, "workflow_ref", None) is None:
+        raise ValueError(f"WorkflowBlock '{block_id}': workflow_ref is required")
+    if workflow_registry is None:
+        raise ValueError(
+            f"WorkflowBlock '{block_id}': workflow_registry must be provided "
+            "when building workflow blocks"
+        )
 
-    Note: In practice, the workflow block is handled as a special case in
-    parse_workflow_yaml because it requires a WorkflowRegistry for recursive
-    parsing. This build() function exists for API consistency and can be
-    used when the child_workflow is already resolved.
-    """
-    raise NotImplementedError(
-        f"WorkflowBlock '{block_id}' must be built via the special-case "
-        f"handler in parse_workflow_yaml, not via the generic builder registry."
+    # Import parser helpers lazily to keep block registration free of parser cycles.
+    from runsight_core.yaml.parser import (
+        _resolve_workflow_block_max_depth,
+        _validate_workflow_block_contract,
+        parse_workflow_yaml,
+    )
+
+    child_file = workflow_registry.get(block_def.workflow_ref)
+    _validate_workflow_block_contract(block_id, block_def, child_file)
+
+    child_raw = child_file.model_dump() if hasattr(child_file, "model_dump") else child_file
+    child_wf = parse_workflow_yaml(
+        child_raw,
+        workflow_registry=workflow_registry,
+        api_keys=api_keys,
+        _base_dir=workflow_base_dir,
+    )
+
+    max_depth = (
+        _resolve_workflow_block_max_depth(parent_file_def, block_def)
+        if parent_file_def is not None
+        else block_def.max_depth or 10
+    )
+    return WorkflowBlock(
+        block_id=block_id,
+        child_workflow=child_wf,
+        inputs=block_def.inputs or {},
+        outputs=block_def.outputs or {},
+        workflow_ref=block_def.workflow_ref,
+        max_depth=max_depth,
+        interface=child_file.interface,
+        on_error=block_def.on_error,
     )
 
 

--- a/packages/core/src/runsight_core/blocks/workflow_block.py
+++ b/packages/core/src/runsight_core/blocks/workflow_block.py
@@ -17,7 +17,7 @@ from runsight_core.state import BlockResult, WorkflowState
 if TYPE_CHECKING:
     from runsight_core.workflow import Workflow
     from runsight_core.yaml.registry import WorkflowRegistry
-    from runsight_core.yaml.schema import WorkflowInterfaceDef
+    from runsight_core.yaml.schema import RunsightWorkflowFile, WorkflowInterfaceDef
 
 
 class WorkflowBlock(BaseBlock):
@@ -392,6 +392,56 @@ from runsight_core.blocks._registry import register_block_def as _register_block
 _register_block_def("workflow", WorkflowBlockDef)
 
 
+def _validate_workflow_block_contract(
+    block_id: str,
+    block_def: Any,
+    child_file: "RunsightWorkflowFile",
+) -> None:
+    child_interface = child_file.interface
+    if child_interface is None:
+        raise ValueError(
+            f"WorkflowBlock '{block_id}': child workflow '{block_def.workflow_ref}' "
+            "must declare an interface"
+        )
+
+    declared_inputs = {item.name: item for item in child_interface.inputs}
+    declared_outputs = {item.name for item in child_interface.outputs}
+
+    for binding_name in (block_def.inputs or {}).keys():
+        if binding_name not in declared_inputs:
+            raise ValueError(
+                f"WorkflowBlock '{block_id}': unknown interface input '{binding_name}'. "
+                f"Declared child inputs: {sorted(declared_inputs)}"
+            )
+
+    missing_required = [
+        item.name
+        for item in child_interface.inputs
+        if item.required and item.default is None and item.name not in (block_def.inputs or {})
+    ]
+    if missing_required:
+        raise ValueError(
+            f"WorkflowBlock '{block_id}': missing required interface inputs {missing_required}"
+        )
+
+    for binding_name in (block_def.outputs or {}).values():
+        if binding_name not in declared_outputs:
+            raise ValueError(
+                f"WorkflowBlock '{block_id}': unknown interface output '{binding_name}'. "
+                f"Declared child outputs: {sorted(declared_outputs)}"
+            )
+
+
+def _resolve_workflow_block_max_depth(
+    file_def: Any,
+    block_def: Any,
+) -> int:
+    """Resolve the max_depth value a workflow block will enforce at runtime."""
+    if block_def.max_depth is not None:
+        return block_def.max_depth
+    return file_def.config.get("max_workflow_depth", 10)
+
+
 # -- Builder function --------------------------------------------------------
 
 
@@ -417,12 +467,8 @@ def build(
             "when building workflow blocks"
         )
 
-    # Import parser helpers lazily to keep block registration free of parser cycles.
-    from runsight_core.yaml.parser import (
-        _resolve_workflow_block_max_depth,
-        _validate_workflow_block_contract,
-        parse_workflow_yaml,
-    )
+    # Import the parser lazily to keep block registration free of parser cycles.
+    from runsight_core.yaml.parser import parse_workflow_yaml
 
     child_file = workflow_registry.get(block_def.workflow_ref)
     _validate_workflow_block_contract(block_id, block_def, child_file)

--- a/packages/core/src/runsight_core/yaml/parser.py
+++ b/packages/core/src/runsight_core/yaml/parser.py
@@ -643,53 +643,6 @@ def parse_workflow_yaml(
     # Step 5: Build all blocks (single pass)
     built_blocks: Dict[str, BaseBlock] = {}
     for block_id, block_def in file_def.blocks.items():
-        # Special case: WorkflowBlock (type: workflow)
-        # Handle before registry lookup to avoid "unknown type" error
-        if block_def.type == "workflow":
-            # Validate workflow_ref field (redundant check — already enforced by BlockDef validator)
-            if block_def.workflow_ref is None:
-                raise ValueError(f"WorkflowBlock '{block_id}': workflow_ref is required")
-
-            # Require workflow_registry parameter
-            if workflow_registry is None:
-                raise ValueError(
-                    f"WorkflowBlock '{block_id}': a WorkflowRegistry must be provided "
-                    f"to parse_workflow_yaml() when workflow blocks are used. "
-                    f"Pass workflow_registry=... parameter."
-                )
-
-            # Resolve child workflow file (registry returns RunsightWorkflowFile)
-            child_file = workflow_registry.get(block_def.workflow_ref)
-            _validate_workflow_block_contract(block_id, block_def, child_file)
-
-            # Normalize to dict so parse_workflow_yaml receives Union[str, Dict] not model instance
-            child_raw = child_file.model_dump() if hasattr(child_file, "model_dump") else child_file
-
-            # Recursively parse child workflow (passes registry + base_dir for nested workflows)
-            child_wf = parse_workflow_yaml(
-                child_raw,
-                workflow_registry=workflow_registry,
-                api_keys=api_keys,
-                _base_dir=workflow_base_dir,
-            )
-
-            # Instantiate WorkflowBlock
-            from runsight_core.blocks.workflow_block import WorkflowBlock
-
-            block = WorkflowBlock(
-                block_id=block_id,
-                child_workflow=child_wf,
-                inputs=block_def.inputs or {},
-                outputs=block_def.outputs or {},
-                workflow_ref=block_def.workflow_ref,
-                max_depth=_resolve_workflow_block_max_depth(file_def, block_def),
-                interface=child_file.interface,
-                on_error=block_def.on_error,
-            )
-
-            built_blocks[block_id] = block
-            continue  # Skip registry lookup
-
         from runsight_core.blocks._registry import get_builder
 
         builder = get_builder(block_def.type)
@@ -700,7 +653,17 @@ def parse_workflow_yaml(
                 f"Unknown block type '{block_def.type}' for block '{block_id}'. "
                 f"Available types: {sorted(BLOCK_BUILDER_REGISTRY.keys())}"
             )
-        built_blocks[block_id] = builder(block_id, block_def, souls_map, runner, built_blocks)
+        built_blocks[block_id] = builder(
+            block_id,
+            block_def,
+            souls_map,
+            runner,
+            built_blocks,
+            workflow_registry=workflow_registry,
+            api_keys=api_keys,
+            workflow_base_dir=workflow_base_dir,
+            parent_file_def=file_def,
+        )
 
     # Step 6.2: Bridge _declared_exits from schema to runtime blocks
     for block_id, block_def in file_def.blocks.items():

--- a/packages/core/src/runsight_core/yaml/parser.py
+++ b/packages/core/src/runsight_core/yaml/parser.py
@@ -386,45 +386,10 @@ from runsight_core.yaml.schema import rebuild_block_def_union as _rebuild  # noq
 _rebuild()
 del _rebuild
 
-
-def _validate_workflow_block_contract(
-    block_id: str,
-    block_def: Any,
-    child_file: RunsightWorkflowFile,
-) -> None:
-    child_interface = child_file.interface
-    if child_interface is None:
-        raise ValueError(
-            f"WorkflowBlock '{block_id}': child workflow '{block_def.workflow_ref}' "
-            "must declare an interface"
-        )
-
-    declared_inputs = {item.name: item for item in child_interface.inputs}
-    declared_outputs = {item.name for item in child_interface.outputs}
-
-    for binding_name in (block_def.inputs or {}).keys():
-        if binding_name not in declared_inputs:
-            raise ValueError(
-                f"WorkflowBlock '{block_id}': unknown interface input '{binding_name}'. "
-                f"Declared child inputs: {sorted(declared_inputs)}"
-            )
-
-    missing_required = [
-        item.name
-        for item in child_interface.inputs
-        if item.required and item.default is None and item.name not in (block_def.inputs or {})
-    ]
-    if missing_required:
-        raise ValueError(
-            f"WorkflowBlock '{block_id}': missing required interface inputs {missing_required}"
-        )
-
-    for binding_name in (block_def.outputs or {}).values():
-        if binding_name not in declared_outputs:
-            raise ValueError(
-                f"WorkflowBlock '{block_id}': unknown interface output '{binding_name}'. "
-                f"Declared child outputs: {sorted(declared_outputs)}"
-            )
+from runsight_core.blocks.workflow_block import (  # noqa: E402
+    _resolve_workflow_block_max_depth,
+    _validate_workflow_block_contract,
+)
 
 
 def _validate_workflow_block_runtime_placement(
@@ -434,16 +399,6 @@ def _validate_workflow_block_runtime_placement(
 ) -> None:
     """Reserved hook for workflow/loop placement validation."""
     return None
-
-
-def _resolve_workflow_block_max_depth(
-    file_def: RunsightWorkflowFile,
-    block_def: Any,
-) -> int:
-    """Resolve the max_depth value a workflow block will enforce at runtime."""
-    if block_def.max_depth is not None:
-        return block_def.max_depth
-    return file_def.config.get("max_workflow_depth", 10)
 
 
 def validate_workflow_call_contracts(

--- a/packages/core/tests/test_run219_auto_registration.py
+++ b/packages/core/tests/test_run219_auto_registration.py
@@ -101,6 +101,44 @@ class TestBlockDefRegistry:
         # Cleanup
         BLOCK_BUILDER_REGISTRY.pop("test_builder_type", None)
 
+    def test_register_block_builder_is_idempotent_for_same_callable(self):
+        """register_block_builder permits re-registering the same callable."""
+        from runsight_core.blocks._registry import (
+            BLOCK_BUILDER_REGISTRY,
+            register_block_builder,
+        )
+
+        def fake_builder():
+            pass
+
+        try:
+            register_block_builder("same_builder_type", fake_builder)
+            register_block_builder("same_builder_type", fake_builder)
+            assert BLOCK_BUILDER_REGISTRY.get("same_builder_type") is fake_builder
+        finally:
+            BLOCK_BUILDER_REGISTRY.pop("same_builder_type", None)
+
+    def test_register_block_builder_rejects_different_duplicate(self):
+        """register_block_builder rejects silent builder replacement."""
+        from runsight_core.blocks._registry import (
+            BLOCK_BUILDER_REGISTRY,
+            register_block_builder,
+        )
+
+        def first_builder():
+            pass
+
+        def second_builder():
+            pass
+
+        try:
+            register_block_builder("conflicting_builder_type", first_builder)
+            with pytest.raises(ValueError, match="Duplicate block-builder registration"):
+                register_block_builder("conflicting_builder_type", second_builder)
+            assert BLOCK_BUILDER_REGISTRY.get("conflicting_builder_type") is first_builder
+        finally:
+            BLOCK_BUILDER_REGISTRY.pop("conflicting_builder_type", None)
+
     def test_get_all_block_types_returns_dict(self):
         """get_all_block_types() returns a dict snapshot of registered types."""
         from runsight_core.blocks._registry import get_all_block_types

--- a/packages/core/tests/test_run774_workflow_block_builder_path.py
+++ b/packages/core/tests/test_run774_workflow_block_builder_path.py
@@ -1,0 +1,189 @@
+"""
+Failing tests for RUN-774: route workflow blocks through the registered builder.
+
+These tests pin the remaining actionable debt in the workflow-block parser path:
+- parse_workflow_yaml should use the registered "workflow" builder, not a parser-only special case
+- the registered builder should be able to construct a real WorkflowBlock when given parser context
+- missing WorkflowRegistry should fail with an actionable ValueError from the builder path
+- workflow blocks referenced from LoopBlock.inner_block_refs should still come through the builder path
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from runsight_core import LoopBlock, WorkflowBlock
+from runsight_core.blocks._registry import BLOCK_BUILDER_REGISTRY
+from runsight_core.workflow import Workflow
+from runsight_core.yaml.parser import parse_workflow_yaml
+from runsight_core.yaml.registry import WorkflowRegistry
+from runsight_core.yaml.schema import RunsightWorkflowFile
+
+_EMPTY_INTERFACE = {"inputs": [], "outputs": []}
+
+
+def _child_workflow_file() -> RunsightWorkflowFile:
+    child_dict = {
+        "version": "1.0",
+        "interface": _EMPTY_INTERFACE,
+        "blocks": {
+            "child_step": {
+                "type": "code",
+                "code": "def main(data):\n    return {'child_step': 'done'}",
+            }
+        },
+        "workflow": {
+            "name": "child_workflow",
+            "entry": "child_step",
+            "transitions": [{"from": "child_step", "to": None}],
+        },
+    }
+    return RunsightWorkflowFile.model_validate(child_dict)
+
+
+def _parent_workflow_dict() -> dict[str, Any]:
+    return {
+        "version": "1.0",
+        "config": {
+            "max_workflow_depth": 7,
+        },
+        "blocks": {
+            "invoke_child": {
+                "type": "workflow",
+                "workflow_ref": "child_workflow",
+            },
+            "loop_block": {
+                "type": "loop",
+                "inner_block_refs": ["invoke_child"],
+                "max_rounds": 1,
+            },
+        },
+        "workflow": {
+            "name": "parent_workflow",
+            "entry": "invoke_child",
+            "transitions": [
+                {"from": "invoke_child", "to": "loop_block"},
+                {"from": "loop_block", "to": None},
+            ],
+        },
+    }
+
+
+def test_parse_workflow_yaml_routes_workflow_blocks_through_registered_builder_even_inside_loops(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Parsing should invoke the registered workflow builder instead of a parser special case."""
+    child_file = _child_workflow_file()
+    registry = WorkflowRegistry(allow_filesystem_fallback=False)
+    registry.register("child_workflow", child_file)
+
+    calls: list[dict[str, Any]] = []
+
+    def spy_builder(
+        block_id: str,
+        block_def: Any,
+        souls_map: dict[str, Any],
+        runner: Any,
+        all_blocks: dict[str, Any],
+        **parser_context: Any,
+    ) -> WorkflowBlock:
+        calls.append(
+            {
+                "block_id": block_id,
+                "block_def": block_def,
+                "souls_map": souls_map,
+                "runner": runner,
+                "all_blocks": dict(all_blocks),
+                "parser_context": parser_context,
+            }
+        )
+        child_workflow = parse_workflow_yaml(
+            child_file.model_dump(),
+            workflow_registry=parser_context["workflow_registry"],
+            api_keys=parser_context.get("api_keys"),
+            _base_dir=parser_context["workflow_base_dir"],
+        )
+        parent_file_def = parser_context["parent_file_def"]
+        max_depth = (
+            block_def.max_depth
+            if block_def.max_depth is not None
+            else parent_file_def.config.get("max_workflow_depth", 10)
+        )
+        return WorkflowBlock(
+            block_id=block_id,
+            child_workflow=child_workflow,
+            inputs=block_def.inputs or {},
+            outputs=block_def.outputs or {},
+            workflow_ref=block_def.workflow_ref,
+            max_depth=max_depth,
+            interface=child_file.interface,
+            on_error=block_def.on_error,
+        )
+
+    monkeypatch.setitem(BLOCK_BUILDER_REGISTRY, "workflow", spy_builder)
+
+    parent_workflow = parse_workflow_yaml(
+        _parent_workflow_dict(),
+        workflow_registry=registry,
+        _base_dir=str(tmp_path),
+    )
+
+    assert calls, "parse_workflow_yaml did not call the registered workflow builder"
+    assert isinstance(parent_workflow, Workflow)
+    assert isinstance(parent_workflow.blocks["invoke_child"], WorkflowBlock)
+    assert parent_workflow.blocks["invoke_child"].child_workflow.name == "child_workflow"
+    assert isinstance(parent_workflow.blocks["loop_block"], LoopBlock)
+    assert parent_workflow.blocks["loop_block"].inner_block_refs == ["invoke_child"]
+
+
+def test_registered_workflow_builder_accepts_parser_context_and_builds_real_workflow_block(
+    tmp_path: Path,
+) -> None:
+    """The registered workflow builder should build a real WorkflowBlock with parser context."""
+    child_file = _child_workflow_file()
+    registry = WorkflowRegistry(allow_filesystem_fallback=False)
+    registry.register("child_workflow", child_file)
+    parent_file = RunsightWorkflowFile.model_validate(_parent_workflow_dict())
+    block_def = parent_file.blocks["invoke_child"]
+    builder = BLOCK_BUILDER_REGISTRY["workflow"]
+
+    block = builder(
+        "invoke_child",
+        block_def,
+        {},
+        MagicMock(),
+        {},
+        workflow_registry=registry,
+        api_keys={},
+        workflow_base_dir=str(tmp_path),
+        parent_file_def=parent_file,
+    )
+
+    assert isinstance(block, WorkflowBlock)
+    assert block.child_workflow.name == "child_workflow"
+    assert block.workflow_ref == "child_workflow"
+    assert block.max_depth == 7
+
+
+def test_registered_workflow_builder_requires_workflow_registry_with_actionable_value_error(
+    tmp_path: Path,
+) -> None:
+    """The builder should fail explicitly when workflow_registry is missing."""
+    parent_file = RunsightWorkflowFile.model_validate(_parent_workflow_dict())
+    block_def = parent_file.blocks["invoke_child"]
+    builder = BLOCK_BUILDER_REGISTRY["workflow"]
+
+    with pytest.raises(ValueError, match="WorkflowRegistry|workflow_registry|registry"):
+        builder(
+            "invoke_child",
+            block_def,
+            {},
+            MagicMock(),
+            {},
+            api_keys={},
+            workflow_base_dir=str(tmp_path),
+            parent_file_def=parent_file,
+        )

--- a/packages/shared/src/__tests__/codegen.test.ts
+++ b/packages/shared/src/__tests__/codegen.test.ts
@@ -425,6 +425,75 @@ describe("RUN-477: generated API types stay aligned for soul contracts", () => {
   });
 });
 
+describe("RUN-823: custom YAML request schemas are strict", () => {
+  const openapi = JSON.parse(readFileSync(resolve(REPO_ROOT, "openapi.json"), "utf8"));
+
+  it.each([
+    "SoulCreate",
+    "SoulUpdate",
+    "TaskCreate",
+    "TaskUpdate",
+    "StepCreate",
+    "StepUpdate",
+    "ProviderCreate",
+    "ProviderUpdate",
+  ])("%s OpenAPI schema forbids unknown fields", (schemaName) => {
+    const schema = openapi.components?.schemas?.[schemaName];
+    expect(schema).toBeDefined();
+    expect(schema.additionalProperties).toBe(false);
+  });
+
+  it("generated request Zod schemas reject unknown fields", async () => {
+    const mod = await import("../zod");
+
+    expect(
+      mod.SoulCreateSchema.safeParse({
+        role: "Reviewer",
+        system_prompt: "Review",
+        custom_notes: "unsupported",
+      }).success,
+    ).toBe(false);
+    expect(
+      mod.SoulUpdateSchema.safeParse({
+        custom_notes: "unsupported",
+      }).success,
+    ).toBe(false);
+    expect(
+      mod.TaskCreateSchema.safeParse({
+        name: "Task",
+        custom_notes: "unsupported",
+      }).success,
+    ).toBe(false);
+    expect(
+      mod.TaskUpdateSchema.safeParse({
+        custom_notes: "unsupported",
+      }).success,
+    ).toBe(false);
+    expect(
+      mod.StepCreateSchema.safeParse({
+        name: "Step",
+        custom_notes: "unsupported",
+      }).success,
+    ).toBe(false);
+    expect(
+      mod.StepUpdateSchema.safeParse({
+        custom_notes: "unsupported",
+      }).success,
+    ).toBe(false);
+    expect(
+      mod.ProviderCreateSchema.safeParse({
+        name: "OpenAI",
+        custom_notes: "unsupported",
+      }).success,
+    ).toBe(false);
+    expect(
+      mod.ProviderUpdateSchema.safeParse({
+        custom_notes: "unsupported",
+      }).success,
+    ).toBe(false);
+  });
+});
+
 // ---------------------------------------------------------------------------
 // 4. package.json has codegen scripts
 // ---------------------------------------------------------------------------

--- a/packages/shared/src/__tests__/codegen.test.ts
+++ b/packages/shared/src/__tests__/codegen.test.ts
@@ -50,7 +50,7 @@ function extractApiComponentFieldNames(source: string, componentName: string): s
 
 function extractSchemaFieldNames(source: string, schemaName: string): string[] {
   const pattern = new RegExp(
-    `export const ${schemaName}Schema = z\\.object\\(\\{([\\s\\S]*?)\\n\\}\\);`,
+    `export const ${schemaName}Schema = z\\.object\\(\\{([\\s\\S]*?)\\n\\}\\)(?:\\.strict\\(\\))?;`,
   );
   const match = source.match(pattern);
   if (!match) {
@@ -491,6 +491,14 @@ describe("RUN-823: custom YAML request schemas are strict", () => {
         custom_notes: "unsupported",
       }).success,
     ).toBe(false);
+  });
+
+  it("generated Zod strictness uses the public Zod API", () => {
+    const source = readFileSync(COMMITTED_ZOD_PATH, "utf8");
+
+    expect(source).not.toContain("_def.unknownKeys");
+    expect(source).toContain("ProviderCreateSchema = z.object");
+    expect(source).toContain("}).strict();");
   });
 });
 

--- a/packages/shared/src/__tests__/settingsContracts.test.ts
+++ b/packages/shared/src/__tests__/settingsContracts.test.ts
@@ -139,10 +139,27 @@ describe("canonical settings transport contracts", () => {
     expect(parsed).not.toHaveProperty("auto_save");
   });
 
+  it("rejects null app-settings update values while allowing omitted fields", () => {
+    const appSettingsUpdateSchema = getCanonicalSchema("AppSettingsUpdateSchema");
+
+    expect(appSettingsUpdateSchema.parse({})).toEqual({});
+    expect(() =>
+      appSettingsUpdateSchema.parse({
+        onboarding_completed: null,
+      }),
+    ).toThrow();
+    expect(() =>
+      appSettingsUpdateSchema.parse({
+        fallback_enabled: null,
+      }),
+    ).toThrow();
+  });
+
   it("keeps generated OpenAPI and shared contract artifacts on fallback-only settings fields", () => {
     const settingsFallbackProps = getSchemaProperties("SettingsFallbackResponse");
     const fallbackUpdateProps = getSchemaProperties("FallbackUpdate");
     const appSettingsProps = getSchemaProperties("AppSettingsOut");
+    const appSettingsUpdateProps = getSchemaProperties("AppSettingsUpdate");
 
     expect(settingsFallbackProps).toHaveProperty("fallback_provider_id");
     expect(settingsFallbackProps).toHaveProperty("fallback_model_id");
@@ -155,10 +172,24 @@ describe("canonical settings transport contracts", () => {
     expect(appSettingsProps).not.toHaveProperty("default_provider");
     expect(appSettingsProps).not.toHaveProperty("fallback_chain_enabled");
     expect(appSettingsProps).not.toHaveProperty("auto_save");
+    expect(appSettingsUpdateProps).toMatchObject({
+      onboarding_completed: {
+        type: "boolean",
+        title: "Onboarding Completed",
+      },
+      fallback_enabled: {
+        type: "boolean",
+        title: "Fallback Enabled",
+      },
+    });
 
     expect(GENERATED_API_SOURCE).toContain("/api/settings/fallbacks");
     expect(GENERATED_API_SOURCE).toContain("SettingsFallbackResponse");
     expect(GENERATED_API_SOURCE).toContain("fallback_enabled");
+    expect(GENERATED_API_SOURCE).toContain("onboarding_completed?: boolean;");
+    expect(GENERATED_API_SOURCE).toContain("fallback_enabled?: boolean;");
+    expect(GENERATED_API_SOURCE).not.toContain("onboarding_completed?: boolean | null;");
+    expect(GENERATED_API_SOURCE).not.toContain("fallback_enabled?: boolean | null;");
     expect(GENERATED_API_SOURCE).not.toContain("auto_save");
     expect(GENERATED_API_SOURCE).not.toContain("/api/settings/models");
     expect(GENERATED_API_SOURCE).not.toContain("/api/settings/models/{model_id}");
@@ -173,6 +204,14 @@ describe("canonical settings transport contracts", () => {
     expect(GENERATED_ZOD_SOURCE).toContain("SettingsFallbackResponseSchema");
     expect(GENERATED_ZOD_SOURCE).toContain("FallbackUpdateSchema");
     expect(GENERATED_ZOD_SOURCE).toContain("fallback_enabled");
+    expect(GENERATED_ZOD_SOURCE).toContain("onboarding_completed: z.boolean().optional()");
+    expect(GENERATED_ZOD_SOURCE).toContain("fallback_enabled: z.boolean().optional()");
+    expect(GENERATED_ZOD_SOURCE).not.toContain(
+      "onboarding_completed: z.boolean().nullable().optional()",
+    );
+    expect(GENERATED_ZOD_SOURCE).not.toContain(
+      "fallback_enabled: z.boolean().nullable().optional()",
+    );
     expect(GENERATED_ZOD_SOURCE).not.toContain("auto_save");
     expect(GENERATED_ZOD_SOURCE).not.toContain("SettingsModelDefaultResponseSchema");
     expect(GENERATED_ZOD_SOURCE).not.toContain("default_provider");

--- a/packages/shared/src/__tests__/settingsContracts.test.ts
+++ b/packages/shared/src/__tests__/settingsContracts.test.ts
@@ -132,9 +132,12 @@ describe("canonical settings transport contracts", () => {
 
     const appSettingsSchema = getCanonicalSchema("AppSettingsOutSchema");
 
-    expect(appSettingsSchema.parse(appSettingsSample)).toEqual(
+    const parsed = appSettingsSchema.parse(appSettingsSample);
+
+    expect(parsed).toEqual(
       expect.objectContaining(appSettingsSample),
     );
+    expect(parsed).not.toHaveProperty("auto_save");
   });
 
   it("keeps generated OpenAPI and shared contract artifacts on fallback-only settings fields", () => {
@@ -152,10 +155,12 @@ describe("canonical settings transport contracts", () => {
     expect(appSettingsProps).toHaveProperty("fallback_enabled");
     expect(appSettingsProps).not.toHaveProperty("default_provider");
     expect(appSettingsProps).not.toHaveProperty("fallback_chain_enabled");
+    expect(appSettingsProps).not.toHaveProperty("auto_save");
 
     expect(GENERATED_API_SOURCE).toContain("/api/settings/fallbacks");
     expect(GENERATED_API_SOURCE).toContain("SettingsFallbackResponse");
     expect(GENERATED_API_SOURCE).toContain("fallback_enabled");
+    expect(GENERATED_API_SOURCE).not.toContain("auto_save");
     expect(GENERATED_API_SOURCE).not.toContain("/api/settings/models");
     expect(GENERATED_API_SOURCE).not.toContain("/api/settings/models/{model_id}");
     expect(GENERATED_API_SOURCE).not.toContain("SettingsModelDefaultResponse");
@@ -169,6 +174,7 @@ describe("canonical settings transport contracts", () => {
     expect(GENERATED_ZOD_SOURCE).toContain("SettingsFallbackResponseSchema");
     expect(GENERATED_ZOD_SOURCE).toContain("FallbackUpdateSchema");
     expect(GENERATED_ZOD_SOURCE).toContain("fallback_enabled");
+    expect(GENERATED_ZOD_SOURCE).not.toContain("auto_save");
     expect(GENERATED_ZOD_SOURCE).not.toContain("SettingsModelDefaultResponseSchema");
     expect(GENERATED_ZOD_SOURCE).not.toContain("default_provider");
   });

--- a/packages/shared/src/__tests__/settingsContracts.test.ts
+++ b/packages/shared/src/__tests__/settingsContracts.test.ts
@@ -125,7 +125,6 @@ describe("canonical settings transport contracts", () => {
   it("exports the canonical app-settings schema on @runsight/shared/zod", () => {
     const appSettingsSample = {
       base_path: "/workspace",
-      auto_save: true,
       onboarding_completed: true,
       fallback_enabled: false,
     };

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -801,16 +801,16 @@ export interface components {
             /** Base Path */
             base_path?: string | null;
             /** Onboarding Completed */
-            onboarding_completed?: boolean | null;
+            onboarding_completed?: boolean;
             /** Fallback Enabled */
-            fallback_enabled?: boolean | null;
+            fallback_enabled?: boolean;
         };
         /** AppSettingsUpdate */
         AppSettingsUpdate: {
             /** Onboarding Completed */
-            onboarding_completed?: boolean | null;
+            onboarding_completed?: boolean;
             /** Fallback Enabled */
-            fallback_enabled?: boolean | null;
+            fallback_enabled?: boolean;
         };
         /** AttentionItem */
         AttentionItem: {

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -1216,8 +1216,11 @@ export interface components {
             eval_pass_pct?: number | null;
             /** Eval Score Avg */
             eval_score_avg?: number | null;
-            /** Regression Count */
-            regression_count?: number | null;
+            /**
+             * Regression Count
+             * @default 0
+             */
+            regression_count: number | null;
             /** Regression Types */
             regression_types?: string[];
             node_summary?: components["schemas"]["NodeSummary"] | null;

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -758,6 +758,40 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/runsight.svg": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Favicon */
+        get: operations["_favicon_runsight_svg_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/{full_path}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Spa Catch All */
+        get: operations["_spa_catch_all__full_path__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -766,8 +800,13 @@ export interface components {
         AppSettingsOut: {
             /** Base Path */
             base_path?: string | null;
-            /** Auto Save */
-            auto_save?: boolean | null;
+            /** Onboarding Completed */
+            onboarding_completed?: boolean | null;
+            /** Fallback Enabled */
+            fallback_enabled?: boolean | null;
+        };
+        /** AppSettingsUpdate */
+        AppSettingsUpdate: {
             /** Onboarding Completed */
             onboarding_completed?: boolean | null;
             /** Fallback Enabled */
@@ -3198,7 +3237,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["AppSettingsOut"];
+                "application/json": components["schemas"]["AppSettingsUpdate"];
             };
         };
         responses: {
@@ -3553,6 +3592,57 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+        };
+    };
+    _favicon_runsight_svg_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    _spa_catch_all__full_path__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                full_path: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };

--- a/packages/shared/src/zod.ts
+++ b/packages/shared/src/zod.ts
@@ -5,11 +5,16 @@ import { z } from "zod";
 
 export const AppSettingsOutSchema = z.object({
   base_path: z.string().nullable().optional(),
-  auto_save: z.boolean().nullable().optional(),
   onboarding_completed: z.boolean().nullable().optional(),
   fallback_enabled: z.boolean().nullable().optional(),
 });
 export type AppSettingsOut = z.infer<typeof AppSettingsOutSchema>;
+
+export const AppSettingsUpdateSchema = z.object({
+  onboarding_completed: z.boolean().nullable().optional(),
+  fallback_enabled: z.boolean().nullable().optional(),
+});
+export type AppSettingsUpdate = z.infer<typeof AppSettingsUpdateSchema>;
 
 export const AttentionItemSchema = z.object({
   type: z.string(),

--- a/packages/shared/src/zod.ts
+++ b/packages/shared/src/zod.ts
@@ -3,11 +3,6 @@
 
 import { z } from "zod";
 
-const markStrict = <T extends z.ZodObject<any>>(schema: T): T => {
-  (schema as any)._def.unknownKeys = "strict";
-  return schema;
-};
-
 export const AppSettingsOutSchema = z.object({
   base_path: z.string().nullable().optional(),
   onboarding_completed: z.boolean().optional(),
@@ -18,8 +13,7 @@ export type AppSettingsOut = z.infer<typeof AppSettingsOutSchema>;
 export const AppSettingsUpdateSchema = z.object({
   onboarding_completed: z.boolean().optional(),
   fallback_enabled: z.boolean().optional(),
-});
-markStrict(AppSettingsUpdateSchema);
+}).strict();
 export type AppSettingsUpdate = z.infer<typeof AppSettingsUpdateSchema>;
 
 export const AttentionItemSchema = z.object({
@@ -173,8 +167,7 @@ export const ProviderCreateSchema = z.object({
   name: z.string(),
   api_key_env: z.string().nullable().optional(),
   base_url: z.string().nullable().optional(),
-});
-markStrict(ProviderCreateSchema);
+}).strict();
 export type ProviderCreate = z.infer<typeof ProviderCreateSchema>;
 
 export const ProviderSummarySchema = z.object({
@@ -208,8 +201,7 @@ export const ProviderUpdateSchema = z.object({
   api_key_env: z.string().nullable().optional(),
   base_url: z.string().nullable().optional(),
   is_active: z.boolean().nullable().optional(),
-});
-markStrict(ProviderUpdateSchema);
+}).strict();
 export type ProviderUpdate = z.infer<typeof ProviderUpdateSchema>;
 
 export const RunCreateSchema = z.object({
@@ -362,8 +354,7 @@ export const SoulCreateSchema = z.object({
   temperature: z.number().nullable().optional(),
   max_tokens: z.number().nullable().optional(),
   avatar_color: z.string().nullable().optional(),
-});
-markStrict(SoulCreateSchema);
+}).strict();
 export type SoulCreate = z.infer<typeof SoulCreateSchema>;
 
 export const SoulVersionEntrySchema = z.object({
@@ -415,8 +406,7 @@ export const SoulUpdateSchema = z.object({
   max_tokens: z.number().nullable().optional(),
   avatar_color: z.string().nullable().optional(),
   copy_on_edit: z.boolean().optional().default(false),
-});
-markStrict(SoulUpdateSchema);
+}).strict();
 export type SoulUpdate = z.infer<typeof SoulUpdateSchema>;
 
 export const SoulUsageEntrySchema = z.object({
@@ -450,8 +440,7 @@ export const StepCreateSchema = z.object({
   name: z.string(),
   type: z.string().optional().default("step"),
   description: z.string().nullable().optional(),
-});
-markStrict(StepCreateSchema);
+}).strict();
 export type StepCreate = z.infer<typeof StepCreateSchema>;
 
 export const StepResponseSchema = z.object({
@@ -473,8 +462,7 @@ export const StepUpdateSchema = z.object({
   name: z.string().nullable().optional(),
   type: z.string().nullable().optional(),
   description: z.string().nullable().optional(),
-});
-markStrict(StepUpdateSchema);
+}).strict();
 export type StepUpdate = z.infer<typeof StepUpdateSchema>;
 
 export const TaskCreateSchema = z.object({
@@ -482,8 +470,7 @@ export const TaskCreateSchema = z.object({
   name: z.string(),
   type: z.string().optional().default("task"),
   description: z.string().nullable().optional(),
-});
-markStrict(TaskCreateSchema);
+}).strict();
 export type TaskCreate = z.infer<typeof TaskCreateSchema>;
 
 export const TaskResponseSchema = z.object({
@@ -505,8 +492,7 @@ export const TaskUpdateSchema = z.object({
   name: z.string().nullable().optional(),
   type: z.string().nullable().optional(),
   description: z.string().nullable().optional(),
-});
-markStrict(TaskUpdateSchema);
+}).strict();
 export type TaskUpdate = z.infer<typeof TaskUpdateSchema>;
 
 export const ToolListItemResponseSchema = z.object({

--- a/packages/shared/src/zod.ts
+++ b/packages/shared/src/zod.ts
@@ -238,7 +238,7 @@ export const RunResponseSchema = z.object({
   run_number: z.number().nullable().optional(),
   eval_pass_pct: z.number().nullable().optional(),
   eval_score_avg: z.number().nullable().optional(),
-  regression_count: z.number().nullable().optional(),
+  regression_count: z.number().nullable().optional().default(0),
   regression_types: z.array(z.string()).optional(),
   node_summary: NodeSummarySchema.nullable().optional(),
   parent_run_id: z.string().nullable().optional(),

--- a/packages/shared/src/zod.ts
+++ b/packages/shared/src/zod.ts
@@ -3,6 +3,11 @@
 
 import { z } from "zod";
 
+const markStrict = <T extends z.ZodObject<any>>(schema: T): T => {
+  (schema as any)._def.unknownKeys = "strict";
+  return schema;
+};
+
 export const AppSettingsOutSchema = z.object({
   base_path: z.string().nullable().optional(),
   onboarding_completed: z.boolean().optional(),
@@ -14,6 +19,7 @@ export const AppSettingsUpdateSchema = z.object({
   onboarding_completed: z.boolean().optional(),
   fallback_enabled: z.boolean().optional(),
 });
+markStrict(AppSettingsUpdateSchema);
 export type AppSettingsUpdate = z.infer<typeof AppSettingsUpdateSchema>;
 
 export const AttentionItemSchema = z.object({
@@ -168,6 +174,7 @@ export const ProviderCreateSchema = z.object({
   api_key_env: z.string().nullable().optional(),
   base_url: z.string().nullable().optional(),
 });
+markStrict(ProviderCreateSchema);
 export type ProviderCreate = z.infer<typeof ProviderCreateSchema>;
 
 export const ProviderSummarySchema = z.object({
@@ -202,6 +209,7 @@ export const ProviderUpdateSchema = z.object({
   base_url: z.string().nullable().optional(),
   is_active: z.boolean().nullable().optional(),
 });
+markStrict(ProviderUpdateSchema);
 export type ProviderUpdate = z.infer<typeof ProviderUpdateSchema>;
 
 export const RunCreateSchema = z.object({
@@ -355,6 +363,7 @@ export const SoulCreateSchema = z.object({
   max_tokens: z.number().nullable().optional(),
   avatar_color: z.string().nullable().optional(),
 });
+markStrict(SoulCreateSchema);
 export type SoulCreate = z.infer<typeof SoulCreateSchema>;
 
 export const SoulVersionEntrySchema = z.object({
@@ -407,6 +416,7 @@ export const SoulUpdateSchema = z.object({
   avatar_color: z.string().nullable().optional(),
   copy_on_edit: z.boolean().optional().default(false),
 });
+markStrict(SoulUpdateSchema);
 export type SoulUpdate = z.infer<typeof SoulUpdateSchema>;
 
 export const SoulUsageEntrySchema = z.object({
@@ -441,6 +451,7 @@ export const StepCreateSchema = z.object({
   type: z.string().optional().default("step"),
   description: z.string().nullable().optional(),
 });
+markStrict(StepCreateSchema);
 export type StepCreate = z.infer<typeof StepCreateSchema>;
 
 export const StepResponseSchema = z.object({
@@ -463,6 +474,7 @@ export const StepUpdateSchema = z.object({
   type: z.string().nullable().optional(),
   description: z.string().nullable().optional(),
 });
+markStrict(StepUpdateSchema);
 export type StepUpdate = z.infer<typeof StepUpdateSchema>;
 
 export const TaskCreateSchema = z.object({
@@ -471,6 +483,7 @@ export const TaskCreateSchema = z.object({
   type: z.string().optional().default("task"),
   description: z.string().nullable().optional(),
 });
+markStrict(TaskCreateSchema);
 export type TaskCreate = z.infer<typeof TaskCreateSchema>;
 
 export const TaskResponseSchema = z.object({
@@ -493,6 +506,7 @@ export const TaskUpdateSchema = z.object({
   type: z.string().nullable().optional(),
   description: z.string().nullable().optional(),
 });
+markStrict(TaskUpdateSchema);
 export type TaskUpdate = z.infer<typeof TaskUpdateSchema>;
 
 export const ToolListItemResponseSchema = z.object({

--- a/packages/shared/src/zod.ts
+++ b/packages/shared/src/zod.ts
@@ -5,14 +5,14 @@ import { z } from "zod";
 
 export const AppSettingsOutSchema = z.object({
   base_path: z.string().nullable().optional(),
-  onboarding_completed: z.boolean().nullable().optional(),
-  fallback_enabled: z.boolean().nullable().optional(),
+  onboarding_completed: z.boolean().optional(),
+  fallback_enabled: z.boolean().optional(),
 });
 export type AppSettingsOut = z.infer<typeof AppSettingsOutSchema>;
 
 export const AppSettingsUpdateSchema = z.object({
-  onboarding_completed: z.boolean().nullable().optional(),
-  fallback_enabled: z.boolean().nullable().optional(),
+  onboarding_completed: z.boolean().optional(),
+  fallback_enabled: z.boolean().optional(),
 });
 export type AppSettingsUpdate = z.infer<typeof AppSettingsUpdateSchema>;
 

--- a/packages/ui/src/components/shared/EmptyState.tsx
+++ b/packages/ui/src/components/shared/EmptyState.tsx
@@ -41,12 +41,12 @@ export function EmptyState({
       </div>
 
       {/* Title */}
-      <div
+      <h2
         data-slot="empty-state-title"
-        className="text-[length:var(--font-size-lg)] font-medium text-(--text-primary)"
+        className="m-0 text-[length:var(--font-size-lg)] font-medium text-(--text-primary)"
       >
         {title}
-      </div>
+      </h2>
 
       {/* Description */}
       {description && (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runsight-workspace"
-version = "0.2.2"
+version = "0.2.3"
 requires-python = ">=3.11"
 dependencies = []
 

--- a/testing/gui-e2e/tests/run783-readonly-surface.spec.ts
+++ b/testing/gui-e2e/tests/run783-readonly-surface.spec.ts
@@ -1,16 +1,22 @@
 import { test, expect, type APIRequestContext, type Page } from "@playwright/test";
+import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
+
+import { applyFixture } from "./helpers/shellReady";
 
 test.describe.configure({ mode: "serial" });
 
 const API = "http://127.0.0.1:8000/api";
+const REPO_ROOT = process.env.RUNSIGHT_E2E_PROJECT_ROOT ?? resolve(process.cwd(), "../..");
+const DB_PATH = resolve(REPO_ROOT, ".runsight/runsight.db");
+const SEEDED_BASELINE_RUN_ID = "seed_rr_baseline";
 const SEEDED_RUN_ID = "seed_rr_regression";
 const SEEDED_WORKFLOW_ID = "research-review";
 const forkedWorkflowIds = new Set<string>();
 const CANVAS_SIDECAR_PATH = resolve(
-  process.cwd(),
-  "../../custom/workflows/.canvas/research-review.canvas.json",
+  REPO_ROOT,
+  "custom/workflows/.canvas/research-review.canvas.json",
 );
 
 type RunSummary = {
@@ -113,7 +119,180 @@ function workflowIdFromUrl(url: string) {
   return decodeURIComponent(match[1]);
 }
 
+function seedReadonlyRunFixture() {
+  const commitSha = execFileSync("git", ["rev-parse", "HEAD"], {
+    cwd: REPO_ROOT,
+    encoding: "utf-8",
+  }).trim();
+
+  execFileSync("python3", [
+    "-c",
+    `
+import json
+import sqlite3
+import sys
+import time
+
+db_path, commit_sha, baseline_run_id, current_run_id = sys.argv[1:5]
+workflow_id = "research-review"
+workflow_name = "Research & Review"
+now = time.time()
+
+conn = sqlite3.connect(db_path)
+cur = conn.cursor()
+run_ids = (baseline_run_id, current_run_id)
+cur.execute(
+    "delete from logentry where run_id in (?, ?)",
+    run_ids,
+)
+cur.execute(
+    "delete from runnode where run_id in (?, ?)",
+    run_ids,
+)
+cur.execute(
+    "delete from run where id in (?, ?)",
+    run_ids,
+)
+
+def insert_run(run_id, created_at, total_cost, total_tokens):
+    cur.execute(
+        """
+        insert into run (
+            id, workflow_id, workflow_name, status, task_json, started_at,
+            completed_at, duration_s, total_cost_usd, total_tokens, branch,
+            source, commit_sha, created_at, updated_at, depth
+        ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            run_id,
+            workflow_id,
+            workflow_name,
+            "completed",
+            "{}",
+            created_at,
+            created_at + 4,
+            4,
+            total_cost,
+            total_tokens,
+            "main",
+            "manual",
+            commit_sha,
+            created_at,
+            created_at + 4,
+            0,
+        ),
+    )
+
+def insert_node(run_id, node_id, block_type, cost, tokens, score, passed, created_at):
+    cur.execute(
+        """
+        insert into runnode (
+            id, run_id, node_id, block_type, status, started_at, completed_at,
+            duration_s, cost_usd, tokens, output, soul_id, model_name,
+            prompt_hash, soul_version, eval_score, eval_passed, eval_results,
+            created_at, updated_at
+        ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            f"{run_id}:{node_id}",
+            run_id,
+            node_id,
+            block_type,
+            "completed",
+            created_at,
+            created_at + 1,
+            1,
+            cost,
+            json.dumps({"input": tokens // 2, "output": tokens // 2, "total": tokens}),
+            f"{node_id} output",
+            f"{node_id}_soul",
+            "gpt-5.4-mini",
+            f"{node_id}_prompt",
+            "v1",
+            score,
+            1 if passed else 0,
+            json.dumps({"assertions": []}),
+            created_at,
+            created_at + 1,
+        ),
+    )
+
+baseline_created = now - 120
+current_created = now - 60
+insert_run(baseline_run_id, baseline_created, 0.04, 4000)
+insert_run(current_run_id, current_created, 0.12, 9000)
+
+baseline_nodes = [
+    ("research", "linear", 0.01, 1000, 0.95, True),
+    ("write_summary", "linear", 0.01, 1000, 0.94, True),
+    ("quality_review", "gate", 0.01, 1000, 0.93, True),
+    ("notify", "linear", 0.01, 1000, 0.92, True),
+]
+current_nodes = [
+    ("research", "linear", 0.03, 3000, 0.70, False),
+    ("write_summary", "linear", 0.03, 3000, 0.70, False),
+    ("quality_review", "gate", 0.01, 1500, 0.70, False),
+    ("notify", "linear", 0.01, 1500, 0.92, True),
+]
+
+for index, node in enumerate(baseline_nodes):
+    insert_node(baseline_run_id, *node, baseline_created + index)
+for index, node in enumerate(current_nodes):
+    insert_node(current_run_id, *node, current_created + index)
+
+conn.commit()
+conn.close()
+`,
+    DB_PATH,
+    commitSha,
+    SEEDED_BASELINE_RUN_ID,
+    SEEDED_RUN_ID,
+  ], { cwd: REPO_ROOT });
+}
+
+function cleanupReadonlyRunFixture() {
+  execFileSync("python3", [
+    "-c",
+    `
+import sqlite3
+import sys
+
+db_path, baseline_run_id, current_run_id = sys.argv[1:4]
+run_ids = (baseline_run_id, current_run_id)
+conn = sqlite3.connect(db_path)
+cur = conn.cursor()
+cur.execute("delete from logentry where run_id in (?, ?)", run_ids)
+cur.execute("delete from runnode where run_id in (?, ?)", run_ids)
+cur.execute("delete from run where id in (?, ?)", run_ids)
+conn.commit()
+conn.close()
+`,
+    DB_PATH,
+    SEEDED_BASELINE_RUN_ID,
+    SEEDED_RUN_ID,
+  ], { cwd: REPO_ROOT });
+}
+
+test.beforeAll(async () => {
+  await applyFixture([
+    {
+      id: "openai",
+      name: "OpenAI",
+      type: "openai",
+      status: "connected",
+      is_active: true,
+      models: ["gpt-4.1-mini"],
+      api_key: null,
+    },
+  ], {
+    onboarding_completed: true,
+    fallback_enabled: false,
+  });
+  seedReadonlyRunFixture();
+});
+
 test.afterAll(async ({ request }) => {
+  cleanupReadonlyRunFixture();
   for (const workflowId of forkedWorkflowIds) {
     await apiDelete(request, `/workflows/${workflowId}`);
   }
@@ -178,7 +357,7 @@ test.describe("RUN-783 readonly surface browser flows", () => {
       "aria-selected",
       "true",
     );
-    await expect(inspector).toContainText("Research");
+    await expect(inspector).toContainText("research");
     await expect(inspector).toContainText("Completed");
 
     await page.getByTestId("workflow-tab-yaml").click();

--- a/tools/generate-zod-schemas.py
+++ b/tools/generate-zod-schemas.py
@@ -69,6 +69,11 @@ def generate_object_schema(schema: dict, schemas: dict) -> str:
     return f"z.object({{\n{body}\n}})"
 
 
+def schema_forbids_unknown_fields(schema: dict) -> bool:
+    """Return whether an OpenAPI object schema rejects additional properties."""
+    return schema.get("additionalProperties") is False
+
+
 def generate_zod_file(openapi_path: str, output_path: str) -> None:
     """Generate Zod schemas TS file from OpenAPI JSON."""
     spec = json.loads(Path(openapi_path).read_text())
@@ -79,6 +84,11 @@ def generate_zod_file(openapi_path: str, output_path: str) -> None:
         "// Source: openapi.json (RUN-134)",
         "",
         'import { z } from "zod";',
+        "",
+        "const markStrict = <T extends z.ZodObject<any>>(schema: T): T => {",
+        '  (schema as any)._def.unknownKeys = "strict";',
+        "  return schema;",
+        "};",
         "",
     ]
 
@@ -112,6 +122,8 @@ def generate_zod_file(openapi_path: str, output_path: str) -> None:
         schema = schemas[name]
         zod_expr = generate_object_schema(schema, schemas)
         lines.append(f"export const {name}Schema = {zod_expr};")
+        if schema_forbids_unknown_fields(schema):
+            lines.append(f"markStrict({name}Schema);")
         lines.append(f"export type {name} = z.infer<typeof {name}Schema>;")
         lines.append("")
 

--- a/tools/generate-zod-schemas.py
+++ b/tools/generate-zod-schemas.py
@@ -85,11 +85,6 @@ def generate_zod_file(openapi_path: str, output_path: str) -> None:
         "",
         'import { z } from "zod";',
         "",
-        "const markStrict = <T extends z.ZodObject<any>>(schema: T): T => {",
-        '  (schema as any)._def.unknownKeys = "strict";',
-        "  return schema;",
-        "};",
-        "",
     ]
 
     # Topological sort: schemas that reference others must come after them
@@ -121,9 +116,9 @@ def generate_zod_file(openapi_path: str, output_path: str) -> None:
     for name in sorted_names:
         schema = schemas[name]
         zod_expr = generate_object_schema(schema, schemas)
-        lines.append(f"export const {name}Schema = {zod_expr};")
         if schema_forbids_unknown_fields(schema):
-            lines.append(f"markStrict({name}Schema);")
+            zod_expr = f"{zod_expr}.strict()"
+        lines.append(f"export const {name}Schema = {zod_expr};")
         lines.append(f"export type {name} = z.infer<typeof {name}Schema>;")
         lines.append("")
 

--- a/uv.lock
+++ b/uv.lock
@@ -2092,7 +2092,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "runsight-workspace"
-version = "0.2.1"
+version = "0.2.2"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -2092,7 +2092,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "runsight-workspace"
-version = "0.2.2"
+version = "0.2.3"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- Completes the core cleanup RGB/TDD ticket batch for RUN-772, RUN-767, RUN-774, RUN-775, and RUN-823.
- Fixes review findings around strict settings validation, block-builder registration, generated contracts, GUI surface typing, and self-contained E2E fixtures.
- Bumps the release version to 0.2.3.

## Verification
- API pytest in batches: passed
- Core pytest in batches: passed
- Shared Vitest in batches: passed
- GUI Vitest in batches: passed
- UI Vitest in batches: passed
- Playwright E2E in batches: passed
- pnpm run lint: passed
- tools/check-types-fresh.sh: passed
