### PR TITLE
RUN-759 parser warnings and non-fatal validation

### DIFF
--- a/apps/api/src/runsight_api/alembic/versions/002_add_run_warnings_json.py
+++ b/apps/api/src/runsight_api/alembic/versions/002_add_run_warnings_json.py
@@ -1,0 +1,29 @@
+"""Add run.warnings_json snapshot column.
+
+Revision ID: 002_add_run_warnings_json
+Revises: 001_initial
+Create Date: 2026-04-14
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "002_add_run_warnings_json"
+down_revision: Union[str, None] = "001_initial"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add nullable warnings snapshot column to run table."""
+    with op.batch_alter_table("run") as batch_op:
+        batch_op.add_column(sa.Column("warnings_json", sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    """Drop warnings snapshot column from run table."""
+    with op.batch_alter_table("run") as batch_op:
+        batch_op.drop_column("warnings_json")

--- a/apps/api/src/runsight_api/data/filesystem/workflow_repo.py
+++ b/apps/api/src/runsight_api/data/filesystem/workflow_repo.py
@@ -201,18 +201,19 @@ class WorkflowRepository:
 
     def _validate_yaml_content(
         self, workflow_id: str, raw_yaml: Optional[str]
-    ) -> Tuple[bool, Optional[str]]:
+    ) -> Tuple[bool, Optional[str], List[Dict[str, Optional[str]]]]:
         """Validate raw YAML string against RunsightWorkflowFile schema.
 
-        Returns (valid, validation_error) — never raises.
+        Returns (valid, validation_error, warnings) — never raises.
         If raw_yaml is None or empty, returns (False, ...).
         """
         if not raw_yaml:
-            return False, "No YAML content to validate"
+            return False, "No YAML content to validate", []
+        warnings: List[Dict[str, Optional[str]]] = []
         try:
             data = yaml_mod.safe_load(raw_yaml)
             if not isinstance(data, dict):
-                return False, "YAML content is not a mapping"
+                return False, "YAML content is not a mapping", []
             file_def = RunsightWorkflowFile.model_validate(data)
             souls_map = SoulScanner(self.base_path).scan().stems()
             validation_result = validate_tool_governance(file_def, souls_map)
@@ -223,17 +224,25 @@ class WorkflowRepository:
                     require_custom_metadata=True,
                 )
             )
+            warnings = validation_result.warnings_as_dicts()
             if validation_result.has_errors:
-                return False, validation_result.error_summary or "Tool governance validation failed"
+                return (
+                    False,
+                    validation_result.error_summary or "Tool governance validation failed",
+                    warnings,
+                )
             if self._has_workflow_blocks(file_def):
-                self.build_runnable_workflow_registry(workflow_id, raw_yaml)
-            return True, None
+                try:
+                    self.build_runnable_workflow_registry(workflow_id, raw_yaml)
+                except ValueError as e:
+                    return False, str(e), warnings
+            return True, None, warnings
         except PydanticValidationError as e:
-            return False, str(e)
+            return False, str(e), []
         except ValueError as e:
-            return False, str(e)
+            return False, str(e), warnings
         except Exception as e:
-            return False, f"Unexpected validation error: {e}"
+            return False, f"Unexpected validation error: {e}", warnings
 
     def _write_canvas_sidecar(self, stem: str, canvas_state: Any) -> None:
         """Write the canvas sidecar JSON file."""
@@ -283,7 +292,7 @@ class WorkflowRepository:
                       field in the entity will be None.
         """
         # Validate the raw YAML content against RunsightWorkflowFile schema
-        valid, validation_error = self._validate_yaml_content(stem, raw_yaml)
+        valid, validation_error, warnings = self._validate_yaml_content(stem, raw_yaml)
 
         entity_data = dict(data)
         # id comes from the filename stem, not from inside the YAML
@@ -291,6 +300,7 @@ class WorkflowRepository:
         entity_data["yaml"] = raw_yaml
         entity_data["valid"] = valid
         entity_data["validation_error"] = validation_error
+        entity_data["warnings"] = warnings
         entity_data["filename"] = f"{stem}.yaml"
         if canvas_state is not None:
             entity_data["canvas_state"] = canvas_state

--- a/apps/api/src/runsight_api/data/filesystem/workflow_repo.py
+++ b/apps/api/src/runsight_api/data/filesystem/workflow_repo.py
@@ -215,12 +215,16 @@ class WorkflowRepository:
                 return False, "YAML content is not a mapping"
             file_def = RunsightWorkflowFile.model_validate(data)
             souls_map = SoulScanner(self.base_path).scan().stems()
-            validate_tool_governance(file_def, souls_map)
-            _validate_declared_tool_definitions(
-                file_def,
-                base_dir=str(self.base_path),
-                require_custom_metadata=True,
+            validation_result = validate_tool_governance(file_def, souls_map)
+            validation_result.merge(
+                _validate_declared_tool_definitions(
+                    file_def,
+                    base_dir=str(self.base_path),
+                    require_custom_metadata=True,
+                )
             )
+            if validation_result.has_errors:
+                return False, validation_result.error_summary or "Tool governance validation failed"
             if self._has_workflow_blocks(file_def):
                 self.build_runnable_workflow_registry(workflow_id, raw_yaml)
             return True, None

--- a/apps/api/src/runsight_api/domain/entities/run.py
+++ b/apps/api/src/runsight_api/domain/entities/run.py
@@ -1,6 +1,6 @@
 import time
 from enum import Enum
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel
 from sqlmodel import JSON, Column, Field, SQLModel
@@ -80,6 +80,7 @@ class Run(SQLModel, table=True):
     # Budget-exceeded terminal state (RUN-717)
     fail_reason: Optional[str] = Field(default=None)
     fail_metadata: Optional[Dict[str, Any]] = Field(default=None, sa_column=Column(JSON))
+    warnings_json: Optional[List[Dict[str, Any]]] = Field(default=None, sa_column=Column(JSON))
 
     # Nested-run linkage (RUN-607)
     parent_run_id: Optional[str] = Field(default=None)

--- a/apps/api/src/runsight_api/domain/value_objects.py
+++ b/apps/api/src/runsight_api/domain/value_objects.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -35,6 +35,7 @@ class WorkflowEntity(BaseModel):
     enabled: bool = False
     validation_error: Optional[str] = None
     filename: Optional[str] = None
+    warnings: List[Dict[str, Optional[str]]] = Field(default_factory=list)
     model_config = {"extra": "allow"}
 
 

--- a/apps/api/src/runsight_api/logic/observers/execution_observer.py
+++ b/apps/api/src/runsight_api/logic/observers/execution_observer.py
@@ -158,6 +158,7 @@ class ExecutionObserver:
                     workflow_name=child_workflow_name,
                     status=RunStatus.running,
                     task_json="{}",
+                    warnings_json=None,
                     parent_run_id=self.run_id,
                     parent_node_id=f"{self.run_id}:{block_id}",
                     root_run_id=root_run_id,

--- a/apps/api/src/runsight_api/logic/services/run_service.py
+++ b/apps/api/src/runsight_api/logic/services/run_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import json
 import time
 import uuid
@@ -64,6 +65,10 @@ class RunService:
             raise WorkflowNotFound(f"Workflow {workflow_id} not found")
 
         run_id = f"run_{uuid.uuid4().hex[:12]}"
+        workflow_warnings = getattr(workflow, "warnings", None)
+        warnings_json: Optional[List[Dict[str, Any]]] = None
+        if isinstance(workflow_warnings, list) and workflow_warnings:
+            warnings_json = copy.deepcopy(workflow_warnings)
 
         run = Run(
             id=run_id,
@@ -73,6 +78,7 @@ class RunService:
             task_json=json.dumps(task_data),
             branch=branch,
             source=source,
+            warnings_json=warnings_json,
         )
         self.run_repo.create_run(run)
 

--- a/apps/api/src/runsight_api/main.py
+++ b/apps/api/src/runsight_api/main.py
@@ -81,6 +81,7 @@ def _ensure_sqlite_columns(engine) -> None:
             "depth": "INTEGER DEFAULT 0",
             "fail_reason": "VARCHAR",
             "fail_metadata": "JSON",
+            "warnings_json": "JSON",
         },
         "runnode": {
             "last_phase": "VARCHAR",

--- a/apps/api/src/runsight_api/transport/routers/runs.py
+++ b/apps/api/src/runsight_api/transport/routers/runs.py
@@ -67,6 +67,79 @@ def _regression_types(result) -> list[str]:
     return types
 
 
+def _run_warning_items(run) -> list[dict[str, str | None]]:
+    run_data = getattr(run, "__dict__", None)
+    raw_warnings = run_data.get("warnings_json") if isinstance(run_data, dict) else None
+    if not isinstance(raw_warnings, list):
+        return []
+
+    warnings: list[dict[str, str | None]] = []
+    for raw_warning in raw_warnings:
+        if not isinstance(raw_warning, dict):
+            continue
+        message = raw_warning.get("message")
+        if not isinstance(message, str):
+            continue
+        source = raw_warning.get("source")
+        context = raw_warning.get("context")
+        warnings.append(
+            {
+                "message": message,
+                "source": source if isinstance(source, str) else None,
+                "context": context if isinstance(context, str) else None,
+            }
+        )
+    return warnings
+
+
+def _run_link_field(run, field: str) -> Optional[str]:
+    value = getattr(run, field, None)
+    return value if value is None or isinstance(value, str) else None
+
+
+def _run_depth(run) -> int:
+    value = getattr(run, "depth", 0)
+    return value if isinstance(value, int) else 0
+
+
+def _build_run_response(
+    run,
+    *,
+    total_cost_usd: float,
+    total_tokens: int,
+    node_summary: NodeSummary,
+    eval_score_avg: Optional[float],
+    regression_count: Optional[int],
+    regression_types: list[str],
+) -> RunResponse:
+    return RunResponse(
+        id=run.id,
+        workflow_id=run.workflow_id,
+        workflow_name=run.workflow_name,
+        status=run.status,
+        error=getattr(run, "error", None),
+        started_at=run.started_at,
+        completed_at=run.completed_at,
+        duration_seconds=run.duration_s,
+        total_cost_usd=total_cost_usd,
+        total_tokens=total_tokens,
+        created_at=run.created_at,
+        branch=_run_response_field(run, "branch", "main"),
+        source=_run_response_field(run, "source", "manual"),
+        commit_sha=_run_response_field(run, "commit_sha", None),
+        run_number=_run_metric_field(run, "run_number"),
+        eval_pass_pct=_run_metric_field(run, "eval_pass_pct"),
+        eval_score_avg=eval_score_avg,
+        regression_count=regression_count,
+        regression_types=regression_types,
+        warnings=_run_warning_items(run),
+        node_summary=node_summary,
+        parent_run_id=_run_link_field(run, "parent_run_id"),
+        root_run_id=_run_link_field(run, "root_run_id"),
+        depth=_run_depth(run),
+    )
+
+
 def _refresh_launch_run(run_service: RunService, run):
     """Read the post-launch run state when the service exposes a real repository-backed run."""
     if not isinstance(run_service, RunService):
@@ -113,27 +186,14 @@ async def create_run(
     if run.status == RunStatus.failed or run.status == RunStatus.failed.value:
         raise RunFailed(run.error or "Run failed during launch", run_id=run.id)
 
-    return RunResponse(
-        id=run.id,
-        workflow_id=run.workflow_id,
-        workflow_name=run.workflow_name,
-        status=run.status,
-        error=getattr(run, "error", None),
-        started_at=run.started_at,
-        completed_at=run.completed_at,
-        duration_seconds=run.duration_s,
+    return _build_run_response(
+        run,
         total_cost_usd=run.total_cost_usd,
         total_tokens=run.total_tokens,
-        created_at=run.created_at,
-        branch=_run_response_field(run, "branch", "main"),
-        source=_run_response_field(run, "source", "manual"),
-        commit_sha=_run_response_field(run, "commit_sha", None),
-        run_number=_run_metric_field(run, "run_number"),
-        eval_pass_pct=_run_metric_field(run, "eval_pass_pct"),
+        node_summary=NodeSummary(total=0, completed=0, running=0, pending=0, failed=0),
         eval_score_avg=_run_metric_field(run, "eval_score_avg"),
         regression_count=_run_metric_field(run, "regression_count"),
         regression_types=[],
-        node_summary=NodeSummary(total=0, completed=0, running=0, pending=0, failed=0),
     )
 
 
@@ -205,26 +265,10 @@ async def list_runs(
     for run in runs:
         summaries = summaries_map.get(run.id, {})
         response_items.append(
-            RunResponse(
-                id=run.id,
-                workflow_id=run.workflow_id,
-                workflow_name=run.workflow_name,
-                status=run.status,
-                error=getattr(run, "error", None),
-                started_at=run.started_at,
-                completed_at=run.completed_at,
-                duration_seconds=run.duration_s,
+            _build_run_response(
+                run,
                 total_cost_usd=summaries.get("total_cost_usd", 0.0),
                 total_tokens=summaries.get("total_tokens", 0),
-                created_at=run.created_at,
-                branch=_run_response_field(run, "branch", "main"),
-                source=_run_response_field(run, "source", "manual"),
-                commit_sha=_run_response_field(run, "commit_sha", None),
-                run_number=_run_metric_field(run, "run_number"),
-                eval_pass_pct=_run_metric_field(run, "eval_pass_pct"),
-                eval_score_avg=summaries.get("eval_score_avg"),
-                regression_count=regression_counts.get(run.id, 0),
-                regression_types=_run_response_field(run, "regression_types", []),
                 node_summary=NodeSummary(
                     total=summaries.get("total", 0),
                     completed=summaries.get("completed", 0),
@@ -232,6 +276,9 @@ async def list_runs(
                     pending=summaries.get("pending", 0),
                     failed=summaries.get("failed", 0),
                 ),
+                eval_score_avg=summaries.get("eval_score_avg"),
+                regression_count=regression_counts.get(run.id, 0),
+                regression_types=_run_response_field(run, "regression_types", []),
             )
         )
 
@@ -251,26 +298,10 @@ async def get_run(
         raise RunNotFound(f"Run {run_id} not found")
     summaries = run_service.get_node_summary(run.id)
     reg_result = eval_service.get_run_regressions(run_id)
-    return RunResponse(
-        id=run.id,
-        workflow_id=run.workflow_id,
-        workflow_name=run.workflow_name,
-        status=run.status,
-        error=getattr(run, "error", None),
-        started_at=run.started_at,
-        completed_at=run.completed_at,
-        duration_seconds=run.duration_s,
+    return _build_run_response(
+        run,
         total_cost_usd=summaries["total_cost_usd"],
         total_tokens=summaries["total_tokens"],
-        created_at=run.created_at,
-        branch=_run_response_field(run, "branch", "main"),
-        source=_run_response_field(run, "source", "manual"),
-        commit_sha=_run_response_field(run, "commit_sha", None),
-        run_number=_run_metric_field(run, "run_number"),
-        eval_pass_pct=_run_metric_field(run, "eval_pass_pct"),
-        eval_score_avg=summaries.get("eval_score_avg"),
-        regression_count=reg_result["count"] if reg_result else 0,
-        regression_types=_regression_types(reg_result),
         node_summary=NodeSummary(
             total=summaries["total"],
             completed=summaries["completed"],
@@ -278,9 +309,9 @@ async def get_run(
             pending=summaries["pending"],
             failed=summaries["failed"],
         ),
-        parent_run_id=getattr(run, "parent_run_id", None),
-        root_run_id=getattr(run, "root_run_id", None),
-        depth=getattr(run, "depth", 0),
+        eval_score_avg=summaries.get("eval_score_avg"),
+        regression_count=reg_result["count"] if reg_result else 0,
+        regression_types=_regression_types(reg_result),
     )
 
 
@@ -297,26 +328,10 @@ async def get_run_children(
         summaries = summaries_map.get(child.id, {})
         reg_result = eval_service.get_run_regressions(child.id)
         response_items.append(
-            RunResponse(
-                id=child.id,
-                workflow_id=child.workflow_id,
-                workflow_name=child.workflow_name,
-                status=child.status,
-                error=getattr(child, "error", None),
-                started_at=child.started_at,
-                completed_at=child.completed_at,
-                duration_seconds=child.duration_s,
+            _build_run_response(
+                child,
                 total_cost_usd=summaries.get("total_cost_usd", 0.0),
                 total_tokens=summaries.get("total_tokens", 0),
-                created_at=child.created_at,
-                branch=_run_response_field(child, "branch", "main"),
-                source=_run_response_field(child, "source", "manual"),
-                commit_sha=_run_response_field(child, "commit_sha", None),
-                run_number=_run_metric_field(child, "run_number"),
-                eval_pass_pct=_run_metric_field(child, "eval_pass_pct"),
-                eval_score_avg=summaries.get("eval_score_avg"),
-                regression_count=reg_result["count"] if reg_result else 0,
-                regression_types=_regression_types(reg_result),
                 node_summary=NodeSummary(
                     total=summaries.get("total", 0),
                     completed=summaries.get("completed", 0),
@@ -324,9 +339,9 @@ async def get_run_children(
                     pending=summaries.get("pending", 0),
                     failed=summaries.get("failed", 0),
                 ),
-                parent_run_id=getattr(child, "parent_run_id", None),
-                root_run_id=getattr(child, "root_run_id", None),
-                depth=getattr(child, "depth", 0),
+                eval_score_avg=summaries.get("eval_score_avg"),
+                regression_count=reg_result["count"] if reg_result else 0,
+                regression_types=_regression_types(reg_result),
             )
         )
     return response_items

--- a/apps/api/src/runsight_api/transport/schemas/runs.py
+++ b/apps/api/src/runsight_api/transport/schemas/runs.py
@@ -2,6 +2,8 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
 
+from .workflows import WarningItem
+
 
 class RunCreate(BaseModel):
     workflow_id: str
@@ -38,6 +40,7 @@ class RunResponse(BaseModel):
     eval_score_avg: Optional[float] = None
     regression_count: Optional[int] = 0
     regression_types: List[str] = Field(default_factory=list)
+    warnings: List[WarningItem] = Field(default_factory=list, json_schema_extra={"default": []})
     node_summary: Optional[NodeSummary] = None
     parent_run_id: Optional[str] = None
     root_run_id: Optional[str] = None

--- a/apps/api/src/runsight_api/transport/schemas/workflows.py
+++ b/apps/api/src/runsight_api/transport/schemas/workflows.py
@@ -25,6 +25,14 @@ class WorkflowHealthMetrics(BaseModel):
     regression_count: int = 0
 
 
+class WarningItem(BaseModel):
+    message: str
+    source: str | None = None
+    context: str | None = None
+
+    model_config = {"json_schema_extra": {"additionalProperties": False}}
+
+
 class WorkflowResponse(BaseModel):
     id: str
     name: Optional[str] = None
@@ -33,6 +41,10 @@ class WorkflowResponse(BaseModel):
     canvas_state: Optional[WorkflowCanvasState] = None
     valid: bool = True
     validation_error: Optional[str] = None
+    warnings: List[WarningItem] = Field(
+        default_factory=list,
+        json_schema_extra={"default": []},
+    )
     block_count: int = 0
     modified_at: float | None = None
     enabled: bool = False

--- a/apps/api/tests/domain/test_entity_extra_config.py
+++ b/apps/api/tests/domain/test_entity_extra_config.py
@@ -117,3 +117,27 @@ class TestWorkflowEntityPreservesExtraFields:
         wf = WorkflowEntity(id="wf1", name="Pipeline")
         assert wf.id == "wf1"
         assert wf.name == "Pipeline"
+
+
+class TestWorkflowEntityWarningsField:
+    def test_warnings_is_an_explicit_field_with_a_list_default(self):
+        assert "warnings" in WorkflowEntity.model_fields
+
+        field_info = WorkflowEntity.model_fields["warnings"]
+        assert field_info.default_factory is list
+
+        wf = WorkflowEntity(id="wf1")
+        assert wf.warnings == []
+
+    def test_warnings_preserve_explicit_payloads(self):
+        warnings = [
+            {
+                "message": "Tool definition warning",
+                "source": "tool_definitions",
+                "context": "lookup_profile",
+            }
+        ]
+
+        wf = WorkflowEntity(id="wf1", warnings=warnings)
+
+        assert wf.warnings == warnings

--- a/apps/api/tests/domain/test_run379_data_model.py
+++ b/apps/api/tests/domain/test_run379_data_model.py
@@ -162,6 +162,32 @@ class TestRunCommitShaField:
             assert loaded.commit_sha == sha
 
 
+class TestRunWarningsJsonField:
+    def test_run_has_warnings_json_attribute(self):
+        """Run entity exposes a `warnings_json` attribute."""
+        run = _make_run()
+        assert hasattr(run, "warnings_json")
+
+    def test_warnings_json_accepts_and_round_trips_in_db(self):
+        """warnings_json round-trips through SQLite as JSON."""
+        engine = _in_memory_engine()
+        warnings = [
+            {
+                "message": "Tool definition warning",
+                "source": "tool_definitions",
+                "context": "fetcher",
+            }
+        ]
+        with Session(engine) as session:
+            session.add(_make_run(id="run-warnings-db", warnings_json=warnings))
+            session.commit()
+        with Session(engine) as session:
+            from runsight_api.domain.entities.run import Run
+
+            loaded = session.get(Run, "run-warnings-db")
+            assert loaded.warnings_json == warnings
+
+
 # ---------------------------------------------------------------------------
 # 4. Backward compat removed — workflow_commit_sha and effective_commit_sha are gone
 # ---------------------------------------------------------------------------
@@ -231,6 +257,40 @@ class TestRunResponseNewFields:
         assert resp.branch == "feat/test"
         assert resp.source == "simulation"
         assert resp.commit_sha == "abc123"
+
+
+class TestRunResponseWarningsField:
+    def test_run_response_has_warnings(self):
+        """RunResponse schema includes a `warnings` field."""
+        from runsight_api.transport.schemas.runs import RunResponse
+
+        fields = RunResponse.model_fields
+        assert "warnings" in fields, "RunResponse must have a 'warnings' field"
+
+    def test_run_response_serializes_warnings(self):
+        """RunResponse can be instantiated with canonical warning payloads."""
+        from runsight_api.transport.schemas.runs import RunResponse
+        from runsight_api.transport.schemas.workflows import WarningItem
+
+        warning = WarningItem(
+            message="Tool definition warning",
+            source="tool_definitions",
+            context="fetcher",
+        )
+        resp = RunResponse(
+            id="run-1",
+            workflow_id="wf-1",
+            workflow_name="Test",
+            status="pending",
+            started_at=None,
+            completed_at=None,
+            duration_seconds=None,
+            total_cost_usd=0.0,
+            total_tokens=0,
+            created_at=1711699200.0,
+            warnings=[warning],
+        )
+        assert resp.warnings == [warning]
 
 
 # ---------------------------------------------------------------------------
@@ -321,6 +381,54 @@ class TestCreateRunPopulatesNewFields:
         run = svc.create_run("wf-1", {"instruction": "go"}, source="webhook")
 
         assert run.source == "webhook"
+
+    def test_create_run_snapshots_workflow_warnings(self):
+        """create_run() snapshots workflow warnings into run.warnings_json."""
+        from runsight_api.logic.services.run_service import RunService
+
+        mock_run_repo = Mock()
+        mock_run_repo.create_run.side_effect = lambda r: r
+
+        mock_workflow = Mock()
+        mock_workflow.name = "Test WF"
+        mock_workflow.id = "wf-1"
+        mock_workflow.warnings = [
+            {
+                "message": "Tool definition warning",
+                "source": "tool_definitions",
+                "context": "fetcher",
+            }
+        ]
+        mock_wf_repo = Mock()
+        mock_wf_repo.get_by_id.return_value = mock_workflow
+
+        svc = RunService(run_repo=mock_run_repo, workflow_repo=mock_wf_repo)
+        run = svc.create_run("wf-1", {"instruction": "go"})
+
+        assert run.warnings_json == mock_workflow.warnings
+        assert run.warnings_json is not mock_workflow.warnings
+
+        mock_workflow.warnings[0]["message"] = "mutated after creation"
+        assert run.warnings_json[0]["message"] == "Tool definition warning"
+
+    def test_create_run_sets_warnings_json_none_when_workflow_has_no_warnings(self):
+        """create_run() should default warnings_json to None when no warnings exist."""
+        from runsight_api.logic.services.run_service import RunService
+
+        mock_run_repo = Mock()
+        mock_run_repo.create_run.side_effect = lambda r: r
+
+        mock_workflow = Mock()
+        mock_workflow.name = "Test WF"
+        mock_workflow.id = "wf-1"
+        mock_workflow.warnings = []
+        mock_wf_repo = Mock()
+        mock_wf_repo.get_by_id.return_value = mock_workflow
+
+        svc = RunService(run_repo=mock_run_repo, workflow_repo=mock_wf_repo)
+        run = svc.create_run("wf-1", {"instruction": "go"})
+
+        assert run.warnings_json is None
 
 
 # ---------------------------------------------------------------------------

--- a/apps/api/tests/domain/test_run379_data_model.py
+++ b/apps/api/tests/domain/test_run379_data_model.py
@@ -430,6 +430,44 @@ class TestCreateRunPopulatesNewFields:
 
         assert run.warnings_json is None
 
+    def test_create_run_sets_warnings_json_none_when_workflow_warnings_missing(self):
+        """Guardrail: missing workflow.warnings on a Mock must not become stored warnings."""
+        from runsight_api.logic.services.run_service import RunService
+
+        mock_run_repo = Mock()
+        mock_run_repo.create_run.side_effect = lambda r: r
+
+        mock_workflow = Mock()
+        mock_workflow.name = "Test WF"
+        mock_workflow.id = "wf-1"
+        # Intentionally leave .warnings unset to exercise Mock getattr behavior.
+        mock_wf_repo = Mock()
+        mock_wf_repo.get_by_id.return_value = mock_workflow
+
+        svc = RunService(run_repo=mock_run_repo, workflow_repo=mock_wf_repo)
+        run = svc.create_run("wf-1", {"instruction": "go"})
+
+        assert run.warnings_json is None
+
+    def test_create_run_ignores_non_list_workflow_warnings(self):
+        """Guardrail: only non-empty list warnings are snapshotted."""
+        from runsight_api.logic.services.run_service import RunService
+
+        mock_run_repo = Mock()
+        mock_run_repo.create_run.side_effect = lambda r: r
+
+        mock_workflow = Mock()
+        mock_workflow.name = "Test WF"
+        mock_workflow.id = "wf-1"
+        mock_workflow.warnings = Mock(name="not_a_warning_list")
+        mock_wf_repo = Mock()
+        mock_wf_repo.get_by_id.return_value = mock_workflow
+
+        svc = RunService(run_repo=mock_run_repo, workflow_repo=mock_wf_repo)
+        run = svc.create_run("wf-1", {"instruction": "go"})
+
+        assert run.warnings_json is None
+
 
 # ---------------------------------------------------------------------------
 # 8. commit_sha does not fallback to workflow_commit_sha for old runs

--- a/apps/api/tests/domain/test_run663_entity_fields.py
+++ b/apps/api/tests/domain/test_run663_entity_fields.py
@@ -1,9 +1,12 @@
 """
 RUN-663 — Failing tests for RunNode.exit_handle field and SQLite backfill columns.
+RUN-842 — Failing tests for Run.warnings_json backfill coverage and migration.
 
 These tests verify:
   3. RunNode has an ``exit_handle`` field (currently missing)
   4. SQLite backfill dict covers the new nested-run columns
+  5. SQLite backfill dict covers Run.warnings_json
+  6. An Alembic migration adds/drops run.warnings_json
 
 Tests MUST fail because:
   - RunNode does not have ``exit_handle`` field
@@ -11,10 +14,13 @@ Tests MUST fail because:
     root_run_id, depth on ``run`` table
   - _ensure_sqlite_columns does not include child_run_id, exit_handle on
     ``runnode`` table
+  - _ensure_sqlite_columns does not include warnings_json on ``run`` table
+  - there is no Alembic migration that adds/drops warnings_json yet
 """
 
 from __future__ import annotations
 
+from pathlib import Path
 
 from runsight_api.domain.entities.run import RunNode
 
@@ -103,3 +109,38 @@ class TestSqliteBackfillColumns:
             assert col in source, (
                 f"_ensure_sqlite_columns must include '{col}' in the 'runnode' table backfill dict"
             )
+
+    def test_ensure_sqlite_columns_includes_run_warnings_json(self) -> None:
+        """(l) Backfill dict must cover warnings_json on the 'run' table."""
+        import inspect
+
+        from runsight_api.main import _ensure_sqlite_columns
+
+        source = inspect.getsource(_ensure_sqlite_columns)
+        assert "warnings_json" in source, (
+            "_ensure_sqlite_columns must include 'warnings_json' in the 'run' table backfill dict"
+        )
+
+
+class TestAlembicMigrationAddsRunWarningsJson:
+    """A migration must add and drop run.warnings_json for non-SQLite DBs."""
+
+    def test_migration_file_adds_and_drops_warnings_json(self) -> None:
+        """The Alembic versions directory should contain a migration for warnings_json."""
+        versions_dir = (
+            Path(__file__).resolve().parents[2] / "src" / "runsight_api" / "alembic" / "versions"
+        )
+        migration_sources = [
+            path.read_text() for path in versions_dir.glob("*.py") if path.name != "__init__.py"
+        ]
+
+        assert migration_sources, f"No Alembic migrations found in {versions_dir}"
+        assert any("warnings_json" in source for source in migration_sources), (
+            "Expected an Alembic migration that mentions warnings_json"
+        )
+        assert any(
+            "add_column" in source and "warnings_json" in source for source in migration_sources
+        ), "Expected an Alembic upgrade path that adds warnings_json"
+        assert any(
+            "drop_column" in source and "warnings_json" in source for source in migration_sources
+        ), "Expected an Alembic downgrade path that drops warnings_json"

--- a/apps/api/tests/domain/test_run663_entity_fields.py
+++ b/apps/api/tests/domain/test_run663_entity_fields.py
@@ -20,6 +20,7 @@ Tests MUST fail because:
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 from runsight_api.domain.entities.run import RunNode
@@ -121,26 +122,96 @@ class TestSqliteBackfillColumns:
             "_ensure_sqlite_columns must include 'warnings_json' in the 'run' table backfill dict"
         )
 
+    def test_ensure_sqlite_columns_backfills_warnings_json_on_legacy_run_table(
+        self, tmp_path
+    ) -> None:
+        """Backfill must execute and add run.warnings_json on legacy SQLite tables."""
+        from sqlalchemy import create_engine
+
+        from runsight_api.main import _ensure_sqlite_columns
+
+        db_path = tmp_path / "run663_legacy.sqlite"
+        engine = create_engine(f"sqlite:///{db_path}")
+        with engine.begin() as conn:
+            conn.exec_driver_sql(
+                """
+                CREATE TABLE run (
+                    id TEXT PRIMARY KEY,
+                    workflow_id TEXT NOT NULL,
+                    workflow_name TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    task_json TEXT NOT NULL
+                )
+                """
+            )
+            conn.exec_driver_sql(
+                """
+                CREATE TABLE runnode (
+                    id TEXT PRIMARY KEY,
+                    run_id TEXT NOT NULL,
+                    node_id TEXT NOT NULL,
+                    block_type TEXT NOT NULL,
+                    status TEXT NOT NULL
+                )
+                """
+            )
+
+        _ensure_sqlite_columns(engine)
+
+        with engine.begin() as conn:
+            run_columns = {
+                row[1] for row in conn.exec_driver_sql("PRAGMA table_info(run)").fetchall()
+            }
+            assert "warnings_json" in run_columns, (
+                "Expected _ensure_sqlite_columns to add warnings_json to legacy run table"
+            )
+
 
 class TestAlembicMigrationAddsRunWarningsJson:
     """A migration must add and drop run.warnings_json for non-SQLite DBs."""
 
     def test_migration_file_adds_and_drops_warnings_json(self) -> None:
-        """The Alembic versions directory should contain a migration for warnings_json."""
+        """Migration after 001_initial must batch-alter run and add/drop warnings_json."""
         versions_dir = (
             Path(__file__).resolve().parents[2] / "src" / "runsight_api" / "alembic" / "versions"
         )
-        migration_sources = [
-            path.read_text() for path in versions_dir.glob("*.py") if path.name != "__init__.py"
-        ]
-
-        assert migration_sources, f"No Alembic migrations found in {versions_dir}"
-        assert any("warnings_json" in source for source in migration_sources), (
-            "Expected an Alembic migration that mentions warnings_json"
+        version_files = sorted(
+            path for path in versions_dir.glob("*.py") if path.name != "__init__.py"
         )
-        assert any(
-            "add_column" in source and "warnings_json" in source for source in migration_sources
-        ), "Expected an Alembic upgrade path that adds warnings_json"
-        assert any(
-            "drop_column" in source and "warnings_json" in source for source in migration_sources
-        ), "Expected an Alembic downgrade path that drops warnings_json"
+        assert version_files, f"No Alembic migrations found in {versions_dir}"
+
+        follow_up_revisions = [path for path in version_files if "001_initial" not in path.stem]
+        assert follow_up_revisions, "Expected at least one migration file after 001_initial"
+
+        target_migrations: list[tuple[Path, str]] = []
+        for path in follow_up_revisions:
+            source = path.read_text()
+            if re.search(r'down_revision\s*[:=][^"\']*["\']001_initial["\']', source):
+                target_migrations.append((path, source))
+
+        assert target_migrations, "Expected a migration with down_revision = '001_initial'"
+
+        warning_migrations = [
+            (path, source) for path, source in target_migrations if "warnings_json" in source
+        ]
+        assert warning_migrations, "Expected migration after 001_initial to reference warnings_json"
+
+        for path, source in warning_migrations:
+            assert 'batch_alter_table("run")' in source or "batch_alter_table('run')" in source, (
+                f"{path.name} must use batch_alter_table('run') for SQLite compatibility"
+            )
+            upgrade_body = source.split("def upgrade", 1)[1].split("def downgrade", 1)[0]
+            assert "warnings_json" in upgrade_body and "add_column" in upgrade_body, (
+                f"{path.name} upgrade() must add run.warnings_json"
+            )
+            assert "nullable=True" in upgrade_body, (
+                f"{path.name} upgrade() must add warnings_json as nullable"
+            )
+            assert "JSON" in upgrade_body, (
+                f"{path.name} upgrade() must use a JSON column type for warnings_json"
+            )
+
+            downgrade_body = source.split("def downgrade", 1)[1]
+            assert "warnings_json" in downgrade_body and "drop_column" in downgrade_body, (
+                f"{path.name} downgrade() must drop run.warnings_json"
+            )

--- a/apps/api/tests/logic/test_run607_nested_run_lifecycle.py
+++ b/apps/api/tests/logic/test_run607_nested_run_lifecycle.py
@@ -47,6 +47,7 @@ def _create_run(
     parent_node_id: str | None = None,
     root_run_id: str | None = None,
     depth: int = 0,
+    warnings_json: list[dict[str, str | None]] | None = None,
 ) -> Run:
     """Insert a Run record with optional parent-child fields."""
     run = Run(
@@ -59,6 +60,7 @@ def _create_run(
         parent_node_id=parent_node_id,
         root_run_id=root_run_id,
         depth=depth,
+        warnings_json=warnings_json,
     )
     session.add(run)
     session.commit()
@@ -243,6 +245,31 @@ class TestChildRunCreatedAsSeparateRecord:
             assert child.depth == 1
             assert child.parent_run_id == "parent_run"
             assert child.id != "parent_run"
+
+    def test_child_run_does_not_inherit_parent_warnings(self, db_engine):
+        """Child workflow runs must not inherit the parent's warning snapshot."""
+        with Session(db_engine) as session:
+            _create_run(
+                session,
+                run_id="parent_warn_run",
+                workflow_id="wf_parent",
+                workflow_name="Parent",
+                depth=0,
+                warnings_json=[
+                    {
+                        "message": "Tool governance warning",
+                        "source": "tool_governance",
+                        "context": "fetcher",
+                    }
+                ],
+            )
+
+        obs = ExecutionObserver(engine=db_engine, run_id="parent_warn_run")
+        obs.on_block_start("Parent", "call_child", "workflow")
+
+        with Session(db_engine) as session:
+            child = session.exec(select(Run).where(Run.parent_run_id == "parent_warn_run")).one()
+            assert child.warnings_json is None
 
 
 # ---------------------------------------------------------------------------

--- a/apps/api/tests/test_run134_openapi_codegen.py
+++ b/apps/api/tests/test_run134_openapi_codegen.py
@@ -54,6 +54,32 @@ class TestOpenAPISpecExtraction:
         for expected in ["WorkflowResponse", "WorkflowCreate", "WorkflowUpdate"]:
             assert expected in schema_names, f"Missing schema: {expected}"
 
+    def test_openapi_spec_contains_warning_item_schema_and_workflow_warnings_property(self):
+        """Workflow responses must expose structured warnings in the OpenAPI schema."""
+        from runsight_api.main import app
+
+        spec = app.openapi()
+        schemas = spec.get("components", {}).get("schemas", {})
+
+        assert "WarningItem" in schemas, "Missing schema: WarningItem"
+
+        workflow_schema = schemas["WorkflowResponse"]
+        workflow_properties = workflow_schema.get("properties", {})
+        assert "warnings" in workflow_properties, "WorkflowResponse is missing warnings"
+
+        warnings_property = workflow_properties["warnings"]
+        assert warnings_property.get("type") == "array"
+        assert warnings_property.get("items", {}).get("$ref", "").endswith(
+            "/WarningItem"
+        )
+
+        warning_item_schema = schemas["WarningItem"]
+        warning_properties = warning_item_schema.get("properties", {})
+        for expected in ["message", "source", "context"]:
+            assert expected in warning_properties, (
+                f"WarningItem is missing property: {expected}"
+            )
+
     def test_openapi_spec_contains_run_schemas(self):
         """The spec must include RunResponse, RunCreate, RunNodeResponse schemas."""
         from runsight_api.main import app

--- a/apps/api/tests/test_run134_openapi_codegen.py
+++ b/apps/api/tests/test_run134_openapi_codegen.py
@@ -83,6 +83,30 @@ class TestOpenAPISpecExtraction:
         assert "code" not in warning_properties
         assert "severity" not in warning_properties
 
+    def test_committed_openapi_snapshot_pins_workflow_only_warning_contract(self):
+        """The committed OpenAPI snapshot must keep workflow warnings out of run contracts."""
+        snapshot = json.loads((REPO_ROOT / "openapi.json").read_text())
+        schemas = snapshot.get("components", {}).get("schemas", {})
+
+        warning_item_schema = schemas.get("WarningItem")
+        assert warning_item_schema is not None, "Missing committed WarningItem schema"
+        warning_properties = warning_item_schema.get("properties", {})
+        assert set(warning_properties) == {"message", "source", "context"}
+
+        workflow_schema = schemas.get("WorkflowResponse")
+        assert workflow_schema is not None, "Missing committed WorkflowResponse schema"
+        workflow_properties = workflow_schema.get("properties", {})
+        warnings_property = workflow_properties.get("warnings")
+        assert warnings_property is not None, "WorkflowResponse missing warnings"
+        assert warnings_property.get("items", {}).get("$ref", "").endswith(
+            "/WarningItem"
+        )
+
+        run_schema = schemas.get("RunResponse")
+        assert run_schema is not None, "Missing committed RunResponse schema"
+        run_properties = run_schema.get("properties", {})
+        assert "warnings" not in run_properties
+
     def test_openapi_spec_contains_run_schemas(self):
         """The spec must include RunResponse, RunCreate, RunNodeResponse schemas."""
         from runsight_api.main import app
@@ -91,6 +115,9 @@ class TestOpenAPISpecExtraction:
         schema_names = set(spec.get("components", {}).get("schemas", {}).keys())
         for expected in ["RunResponse", "RunCreate", "RunNodeResponse"]:
             assert expected in schema_names, f"Missing schema: {expected}"
+
+        run_properties = spec["components"]["schemas"]["RunResponse"]["properties"]
+        assert "warnings" not in run_properties
 
     def test_openapi_spec_contains_soul_schemas(self):
         """The spec must include SoulResponse, SoulCreate, SoulUpdate schemas."""

--- a/apps/api/tests/test_run134_openapi_codegen.py
+++ b/apps/api/tests/test_run134_openapi_codegen.py
@@ -83,8 +83,8 @@ class TestOpenAPISpecExtraction:
         assert "code" not in warning_properties
         assert "severity" not in warning_properties
 
-    def test_committed_openapi_snapshot_pins_workflow_only_warning_contract(self):
-        """The committed OpenAPI snapshot must keep workflow warnings out of run contracts."""
+    def test_committed_openapi_snapshot_pins_workflow_and_run_warning_contracts(self):
+        """The committed OpenAPI snapshot must expose warnings on workflow and run responses."""
         snapshot = json.loads((REPO_ROOT / "openapi.json").read_text())
         schemas = snapshot.get("components", {}).get("schemas", {})
 
@@ -105,7 +105,10 @@ class TestOpenAPISpecExtraction:
         run_schema = schemas.get("RunResponse")
         assert run_schema is not None, "Missing committed RunResponse schema"
         run_properties = run_schema.get("properties", {})
-        assert "warnings" not in run_properties
+        run_warnings = run_properties.get("warnings")
+        assert run_warnings is not None, "RunResponse missing warnings"
+        assert run_warnings.get("type") == "array"
+        assert run_warnings.get("items", {}).get("$ref", "").endswith("/WarningItem")
 
     def test_openapi_spec_contains_run_schemas(self):
         """The spec must include RunResponse, RunCreate, RunNodeResponse schemas."""
@@ -117,7 +120,11 @@ class TestOpenAPISpecExtraction:
             assert expected in schema_names, f"Missing schema: {expected}"
 
         run_properties = spec["components"]["schemas"]["RunResponse"]["properties"]
-        assert "warnings" not in run_properties
+        assert "warnings" in run_properties, "RunResponse is missing warnings"
+        assert run_properties["warnings"].get("type") == "array"
+        assert run_properties["warnings"].get("items", {}).get("$ref", "").endswith(
+            "/WarningItem"
+        )
 
     def test_openapi_spec_contains_soul_schemas(self):
         """The spec must include SoulResponse, SoulCreate, SoulUpdate schemas."""

--- a/apps/api/tests/test_run134_openapi_codegen.py
+++ b/apps/api/tests/test_run134_openapi_codegen.py
@@ -83,6 +83,24 @@ class TestOpenAPISpecExtraction:
         assert "code" not in warning_properties
         assert "severity" not in warning_properties
 
+    def test_openapi_spec_exposes_single_canonical_warning_item_component(self):
+        """Warnings must use one canonical WarningItem component across workflow/run schemas."""
+        from runsight_api.main import app
+
+        spec = app.openapi()
+        schemas = spec.get("components", {}).get("schemas", {})
+
+        warning_components = sorted(
+            name for name in schemas if "warningitem" in name.lower()
+        )
+        assert warning_components == ["WarningItem"], (
+            "OpenAPI must expose exactly one WarningItem-like component"
+        )
+
+        run_schema = schemas.get("RunResponse", {})
+        run_warnings = run_schema.get("properties", {}).get("warnings", {})
+        assert run_warnings.get("items", {}).get("$ref", "").endswith("/WarningItem")
+
     def test_committed_openapi_snapshot_pins_workflow_and_run_warning_contracts(self):
         """The committed OpenAPI snapshot must expose warnings on workflow and run responses."""
         snapshot = json.loads((REPO_ROOT / "openapi.json").read_text())
@@ -109,6 +127,13 @@ class TestOpenAPISpecExtraction:
         assert run_warnings is not None, "RunResponse missing warnings"
         assert run_warnings.get("type") == "array"
         assert run_warnings.get("items", {}).get("$ref", "").endswith("/WarningItem")
+
+        warning_components = sorted(
+            name for name in schemas if "warningitem" in name.lower()
+        )
+        assert warning_components == ["WarningItem"], (
+            "Committed snapshot must keep a single canonical WarningItem component"
+        )
 
     def test_openapi_spec_contains_run_schemas(self):
         """The spec must include RunResponse, RunCreate, RunNodeResponse schemas."""

--- a/apps/api/tests/test_run134_openapi_codegen.py
+++ b/apps/api/tests/test_run134_openapi_codegen.py
@@ -75,10 +75,13 @@ class TestOpenAPISpecExtraction:
 
         warning_item_schema = schemas["WarningItem"]
         warning_properties = warning_item_schema.get("properties", {})
+        assert set(warning_properties) == {"message", "source", "context"}
         for expected in ["message", "source", "context"]:
             assert expected in warning_properties, (
                 f"WarningItem is missing property: {expected}"
             )
+        assert "code" not in warning_properties
+        assert "severity" not in warning_properties
 
     def test_openapi_spec_contains_run_schemas(self):
         """The spec must include RunResponse, RunCreate, RunNodeResponse schemas."""

--- a/apps/api/tests/test_run845_parser_warnings_e2e.py
+++ b/apps/api/tests/test_run845_parser_warnings_e2e.py
@@ -261,12 +261,18 @@ async def test_workflow_warning_shape_run_snapshot_and_immutability(
     app_without_execution, base_dir
 ):
     from httpx import ASGITransport, AsyncClient
+    from runsight_api.transport.deps import get_execution_service
 
     soul_key = "run845_warning_soul"
     _write_warning_soul(base_dir, soul_key)
 
     warning_yaml = _warning_workflow_yaml(soul_key, declare_http=False)
     fixed_yaml = _warning_workflow_yaml(soul_key, declare_http=True)
+    fake_execution = Mock()
+    fake_execution.launch_execution = AsyncMock()
+    app_without_execution.dependency_overrides[get_execution_service] = (
+        lambda request=None: fake_execution
+    )
 
     async with AsyncClient(
         transport=ASGITransport(app=app_without_execution),
@@ -310,6 +316,12 @@ async def test_workflow_warning_shape_run_snapshot_and_immutability(
         run_data = create_run.json()
         run_id = run_data["id"]
         assert run_data["warnings"] == warnings
+        fake_execution.launch_execution.assert_called_once_with(
+            run_id,
+            workflow_id,
+            {},
+            branch="main",
+        )
 
         run_detail_before_fix = await client.get(f"/api/runs/{run_id}")
         assert run_detail_before_fix.status_code == 200

--- a/apps/api/tests/test_run845_parser_warnings_e2e.py
+++ b/apps/api/tests/test_run845_parser_warnings_e2e.py
@@ -1,0 +1,440 @@
+"""E2E coverage for RUN-845 parser warnings across workflow/run API flows.
+
+These tests verify:
+1) Workflow warnings are returned in canonical v1 shape (message/source/context)
+2) Run creation snapshots workflow warnings immutably
+3) Declared tools with corrupt metadata produce warnings while execution continues
+4) Child runs do not inherit parent warning snapshots through API responses
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from sqlmodel import SQLModel, Session, create_engine, select
+
+from runsight_api.domain.entities.run import Run, RunStatus
+from runsight_api.logic.observers.execution_observer import ExecutionObserver
+
+
+def _write_warning_soul(base_dir: Path, soul_key: str) -> None:
+    souls_dir = base_dir / "custom" / "souls"
+    souls_dir.mkdir(parents=True, exist_ok=True)
+    (souls_dir / f"{soul_key}.yaml").write_text(
+        "\n".join(
+            [
+                f"id: {soul_key}",
+                "role: Warning Soul",
+                "system_prompt: You are a warning-only soul.",
+                "provider: openai",
+                "model_name: gpt-4o",
+                "tools: [http]",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_openai_provider(base_dir: Path) -> None:
+    provider_dir = base_dir / "custom" / "providers"
+    provider_dir.mkdir(parents=True, exist_ok=True)
+    (provider_dir / "openai.yaml").write_text(
+        "\n".join(
+            [
+                "name: openai",
+                "type: openai",
+                "api_key: ${OPENAI_API_KEY}",
+                "is_active: true",
+                "models:",
+                "  - gpt-4o",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_corrupt_custom_tool(base_dir: Path, tool_id: str) -> None:
+    tools_dir = base_dir / "custom" / "tools"
+    tools_dir.mkdir(parents=True, exist_ok=True)
+    (tools_dir / f"{tool_id}.yaml").write_text(
+        "\n".join(
+            [
+                'version: "1.0"',
+                "type: custom",
+                "executor: python",
+                "name: Broken lookup",
+                "description: Intentionally broken metadata",
+                "parameters:",
+                "  type: object",
+                "code: |",
+                "  def main(args):",
+                "      return {'broken':",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def _warning_workflow_yaml(soul_key: str, *, declare_http: bool) -> str:
+    tools_section = "tools:\n  - http\n" if declare_http else ""
+    return (
+        'version: "1.0"\n'
+        "config:\n"
+        "  model_name: gpt-4o\n"
+        f"{tools_section}"
+        "blocks:\n"
+        "  analyze:\n"
+        "    type: linear\n"
+        f"    soul_ref: {soul_key}\n"
+        "workflow:\n"
+        "  name: run845_parser_warning_workflow\n"
+        "  entry: analyze\n"
+        "  transitions:\n"
+        "    - from: analyze\n"
+        "      to: null\n"
+    )
+
+
+BIND_LOOP_WARNING_YAML = """\
+version: "1.0"
+config:
+  model_name: gpt-4o
+tools:
+  - lookup_profile
+souls:
+  analyst:
+    id: analyst
+    role: Analyst
+    system_prompt: Use the lookup tool if needed.
+    provider: openai
+    model_name: gpt-4o
+    tools:
+      - lookup_profile
+blocks:
+  analyze:
+    type: linear
+    soul_ref: analyst
+workflow:
+  name: run845_bind_loop_warning
+  entry: analyze
+  transitions:
+    - from: analyze
+      to: null
+"""
+
+
+def _make_achat_response(content: str):
+    return {
+        "content": content,
+        "cost_usd": 0.001,
+        "prompt_tokens": 50,
+        "completion_tokens": 50,
+        "total_tokens": 100,
+        "tool_calls": None,
+        "finish_reason": "stop",
+        "raw_message": {"role": "assistant", "content": content},
+    }
+
+
+async def _wait_for_run_terminal(engine, run_id: str, timeout: float = 10.0):
+    deadline = asyncio.get_running_loop().time() + timeout
+    terminal = {RunStatus.completed, RunStatus.failed, RunStatus.cancelled}
+    while asyncio.get_running_loop().time() < deadline:
+        with Session(engine) as session:
+            run = session.get(Run, run_id)
+            if run is not None and run.status in terminal:
+                return run
+        await asyncio.sleep(0.1)
+    with Session(engine) as session:
+        return session.get(Run, run_id)
+
+
+@pytest.fixture
+def db_engine():
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    SQLModel.metadata.create_all(engine)
+    return engine
+
+
+@pytest.fixture
+def base_dir():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield Path(tmpdir)
+
+
+def _build_app(db_engine, base_dir: Path, *, include_execution: bool):
+    from fastapi import FastAPI
+    from sqlmodel import Session
+
+    from runsight_api.data.filesystem.provider_repo import FileSystemProviderRepo
+    from runsight_api.data.filesystem.workflow_repo import WorkflowRepository
+    from runsight_api.data.repositories.run_repo import RunRepository
+    from runsight_api.logic.services.eval_service import EvalService
+    from runsight_api.logic.services.execution_service import ExecutionService
+    from runsight_api.logic.services.run_service import RunService
+    from runsight_api.logic.services.workflow_service import WorkflowService
+    from runsight_api.transport.deps import (
+        get_eval_service,
+        get_execution_service,
+        get_run_service,
+        get_workflow_service,
+    )
+    from runsight_api.transport.routers import runs, workflows
+
+    workflow_repo = WorkflowRepository(str(base_dir))
+
+    app = FastAPI()
+    app.include_router(workflows.router, prefix="/api")
+    app.include_router(runs.router, prefix="/api")
+
+    def _get_workflow_service():
+        session = Session(db_engine)
+        run_repo = RunRepository(session)
+        return WorkflowService(workflow_repo, run_repo, git_service=None)
+
+    def _get_run_service():
+        session = Session(db_engine)
+        run_repo = RunRepository(session)
+        return RunService(run_repo, workflow_repo)
+
+    def _get_eval_service():
+        session = Session(db_engine)
+        run_repo = RunRepository(session)
+        return EvalService(run_repo)
+
+    app.dependency_overrides[get_workflow_service] = _get_workflow_service
+    app.dependency_overrides[get_run_service] = _get_run_service
+    app.dependency_overrides[get_eval_service] = _get_eval_service
+
+    if include_execution:
+        provider_repo = FileSystemProviderRepo(base_path=str(base_dir))
+        mock_secrets = Mock()
+        mock_secrets.resolve = Mock(return_value="sk-fake-run845")
+        execution_service = ExecutionService(
+            run_repo=None,
+            workflow_repo=workflow_repo,
+            provider_repo=provider_repo,
+            engine=db_engine,
+            secrets=mock_secrets,
+            settings_repo=None,
+        )
+        app.state.execution_service = execution_service
+
+        def _get_execution_service(request=None):
+            return execution_service
+
+        app.dependency_overrides[get_execution_service] = _get_execution_service
+    else:
+
+        def _get_execution_service(request=None):
+            return None
+
+        app.dependency_overrides[get_execution_service] = _get_execution_service
+
+    return app
+
+
+@pytest.fixture
+def app_without_execution(db_engine, base_dir):
+    app = _build_app(db_engine, base_dir, include_execution=False)
+    yield app
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def app_with_execution(db_engine, base_dir):
+    _write_openai_provider(base_dir)
+    app = _build_app(db_engine, base_dir, include_execution=True)
+    yield app
+    app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_workflow_warning_shape_run_snapshot_and_immutability(
+    app_without_execution, base_dir
+):
+    from httpx import ASGITransport, AsyncClient
+
+    soul_key = "run845_warning_soul"
+    _write_warning_soul(base_dir, soul_key)
+
+    warning_yaml = _warning_workflow_yaml(soul_key, declare_http=False)
+    fixed_yaml = _warning_workflow_yaml(soul_key, declare_http=True)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app_without_execution),
+        base_url="http://test",
+    ) as client:
+        create_workflow = await client.post(
+            "/api/workflows",
+            json={
+                "name": "RUN-845 warning workflow",
+                "yaml": warning_yaml,
+                "commit": False,
+            },
+        )
+        assert create_workflow.status_code == 200
+        workflow_id = create_workflow.json()["id"]
+
+        workflow_detail = await client.get(f"/api/workflows/{workflow_id}")
+        assert workflow_detail.status_code == 200
+        workflow_data = workflow_detail.json()
+        assert workflow_data["valid"] is True
+
+        warnings = workflow_data["warnings"]
+        assert len(warnings) == 1
+        warning = warnings[0]
+        assert set(warning.keys()) == {"message", "source", "context"}
+        assert isinstance(warning["message"], str)
+        assert warning["context"] is None or isinstance(warning["context"], str)
+        assert warning["source"] is None or isinstance(warning["source"], str)
+        assert "undeclared tool" in warning["message"].lower()
+        assert "code" not in warning
+        assert not isinstance(warning["context"], dict)
+
+        create_run = await client.post(
+            "/api/runs",
+            json={
+                "workflow_id": workflow_id,
+                "task_data": {},
+            },
+        )
+        assert create_run.status_code == 200
+        run_data = create_run.json()
+        run_id = run_data["id"]
+        assert run_data["warnings"] == warnings
+
+        run_detail_before_fix = await client.get(f"/api/runs/{run_id}")
+        assert run_detail_before_fix.status_code == 200
+        assert run_detail_before_fix.json()["warnings"] == warnings
+
+        update_workflow = await client.put(
+            f"/api/workflows/{workflow_id}",
+            json={"yaml": fixed_yaml},
+        )
+        assert update_workflow.status_code == 200
+
+        workflow_detail_after_fix = await client.get(f"/api/workflows/{workflow_id}")
+        assert workflow_detail_after_fix.status_code == 200
+        assert workflow_detail_after_fix.json()["warnings"] == []
+
+        run_detail_after_fix = await client.get(f"/api/runs/{run_id}")
+        assert run_detail_after_fix.status_code == 200
+        assert run_detail_after_fix.json()["warnings"] == warnings
+
+
+@pytest.mark.asyncio
+async def test_bind_loop_warning_from_corrupt_metadata_does_not_block_execution(
+    app_with_execution, base_dir, db_engine
+):
+    from httpx import ASGITransport, AsyncClient
+
+    _write_corrupt_custom_tool(base_dir, "lookup_profile")
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app_with_execution),
+        base_url="http://test",
+    ) as client:
+        create_workflow = await client.post(
+            "/api/workflows",
+            json={
+                "name": "RUN-845 bind-loop warning workflow",
+                "yaml": BIND_LOOP_WARNING_YAML,
+                "commit": False,
+            },
+        )
+        assert create_workflow.status_code == 200
+        workflow_id = create_workflow.json()["id"]
+
+        workflow_detail = await client.get(f"/api/workflows/{workflow_id}")
+        assert workflow_detail.status_code == 200
+        workflow_data = workflow_detail.json()
+        assert workflow_data["valid"] is True
+        assert workflow_data["warnings"], "Expected warning from corrupt custom tool metadata"
+        first_warning = workflow_data["warnings"][0]
+        assert first_warning["source"] == "tool_definitions"
+        assert first_warning["context"] == "lookup_profile"
+
+        with patch(
+            "runsight_core.llm.client.LiteLLMClient.achat",
+            new_callable=AsyncMock,
+            return_value=_make_achat_response("Execution continued despite warning."),
+        ):
+            create_run = await client.post(
+                "/api/runs",
+                json={
+                    "workflow_id": workflow_id,
+                    "task_data": {"instruction": "Run with warning-only tool metadata"},
+                },
+            )
+
+            assert create_run.status_code == 200
+            run_payload = create_run.json()
+            run_id = run_payload["id"]
+            assert run_payload["warnings"] == workflow_data["warnings"]
+
+            terminal_run = await _wait_for_run_terminal(db_engine, run_id, timeout=10.0)
+            assert terminal_run is not None
+            assert terminal_run.status == RunStatus.completed
+
+            run_detail = await client.get(f"/api/runs/{run_id}")
+            assert run_detail.status_code == 200
+            run_data = run_detail.json()
+            assert run_data["warnings"] == workflow_data["warnings"]
+            assert run_data["status"] == RunStatus.completed.value
+
+
+@pytest.mark.asyncio
+async def test_child_run_warnings_do_not_inherit_parent_snapshot(app_without_execution, db_engine):
+    from httpx import ASGITransport, AsyncClient
+
+    parent_run_id = "run845_parent"
+    parent_warning = {
+        "message": "Parent warning should not propagate",
+        "source": "tool_governance",
+        "context": "parent_soul",
+    }
+
+    with Session(db_engine) as session:
+        session.add(
+            Run(
+                id=parent_run_id,
+                workflow_id="wf_parent_845",
+                workflow_name="Parent workflow",
+                status=RunStatus.running,
+                task_json="{}",
+                warnings_json=[parent_warning],
+            )
+        )
+        session.commit()
+
+    observer = ExecutionObserver(engine=db_engine, run_id=parent_run_id)
+    observer.on_block_start(
+        "Parent workflow",
+        "invoke_child",
+        "workflow",
+        child_workflow_id="wf_child_845",
+        child_workflow_name="Child workflow",
+    )
+
+    with Session(db_engine) as session:
+        children = list(session.exec(select(Run).where(Run.parent_run_id == parent_run_id)).all())
+        assert len(children) == 1
+        child = children[0]
+        assert child.warnings_json is None
+        child_run_id = child.id
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app_without_execution),
+        base_url="http://test",
+    ) as client:
+        child_response = await client.get(f"/api/runs/{child_run_id}")
+        assert child_response.status_code == 200
+        assert child_response.json()["warnings"] == []

--- a/apps/api/tests/transport/test_run478_workflow_health_router.py
+++ b/apps/api/tests/transport/test_run478_workflow_health_router.py
@@ -11,7 +11,9 @@ import pytest
 from runsight_api.domain.value_objects import WorkflowEntity
 from runsight_api.main import app
 from runsight_api.transport.deps import get_workflow_service
-from runsight_api.transport.schemas.workflows import WorkflowResponse
+from runsight_api.transport.schemas import workflows as workflow_schemas
+
+WorkflowResponse = workflow_schemas.WorkflowResponse
 
 client = TestClient(app, raise_server_exceptions=False)
 
@@ -99,6 +101,43 @@ class TestWorkflowResponseModelShape:
             assert field_name in fields, f"Missing workflow response field: {field_name}"
 
         assert "eval_health" in _workflow_health_model_fields()
+
+
+class TestWorkflowResponseWarningsModelShape:
+    def test_workflow_response_declares_warnings_as_a_list_field(self):
+        fields = WorkflowResponse.model_fields
+
+        assert "warnings" in fields
+        assert fields["warnings"].default_factory is list
+
+    def test_warning_item_declares_the_canonical_warning_payload_fields(self):
+        warning_item = getattr(workflow_schemas, "WarningItem")
+        fields = warning_item.model_fields
+
+        assert set(fields) == {"message", "source", "context"}
+        assert fields["message"].is_required()
+        assert fields["source"].default is None
+        assert fields["context"].default is None
+
+    def test_workflow_response_parses_warning_items(self):
+        response = WorkflowResponse.model_validate(
+            {
+                "id": "wf_1",
+                "warnings": [
+                    {
+                        "message": "Tool definition warning",
+                        "source": "tool_definitions",
+                        "context": "lookup_profile",
+                    }
+                ],
+            }
+        )
+
+        assert len(response.warnings) == 1
+        warning = response.warnings[0]
+        assert warning.message == "Tool definition warning"
+        assert warning.source == "tool_definitions"
+        assert warning.context == "lookup_profile"
 
 
 class TestWorkflowsListResponse:

--- a/apps/api/tests/transport/test_run478_workflow_health_router.py
+++ b/apps/api/tests/transport/test_run478_workflow_health_router.py
@@ -6,6 +6,7 @@ Uses the real app with dependency_overrides — no sys.modules stubbing.
 from unittest.mock import Mock
 
 from fastapi.testclient import TestClient
+from pydantic import ValidationError
 import pytest
 
 from runsight_api.domain.value_objects import WorkflowEntity
@@ -119,6 +120,32 @@ class TestWorkflowResponseWarningsModelShape:
         assert fields["source"].default is None
         assert fields["context"].default is None
 
+    def test_warning_item_rejects_object_context_and_extra_fields(self):
+        warning_item = getattr(workflow_schemas, "WarningItem")
+
+        with pytest.raises(ValidationError):
+            warning_item.model_validate(
+                {
+                    "message": "Tool definition warning",
+                    "source": "tool_definitions",
+                    "context": {"tool_id": "lookup_profile"},
+                }
+            )
+
+        parsed = warning_item.model_validate(
+            {
+                "message": "Tool definition warning",
+                "source": "tool_definitions",
+                "context": None,
+                "code": "W001",
+                "severity": "warning",
+            }
+        )
+
+        assert parsed.context is None
+        assert not hasattr(parsed, "code")
+        assert not hasattr(parsed, "severity")
+
     def test_workflow_response_parses_warning_items(self):
         response = WorkflowResponse.model_validate(
             {
@@ -138,6 +165,22 @@ class TestWorkflowResponseWarningsModelShape:
         assert warning.message == "Tool definition warning"
         assert warning.source == "tool_definitions"
         assert warning.context == "lookup_profile"
+
+    def test_workflow_response_parses_null_context_warning_items(self):
+        response = WorkflowResponse.model_validate(
+            {
+                "id": "wf_1",
+                "warnings": [
+                    {
+                        "message": "Tool definition warning",
+                        "source": "tool_definitions",
+                        "context": None,
+                    }
+                ],
+            }
+        )
+
+        assert response.warnings[0].context is None
 
 
 class TestWorkflowsListResponse:

--- a/apps/api/tests/transport/test_run612_child_run_queries.py
+++ b/apps/api/tests/transport/test_run612_child_run_queries.py
@@ -220,6 +220,39 @@ class TestGetChildrenReturnsChildRunsOnly:
         finally:
             app.dependency_overrides.clear()
 
+    def test_get_children_wires_non_empty_warnings(self):
+        """Children response must expose warnings from child.warnings_json when present."""
+        parent = _make_mock_run("run_612_parent")
+        child = _make_mock_run(
+            "run_612_child_warned",
+            parent_run_id="run_612_parent",
+            root_run_id="run_612_parent",
+            depth=1,
+        )
+        child.warnings_json = [
+            {
+                "message": "Tool definition warning",
+                "source": "tool_definitions",
+                "context": "fetch_child_profile",
+            }
+        ]
+        mock_service = _mock_run_service_with_children(parent, [child])
+        mock_eval = _mock_eval_service()
+
+        app.dependency_overrides[get_run_service] = lambda: mock_service
+        app.dependency_overrides[get_eval_service] = lambda: mock_eval
+        client = TestClient(app, raise_server_exceptions=False)
+
+        try:
+            response = client.get("/api/runs/run_612_parent/children")
+            assert response.status_code == 200
+            body = response.json()
+            assert len(body) == 1
+            assert body[0]["id"] == "run_612_child_warned"
+            assert body[0]["warnings"] == child.warnings_json
+        finally:
+            app.dependency_overrides.clear()
+
 
 # ===========================================================================
 # 3. GET /runs/{run_id}/children returns empty list for leaf runs

--- a/apps/api/tests/transport/test_run612_child_run_queries.py
+++ b/apps/api/tests/transport/test_run612_child_run_queries.py
@@ -78,6 +78,7 @@ def _make_mock_run(
     mock_run.parent_run_id = parent_run_id
     mock_run.root_run_id = root_run_id
     mock_run.depth = depth
+    mock_run.warnings_json = None
     mock_run.error = None
     mock_run.regression_count = None
     return mock_run
@@ -215,6 +216,7 @@ class TestGetChildrenReturnsChildRunsOnly:
             assert body[0]["parent_run_id"] == "run_612_parent"
             assert body[0]["root_run_id"] == "run_612_parent"
             assert body[0]["depth"] == 1
+            assert body[0]["warnings"] == []
         finally:
             app.dependency_overrides.clear()
 
@@ -290,6 +292,7 @@ class TestRunDetailIncludesLinkageFields:
             assert body["parent_run_id"] == "run_612_parent"
             assert body["root_run_id"] == "run_612_parent"
             assert body["depth"] == 1
+            assert body["warnings"] == []
         finally:
             app.dependency_overrides.clear()
 

--- a/apps/api/tests/transport/test_runs_router.py
+++ b/apps/api/tests/transport/test_runs_router.py
@@ -37,6 +37,7 @@ def _make_mock_run(run_id="run_123"):
     mock_run.parent_run_id = None
     mock_run.root_run_id = None
     mock_run.depth = 0
+    mock_run.warnings_json = None
     mock_run.error = None
     return mock_run
 
@@ -44,6 +45,13 @@ def _make_mock_run(run_id="run_123"):
 def test_runs_list():
     mock_service = Mock()
     mock_run = _make_mock_run()
+    mock_run.warnings_json = [
+        {
+            "message": "Tool definition warning",
+            "source": "tool_definitions",
+            "context": "fetcher",
+        }
+    ]
     mock_service.list_runs_paginated.return_value = ([mock_run], 1)
     mock_service.get_node_summaries_batch.return_value = {
         mock_run.id: {
@@ -77,12 +85,14 @@ def test_runs_list():
     assert "total" in data
     assert len(data["items"]) == 1
     assert data["items"][0]["id"] == "run_123"
+    assert data["items"][0]["warnings"] == mock_run.warnings_json
     app.dependency_overrides.clear()
 
 
 def test_runs_get():
     mock_service = Mock()
     mock_run = _make_mock_run()
+    mock_run.warnings_json = None
     mock_service.get_run.return_value = mock_run
     mock_service.get_node_summary.return_value = {
         "total_cost_usd": 0.0,
@@ -100,6 +110,7 @@ def test_runs_get():
     response = client.get("/api/runs/run_123")
     assert response.status_code == 200
     assert response.json()["id"] == "run_123"
+    assert response.json()["warnings"] == []
     app.dependency_overrides.clear()
 
 
@@ -116,6 +127,13 @@ def test_runs_get_404():
 def test_runs_post():
     mock_service = Mock()
     mock_run = _make_mock_run("run_new")
+    mock_run.warnings_json = [
+        {
+            "message": "Tool definition warning",
+            "source": "tool_definitions",
+            "context": "fetcher",
+        }
+    ]
     mock_service.create_run.return_value = mock_run
     mock_exec_service = Mock()
     mock_exec_service.launch_execution = AsyncMock()
@@ -125,6 +143,7 @@ def test_runs_post():
     response = client.post("/api/runs", json={"workflow_id": "wf_1", "task_data": {}})
     assert response.status_code == 200
     assert response.json()["id"] == "run_new"
+    assert response.json()["warnings"] == mock_run.warnings_json
     app.dependency_overrides.clear()
 
 

--- a/apps/api/tests/transport/test_runs_router.py
+++ b/apps/api/tests/transport/test_runs_router.py
@@ -114,6 +114,78 @@ def test_runs_get():
     app.dependency_overrides.clear()
 
 
+def test_runs_get_wires_non_empty_warnings():
+    mock_service = Mock()
+    mock_run = _make_mock_run("run_warned_detail")
+    mock_run.warnings_json = [
+        {
+            "message": "Tool definition warning",
+            "source": "tool_definitions",
+            "context": "fetcher",
+        }
+    ]
+    mock_service.get_run.return_value = mock_run
+    mock_service.get_node_summary.return_value = {
+        "total_cost_usd": 0.0,
+        "total_tokens": 0,
+        "nodes_count": 0,
+        "total": 0,
+        "completed": 0,
+        "running": 0,
+        "pending": 0,
+        "failed": 0,
+    }
+    app.dependency_overrides[get_run_service] = lambda: mock_service
+    app.dependency_overrides[get_eval_service] = lambda: _mock_eval_svc()
+
+    response = client.get("/api/runs/run_warned_detail")
+    assert response.status_code == 200
+    assert response.json()["warnings"] == mock_run.warnings_json
+    app.dependency_overrides.clear()
+
+
+def test_runs_get_coerces_non_list_warning_payloads_to_empty_list():
+    """Guardrail: route coercion must ignore mock placeholders and non-list warnings_json."""
+    mock_service = Mock()
+    mock_run = Mock()
+    mock_run.id = "run_mock_warn_trap"
+    mock_run.workflow_id = "wf_1"
+    mock_run.workflow_name = "wf_1"
+    mock_run.status = RunStatus.pending
+    mock_run.started_at = 123.0
+    mock_run.completed_at = None
+    mock_run.duration_s = None
+    mock_run.created_at = 123.0
+    mock_run.branch = "main"
+    mock_run.source = "manual"
+    mock_run.commit_sha = None
+    mock_run.run_number = None
+    mock_run.eval_pass_pct = None
+    mock_run.parent_run_id = None
+    mock_run.root_run_id = None
+    mock_run.depth = 0
+    mock_run.error = None
+    # Intentionally omit warnings_json to exercise Mock getattr() trap.
+    mock_service.get_run.return_value = mock_run
+    mock_service.get_node_summary.return_value = {
+        "total_cost_usd": 0.0,
+        "total_tokens": 0,
+        "nodes_count": 0,
+        "total": 0,
+        "completed": 0,
+        "running": 0,
+        "pending": 0,
+        "failed": 0,
+    }
+    app.dependency_overrides[get_run_service] = lambda: mock_service
+    app.dependency_overrides[get_eval_service] = lambda: _mock_eval_svc()
+
+    response = client.get("/api/runs/run_mock_warn_trap")
+    assert response.status_code == 200
+    assert response.json()["warnings"] == []
+    app.dependency_overrides.clear()
+
+
 def test_runs_get_404():
     mock_service = Mock()
     mock_service.get_run.return_value = None

--- a/apps/api/tests/transport/test_workflows_router.py
+++ b/apps/api/tests/transport/test_workflows_router.py
@@ -12,6 +12,11 @@ from runsight_api.main import app
 from runsight_api.transport.deps import get_workflow_service
 
 client = TestClient(app, raise_server_exceptions=False)
+WARNING_PAYLOAD = {
+    "message": "Tool definition warning",
+    "source": "tool_definitions",
+    "context": "lookup_profile",
+}
 
 
 def teardown_function():
@@ -20,7 +25,13 @@ def teardown_function():
 
 def test_workflows_list():
     mock_service = Mock()
-    mock_wf = WorkflowEntity(id="wf_1", name="Test Flow", blocks={}, edges=[])
+    mock_wf = WorkflowEntity(
+        id="wf_1",
+        name="Test Flow",
+        blocks={},
+        edges=[],
+        warnings=[WARNING_PAYLOAD],
+    )
     mock_service.list_workflows.return_value = [mock_wf]
     app.dependency_overrides[get_workflow_service] = lambda: mock_service
 
@@ -31,7 +42,7 @@ def test_workflows_list():
     assert "total" in data
     assert len(data["items"]) == 1
     assert data["items"][0]["id"] == "wf_1"
-    assert data["items"][0]["warnings"] == []
+    assert data["items"][0]["warnings"] == [WARNING_PAYLOAD]
 
 
 def test_workflows_get():
@@ -48,13 +59,7 @@ def test_workflows_get():
         blocks={},
         edges=[],
         commit_sha="abc123def456",
-        warnings=[
-            {
-                "message": "Tool definition warning",
-                "source": "tool_definitions",
-                "context": "lookup_profile",
-            }
-        ],
+        warnings=[WARNING_PAYLOAD],
     )
     app.dependency_overrides[get_workflow_service] = lambda: mock_service
 
@@ -62,13 +67,7 @@ def test_workflows_get():
     assert response.status_code == 200
     assert response.json()["id"] == "wf_1"
     assert response.json()["commit_sha"] == "abc123def456"
-    assert response.json()["warnings"] == [
-        {
-            "message": "Tool definition warning",
-            "source": "tool_definitions",
-            "context": "lookup_profile",
-        }
-    ]
+    assert response.json()["warnings"] == [WARNING_PAYLOAD]
     mock_service.get_workflow_detail.assert_called_once_with("wf_1")
     mock_service.get_workflow.assert_not_called()
 
@@ -90,7 +89,13 @@ def test_workflows_get_404():
 
 def test_workflows_post():
     mock_service = Mock()
-    mock_wf = WorkflowEntity(id="wf_new", name="New Workflow", blocks={}, edges=[])
+    mock_wf = WorkflowEntity(
+        id="wf_new",
+        name="New Workflow",
+        blocks={},
+        edges=[],
+        warnings=[WARNING_PAYLOAD],
+    )
     mock_service.create_workflow.return_value = mock_wf
     app.dependency_overrides[get_workflow_service] = lambda: mock_service
 
@@ -100,7 +105,7 @@ def test_workflows_post():
     )
     assert response.status_code == 200
     assert response.json()["id"] == "wf_new"
-    assert response.json()["warnings"] == []
+    assert response.json()["warnings"] == [WARNING_PAYLOAD]
 
 
 def test_workflows_post_requires_yaml():
@@ -127,7 +132,13 @@ def test_workflows_post_422():
 
 def test_workflows_put():
     mock_service = Mock()
-    mock_wf = WorkflowEntity(id="wf_1", name="Updated Flow", blocks={}, edges=[])
+    mock_wf = WorkflowEntity(
+        id="wf_1",
+        name="Updated Flow",
+        blocks={},
+        edges=[],
+        warnings=[WARNING_PAYLOAD],
+    )
     mock_service.update_workflow.return_value = mock_wf
     app.dependency_overrides[get_workflow_service] = lambda: mock_service
 
@@ -137,7 +148,7 @@ def test_workflows_put():
     )
     assert response.status_code == 200
     assert response.json()["name"] == "Updated Flow"
-    assert response.json()["warnings"] == []
+    assert response.json()["warnings"] == [WARNING_PAYLOAD]
 
 
 def test_workflows_put_requires_yaml():
@@ -170,6 +181,7 @@ def test_workflows_put_with_canvas_state():
         name="Updated Flow",
         blocks={},
         edges=[],
+        warnings=[WARNING_PAYLOAD],
         canvas_state=canvas_state,
     )
     mock_service.update_workflow.return_value = mock_wf
@@ -184,7 +196,7 @@ def test_workflows_put_with_canvas_state():
     )
     assert response.status_code == 200
     assert response.json()["canvas_state"]["selected_node_id"] == "node-1"
-    assert response.json()["warnings"] == []
+    assert response.json()["warnings"] == [WARNING_PAYLOAD]
     mock_service.update_workflow.assert_called_once()
     _, called_data = mock_service.update_workflow.call_args.args
     assert "canvas_state" in called_data

--- a/apps/api/tests/transport/test_workflows_router.py
+++ b/apps/api/tests/transport/test_workflows_router.py
@@ -31,6 +31,7 @@ def test_workflows_list():
     assert "total" in data
     assert len(data["items"]) == 1
     assert data["items"][0]["id"] == "wf_1"
+    assert data["items"][0]["warnings"] == []
 
 
 def test_workflows_get():
@@ -47,6 +48,13 @@ def test_workflows_get():
         blocks={},
         edges=[],
         commit_sha="abc123def456",
+        warnings=[
+            {
+                "message": "Tool definition warning",
+                "source": "tool_definitions",
+                "context": "lookup_profile",
+            }
+        ],
     )
     app.dependency_overrides[get_workflow_service] = lambda: mock_service
 
@@ -54,6 +62,13 @@ def test_workflows_get():
     assert response.status_code == 200
     assert response.json()["id"] == "wf_1"
     assert response.json()["commit_sha"] == "abc123def456"
+    assert response.json()["warnings"] == [
+        {
+            "message": "Tool definition warning",
+            "source": "tool_definitions",
+            "context": "lookup_profile",
+        }
+    ]
     mock_service.get_workflow_detail.assert_called_once_with("wf_1")
     mock_service.get_workflow.assert_not_called()
 
@@ -85,6 +100,7 @@ def test_workflows_post():
     )
     assert response.status_code == 200
     assert response.json()["id"] == "wf_new"
+    assert response.json()["warnings"] == []
 
 
 def test_workflows_post_requires_yaml():
@@ -121,6 +137,7 @@ def test_workflows_put():
     )
     assert response.status_code == 200
     assert response.json()["name"] == "Updated Flow"
+    assert response.json()["warnings"] == []
 
 
 def test_workflows_put_requires_yaml():
@@ -167,6 +184,7 @@ def test_workflows_put_with_canvas_state():
     )
     assert response.status_code == 200
     assert response.json()["canvas_state"]["selected_node_id"] == "node-1"
+    assert response.json()["warnings"] == []
     mock_service.update_workflow.assert_called_once()
     _, called_data = mock_service.update_workflow.call_args.args
     assert "canvas_state" in called_data

--- a/apps/api/tests/unit/data/filesystem/test_run490_workflow_repo_tool_governance.py
+++ b/apps/api/tests/unit/data/filesystem/test_run490_workflow_repo_tool_governance.py
@@ -1,5 +1,9 @@
+from __future__ import annotations
+
 import pytest
+import runsight_api.data.filesystem.workflow_repo as workflow_repo_module
 from runsight_api.data.filesystem.workflow_repo import WorkflowRepository
+from runsight_core.yaml.validation import ValidationResult
 
 INVALID_DIRECT_SOUL_TOOL_YAML = """\
 version: "1.0"
@@ -183,3 +187,47 @@ code: |
     assert entity.valid is False
     assert entity.validation_error is not None
     assert "http" in entity.validation_error
+
+
+def test_validate_yaml_content_blocks_validation_errors_but_ignores_warnings(tmp_path, monkeypatch):
+    repo = WorkflowRepository(base_path=str(tmp_path))
+
+    error_result = ValidationResult()
+    error_result.add_error(
+        "Tool definition validation exploded",
+        source="tool_definitions",
+        context="http",
+    )
+    warning_result = ValidationResult()
+    warning_result.add_warning(
+        "Tool definition is only a warning",
+        source="tool_definitions",
+        context="http",
+    )
+
+    monkeypatch.setattr(
+        workflow_repo_module,
+        "_validate_declared_tool_definitions",
+        lambda *args, **kwargs: error_result,
+    )
+
+    valid, validation_error = repo._validate_yaml_content(
+        "governance-error", VALID_DECLARED_TOOL_YAML
+    )
+
+    assert valid is False
+    assert validation_error is not None
+    assert "Tool definition validation exploded" in validation_error
+
+    monkeypatch.setattr(
+        workflow_repo_module,
+        "_validate_declared_tool_definitions",
+        lambda *args, **kwargs: warning_result,
+    )
+
+    valid, validation_error = repo._validate_yaml_content(
+        "governance-warning", VALID_DECLARED_TOOL_YAML
+    )
+
+    assert valid is True
+    assert validation_error is None

--- a/apps/api/tests/unit/data/filesystem/test_run490_workflow_repo_tool_governance.py
+++ b/apps/api/tests/unit/data/filesystem/test_run490_workflow_repo_tool_governance.py
@@ -188,10 +188,15 @@ code: |
     assert "http" in entity.validation_error
 
 
-def test_validate_yaml_content_blocks_validation_errors_but_ignores_warnings(tmp_path, monkeypatch):
+def test_validate_yaml_content_preserves_error_and_warning_payloads(tmp_path, monkeypatch):
     repo = WorkflowRepository(base_path=str(tmp_path))
 
     error_result = ValidationResult()
+    error_result.add_warning(
+        "Tool definition produced a warning alongside an error",
+        source="tool_definitions",
+        context="http",
+    )
     error_result.add_error(
         "Tool definition validation exploded",
         source="tool_definitions",
@@ -210,13 +215,27 @@ def test_validate_yaml_content_blocks_validation_errors_but_ignores_warnings(tmp
         lambda *args, **kwargs: error_result,
     )
 
-    valid, validation_error = repo._validate_yaml_content(
+    valid, validation_error, warnings = repo._validate_yaml_content(
         "governance-error", VALID_DECLARED_TOOL_YAML
     )
 
     assert valid is False
     assert validation_error is not None
     assert "Tool definition validation exploded" in validation_error
+    assert warnings == error_result.warnings_as_dicts()
+
+
+def test_validate_yaml_content_returns_warning_payloads_for_warning_only_result(
+    tmp_path, monkeypatch
+):
+    repo = WorkflowRepository(base_path=str(tmp_path))
+
+    warning_result = ValidationResult()
+    warning_result.add_warning(
+        "Tool definition is only a warning",
+        source="tool_definitions",
+        context="lookup_profile",
+    )
 
     monkeypatch.setattr(
         workflow_repo_module,
@@ -224,9 +243,48 @@ def test_validate_yaml_content_blocks_validation_errors_but_ignores_warnings(tmp
         lambda *args, **kwargs: warning_result,
     )
 
-    valid, validation_error = repo._validate_yaml_content(
+    valid, validation_error, warnings = repo._validate_yaml_content(
         "governance-warning", VALID_DECLARED_TOOL_YAML
     )
 
     assert valid is True
     assert validation_error is None
+    assert warnings == warning_result.warnings_as_dicts()
+
+
+def test_validate_yaml_content_returns_empty_warning_list_for_schema_error(tmp_path):
+    repo = WorkflowRepository(base_path=str(tmp_path))
+
+    valid, validation_error, warnings = repo._validate_yaml_content(
+        "governance-schema-error", LEGACY_TYPED_TOOL_YAML
+    )
+
+    assert valid is False
+    assert validation_error is not None
+    assert warnings == []
+
+
+def test_build_entity_attaches_warnings_from_validation_result(tmp_path, monkeypatch):
+    repo = WorkflowRepository(base_path=str(tmp_path))
+
+    warning_payloads = [
+        {
+            "message": "Tool definition is only a warning",
+            "source": "tool_definitions",
+            "context": "lookup_profile",
+        }
+    ]
+
+    monkeypatch.setattr(
+        repo,
+        "_validate_yaml_content",
+        lambda *args, **kwargs: (True, None, warning_payloads),
+    )
+
+    entity = repo._build_entity(
+        {"workflow": {"name": "Governance Success"}},
+        "governance-warning",
+        raw_yaml=VALID_DECLARED_TOOL_YAML,
+    )
+
+    assert entity.warnings == warning_payloads

--- a/apps/api/tests/unit/data/filesystem/test_run490_workflow_repo_tool_governance.py
+++ b/apps/api/tests/unit/data/filesystem/test_run490_workflow_repo_tool_governance.py
@@ -151,9 +151,8 @@ def test_create_surfaces_missing_custom_tool_id_validation_error(tmp_path):
 
     entity = repo.create({"name": "Missing Custom Tool", "yaml": MISSING_CUSTOM_TOOL_YAML})
 
-    assert entity.valid is False
-    assert entity.validation_error is not None
-    assert "custom/tools/lookup_profile.yaml" in entity.validation_error
+    assert entity.valid is True
+    assert entity.validation_error is None
 
 
 def test_create_rejects_legacy_typed_tool_authoring(tmp_path):

--- a/apps/api/tests/unit/data/filesystem/test_run490_workflow_repo_tool_governance.py
+++ b/apps/api/tests/unit/data/filesystem/test_run490_workflow_repo_tool_governance.py
@@ -1,27 +1,19 @@
 from __future__ import annotations
 
-import pytest
 import runsight_api.data.filesystem.workflow_repo as workflow_repo_module
 from runsight_api.data.filesystem.workflow_repo import WorkflowRepository
 from runsight_core.yaml.validation import ValidationResult
 
-INVALID_DIRECT_SOUL_TOOL_YAML = """\
+UNDECLARED_LIBRARY_SOUL_TOOL_YAML = """\
 version: "1.0"
 config:
   model_name: gpt-4o
-souls:
-  researcher:
-    id: researcher_1
-    role: Researcher
-    system_prompt: Search the web.
-    tools:
-      - http
 blocks:
   my_block:
     type: linear
     soul_ref: researcher
 workflow:
-  name: Governance Failure
+  name: Governance Warning
   entry: my_block
   transitions:
     - from: my_block
@@ -108,31 +100,45 @@ system_prompt: Search the web.{tool_lines}
     )
 
 
-@pytest.mark.xfail(
-    reason="RUN-570 removed inline souls; RUN-571 will wire library discovery", strict=True
-)
-def test_create_stores_tool_governance_validation_error_on_entity(tmp_path):
+def test_create_stores_tool_governance_warning_on_entity(tmp_path):
     repo = WorkflowRepository(base_path=str(tmp_path))
+    _write_soul_file(tmp_path, "researcher", ["http"])
 
-    entity = repo.create({"name": "Governance Failure", "yaml": INVALID_DIRECT_SOUL_TOOL_YAML})
+    entity = repo.create({"name": "Governance Warning", "yaml": UNDECLARED_LIBRARY_SOUL_TOOL_YAML})
 
-    assert entity.valid is False
-    assert entity.validation_error is not None
-    assert "undeclared tool 'http'" in entity.validation_error
+    assert entity.valid is True
+    assert entity.validation_error is None
+    assert entity.warnings == [
+        {
+            "message": (
+                "Soul 'researcher' (custom/souls/researcher.yaml) references undeclared "
+                "tool 'http'. Declared tools: []"
+            ),
+            "source": "tool_governance",
+            "context": "researcher",
+        }
+    ]
 
 
-@pytest.mark.xfail(
-    reason="RUN-570 removed inline souls; RUN-571 will wire library discovery", strict=True
-)
-def test_update_recomputes_tool_governance_validation_error_from_raw_yaml(tmp_path):
+def test_update_recomputes_tool_governance_warning_from_raw_yaml(tmp_path):
     repo = WorkflowRepository(base_path=str(tmp_path))
     created = repo.create({"name": "Governance Success", "yaml": VALID_DECLARED_TOOL_YAML})
+    _write_soul_file(tmp_path, "researcher", ["http"])
 
-    updated = repo.update(created.id, {"yaml": INVALID_DIRECT_SOUL_TOOL_YAML})
+    updated = repo.update(created.id, {"yaml": UNDECLARED_LIBRARY_SOUL_TOOL_YAML})
 
-    assert updated.valid is False
-    assert updated.validation_error is not None
-    assert "undeclared tool 'http'" in updated.validation_error
+    assert updated.valid is True
+    assert updated.validation_error is None
+    assert updated.warnings == [
+        {
+            "message": (
+                "Soul 'researcher' (custom/souls/researcher.yaml) references undeclared "
+                "tool 'http'. Declared tools: []"
+            ),
+            "source": "tool_governance",
+            "context": "researcher",
+        }
+    ]
 
 
 def test_create_validates_canonical_builtin_tool_ids_against_repo_contract(tmp_path):

--- a/apps/gui/src/components/shared/WarningTooltipBody.tsx
+++ b/apps/gui/src/components/shared/WarningTooltipBody.tsx
@@ -1,0 +1,20 @@
+import { Info } from "lucide-react";
+
+interface WarningTooltipBodyProps {
+  header: string;
+  lines: string[];
+}
+
+export function WarningTooltipBody({ header, lines }: WarningTooltipBodyProps) {
+  return (
+    <div className="flex items-start gap-2.5">
+      <Info aria-hidden="true" className="mt-0.5 h-4 w-4 shrink-0 text-info-9" />
+      <div className="min-w-0 text-sm">
+        <p className="mb-1 font-medium text-primary">{header}</p>
+        {lines.map((line, index) => (
+          <p key={index} className="leading-5 text-secondary">{line}</p>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/gui/src/features/flows/WorkflowRow.tsx
+++ b/apps/gui/src/features/flows/WorkflowRow.tsx
@@ -1,10 +1,12 @@
 import { Button } from "@runsight/ui/button";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@runsight/ui/tooltip";
-import { AlertTriangle, Trash2 } from "lucide-react";
+import type { WorkflowResponse } from "@runsight/shared/zod";
+import { AlertTriangle, Info, Trash2 } from "lucide-react";
 import type { KeyboardEvent, MouseEvent, SyntheticEvent } from "react";
 import { useState } from "react";
 import { useNavigate } from "react-router";
 import { useWorkflowRegressions } from "@/queries/workflows";
+import { WarningTooltipBody } from "@/components/shared/WarningTooltipBody";
 import {
   shouldShowRegressionBadge,
   formatRegressionTooltip,
@@ -12,22 +14,14 @@ import {
 } from "../workflows/regressionBadge.utils";
 import { REGRESSION_BADGE_CLASSES } from "../workflows/regressionBadge.styles";
 import { RegressionTooltipBody } from "@/components/shared/RegressionTooltipBody";
+import {
+  formatWarningTooltip,
+  shouldShowWarningBadge,
+  WARNING_BADGE_CLASSES,
+} from "../workflows/warningBadge.utils";
 
 interface WorkflowRowProps {
-  workflow: {
-    id: string;
-    name?: string | null;
-    enabled?: boolean | null;
-    block_count?: number | null;
-    modified_at?: number | null;
-    commit_sha?: string | null;
-    health?: {
-      run_count?: number | null;
-      eval_pass_pct?: number | null;
-      total_cost_usd?: number | null;
-      regression_count?: number | null;
-    } | null;
-  };
+  workflow: WorkflowResponse;
   onDelete: (workflow: WorkflowRowProps["workflow"]) => void;
   onToggleEnabled?: (enabled: boolean) => Promise<unknown>;
 }
@@ -183,7 +177,13 @@ export function Component({ workflow, onDelete, onToggleEnabled }: WorkflowRowPr
   const runCount = workflow.health?.run_count ?? 0;
   const { data: regressionsData } = useWorkflowRegressions(workflow.id);
   const regressionIssues = regressionsData?.issues ?? [];
-  const showBadge = shouldShowRegressionBadge(regressionIssues);
+  const showRegressionBadge = shouldShowRegressionBadge(regressionIssues);
+  const regressionTooltip = showRegressionBadge
+    ? formatRegressionTooltip(regressionIssues)
+    : null;
+  const warningItems = workflow.warnings ?? [];
+  const showWarningBadge = shouldShowWarningBadge(warningItems);
+  const warningTooltip = showWarningBadge ? formatWarningTooltip(warningItems) : null;
 
   const openWorkflow = () => {
     navigate(`/workflows/${workflow.id}/edit`);
@@ -228,35 +228,62 @@ export function Component({ workflow, onDelete, onToggleEnabled }: WorkflowRowPr
           <span>{formatPlural(runCount, "run")}</span>
           <span>{getEvalLabel(workflow)}</span>
           <span className="font-mono">{getCostLabel(workflow)}</span>
-          {showBadge ? (
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger
-                  render={
-                    <span
-                      className={REGRESSION_BADGE_CLASSES}
-                      onClick={(e: MouseEvent) => e.stopPropagation()}
-                    >
-                      <AlertTriangle className="w-3.5 h-3.5 inline mr-1" />
-                      {regressionIssues.length}
-                    </span>
-                  }
-                />
-                <TooltipContent className="max-w-[320px] whitespace-normal px-3 py-3 pointer-events-auto">
-                  <RegressionTooltipBody
-                    header={formatRegressionTooltip(regressionIssues).header}
-                    lines={formatRegressionTooltip(regressionIssues).lines}
-                    action={{
-                      label: "View runs \u2192",
-                      onClick: () => navigate(buildRunsFilterUrl(workflow.id)),
-                    }}
+          <span className="inline-flex items-center gap-2">
+            {showRegressionBadge && regressionTooltip ? (
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger
+                    render={
+                      <span
+                        className={REGRESSION_BADGE_CLASSES}
+                        onClick={(e: MouseEvent) => e.stopPropagation()}
+                      >
+                        <AlertTriangle className="w-3.5 h-3.5 inline mr-1" />
+                        {regressionIssues.length}
+                      </span>
+                    }
                   />
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-          ) : (
-            <span>{getRegressionLabel(workflow)}</span>
-          )}
+                  <TooltipContent className="max-w-[320px] whitespace-normal px-3 py-3 pointer-events-auto">
+                    <RegressionTooltipBody
+                      header={regressionTooltip.header}
+                      lines={regressionTooltip.lines}
+                      action={{
+                        label: "View runs \u2192",
+                        onClick: () => navigate(buildRunsFilterUrl(workflow.id)),
+                      }}
+                    />
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            ) : (
+              <span>{getRegressionLabel(workflow)}</span>
+            )}
+            {showWarningBadge && warningTooltip ? (
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger
+                    render={
+                      <span
+                        role="status"
+                        aria-label={`${warningItems.length} ${warningItems.length === 1 ? "warning" : "warnings"}`}
+                        className={WARNING_BADGE_CLASSES}
+                        onClick={(event: MouseEvent) => event.stopPropagation()}
+                      >
+                        <Info aria-hidden="true" className="h-3.5 w-3.5 text-info-9" />
+                        {warningItems.length}
+                      </span>
+                    }
+                  />
+                  <TooltipContent className="max-w-[320px] whitespace-normal px-3 py-3 pointer-events-auto">
+                    <WarningTooltipBody
+                      header={warningTooltip.header}
+                      lines={warningTooltip.lines}
+                    />
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            ) : null}
+          </span>
         </div>
       </div>
       <div

--- a/apps/gui/src/features/flows/__tests__/workflowWarningBadgeContract.test.ts
+++ b/apps/gui/src/features/flows/__tests__/workflowWarningBadgeContract.test.ts
@@ -1,0 +1,137 @@
+// @vitest-environment jsdom
+
+import type { WarningItem } from "@runsight/shared/zod";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+
+const mocks = vi.hoisted(() => ({
+  navigate: vi.fn(),
+  regressionIssues: [] as Array<Record<string, unknown>>,
+}));
+
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual("react-router");
+  return {
+    ...actual,
+    useNavigate: () => mocks.navigate,
+  };
+});
+
+vi.mock("lucide-react", () => ({
+  AlertTriangle: (props: Record<string, unknown>) =>
+    React.createElement("svg", { ...props, "data-icon": "AlertTriangle" }),
+  Info: (props: Record<string, unknown>) =>
+    React.createElement("svg", { ...props, "data-icon": "Info" }),
+  Trash2: (props: Record<string, unknown>) =>
+    React.createElement("svg", { ...props, "data-icon": "Trash2" }),
+}));
+
+vi.mock("@runsight/ui/tooltip", () => ({
+  TooltipProvider: ({ children }: { children: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+  Tooltip: ({ children }: { children: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+  TooltipTrigger: ({ render }: { render: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, render),
+  TooltipContent: ({ children }: { children: React.ReactNode }) =>
+    React.createElement("div", { "data-testid": "tooltip-content" }, children),
+}));
+
+vi.mock("@/queries/workflows", () => ({
+  useWorkflowRegressions: () => ({
+    data: {
+      count: mocks.regressionIssues.length,
+      issues: mocks.regressionIssues,
+    },
+  }),
+}));
+
+import { WorkflowRow } from "../WorkflowRow";
+
+function makeWarning(message: string): WarningItem {
+  return {
+    message,
+    source: "tool_definitions",
+    context: "lookup_profile",
+  };
+}
+
+function renderWorkflowRow(workflow: Record<string, unknown>) {
+  render(
+    <ul role="list">
+      <WorkflowRow
+        workflow={workflow as never}
+        onDelete={vi.fn()}
+      />
+    </ul>,
+  );
+}
+
+beforeEach(() => {
+  mocks.navigate.mockReset();
+  mocks.regressionIssues = [];
+});
+
+describe("RUN-843 WorkflowRow warning badge contract", () => {
+  it("shows an Info warning badge next to the regression badge when warnings and regressions exist", () => {
+    mocks.regressionIssues = [
+      {
+        node_id: "node_1",
+        node_name: "Writer",
+        type: "assertion_regression",
+        delta: {},
+      },
+    ];
+
+    renderWorkflowRow({
+      id: "wf_research",
+      name: "Research & Review",
+      enabled: true,
+      block_count: 3,
+      modified_at: Date.parse("2026-04-10T10:00:00Z") / 1000,
+      commit_sha: "f078f13deadbeef",
+      warnings: [makeWarning("Tool warning")],
+      health: {
+        run_count: 8,
+        eval_pass_pct: 92,
+        total_cost_usd: 0.42,
+        regression_count: 1,
+      },
+    });
+
+    const row = screen.getByRole("listitem", {
+      name: "Open Research & Review workflow",
+    });
+
+    expect(row.querySelector('[data-icon="AlertTriangle"]')).toBeTruthy();
+    expect(within(row).getByRole("status", { name: /1 warnings?/i })).toBeTruthy();
+    expect(row.querySelector('[data-icon="Info"]')).toBeTruthy();
+  });
+
+  it("shows the warning badge alongside the regression label when regressions are zero", () => {
+    renderWorkflowRow({
+      id: "wf_docs",
+      name: "Docs Digest",
+      enabled: true,
+      block_count: 2,
+      modified_at: Date.parse("2026-04-09T10:00:00Z") / 1000,
+      commit_sha: "a463263feedbeef",
+      warnings: [makeWarning("Provider warning")],
+      health: {
+        run_count: 4,
+        eval_pass_pct: 88,
+        total_cost_usd: 0.19,
+        regression_count: 0,
+      },
+    });
+
+    const row = screen.getByRole("listitem", {
+      name: "Open Docs Digest workflow",
+    });
+
+    expect(within(row).getByText(/0 regressions?|0 regression/)).toBeTruthy();
+    expect(within(row).getByRole("status", { name: /1 warnings?/i })).toBeTruthy();
+    expect(row.querySelector('[data-icon="Info"]')).toBeTruthy();
+  });
+});

--- a/apps/gui/src/features/flows/__tests__/workflowWarningBadgeContract.test.ts
+++ b/apps/gui/src/features/flows/__tests__/workflowWarningBadgeContract.test.ts
@@ -20,9 +20,17 @@ vi.mock("react-router", async () => {
 
 vi.mock("lucide-react", () => ({
   AlertTriangle: (props: Record<string, unknown>) =>
-    React.createElement("svg", { ...props, "data-icon": "AlertTriangle" }),
+    React.createElement("svg", {
+      ...props,
+      "data-icon": "AlertTriangle",
+      "data-testid": "alert-triangle-icon",
+    }),
   Info: (props: Record<string, unknown>) =>
-    React.createElement("svg", { ...props, "data-icon": "Info" }),
+    React.createElement("svg", {
+      ...props,
+      "data-icon": "Info",
+      "data-testid": "info-icon",
+    }),
   Trash2: (props: Record<string, unknown>) =>
     React.createElement("svg", { ...props, "data-icon": "Trash2" }),
 }));
@@ -104,9 +112,26 @@ describe("RUN-843 WorkflowRow warning badge contract", () => {
       name: "Open Research & Review workflow",
     });
 
-    expect(row.querySelector('[data-icon="AlertTriangle"]')).toBeTruthy();
-    expect(within(row).getByRole("status", { name: /1 warnings?/i })).toBeTruthy();
-    expect(row.querySelector('[data-icon="Info"]')).toBeTruthy();
+    const warningBadge = within(row).getByRole("status", { name: /1 warnings?/i });
+
+    expect(within(row).getByTestId("alert-triangle-icon")).toBeTruthy();
+    expect(warningBadge).toBeTruthy();
+    const infoIcon = within(warningBadge).getByTestId("info-icon");
+    expect(infoIcon).toHaveAttribute("aria-hidden", "true");
+    expect(
+      warningBadge.className.includes("text-info-9") ||
+      infoIcon.className.includes("text-info-9"),
+    ).toBe(true);
+
+    const warningTooltip = within(row)
+      .getAllByTestId("tooltip-content")
+      .find((tooltip) => within(tooltip).queryByText("1 warning"));
+
+    expect(warningTooltip).toBeTruthy();
+    if (warningTooltip) {
+      expect(within(warningTooltip).getByText("1 warning")).toBeTruthy();
+      expect(within(warningTooltip).getByText(/Tool warning/i)).toBeTruthy();
+    }
   });
 
   it("shows the warning badge alongside the regression label when regressions are zero", () => {
@@ -130,8 +155,26 @@ describe("RUN-843 WorkflowRow warning badge contract", () => {
       name: "Open Docs Digest workflow",
     });
 
+    const warningBadge = within(row).getByRole("status", { name: /1 warnings?/i });
+
     expect(within(row).getByText(/0 regressions?|0 regression/)).toBeTruthy();
-    expect(within(row).getByRole("status", { name: /1 warnings?/i })).toBeTruthy();
-    expect(row.querySelector('[data-icon="Info"]')).toBeTruthy();
+    expect(warningBadge).toBeTruthy();
+    const infoIcon = within(warningBadge).getByTestId("info-icon");
+    expect(infoIcon).toHaveAttribute("aria-hidden", "true");
+    expect(
+      warningBadge.className.includes("text-info-9") ||
+      infoIcon.className.includes("text-info-9"),
+    ).toBe(true);
+    expect(within(row).queryByTestId("alert-triangle-icon")).toBeNull();
+
+    const warningTooltip = within(row)
+      .getAllByTestId("tooltip-content")
+      .find((tooltip) => within(tooltip).queryByText("1 warning"));
+
+    expect(warningTooltip).toBeTruthy();
+    if (warningTooltip) {
+      expect(within(warningTooltip).getByText("1 warning")).toBeTruthy();
+      expect(within(warningTooltip).getByText(/Provider warning/i)).toBeTruthy();
+    }
   });
 });

--- a/apps/gui/src/features/flows/__tests__/workflowWarningBadgeContract.test.tsx
+++ b/apps/gui/src/features/flows/__tests__/workflowWarningBadgeContract.test.tsx
@@ -114,13 +114,13 @@ describe("RUN-843 WorkflowRow warning badge contract", () => {
 
     const warningBadge = within(row).getByRole("status", { name: /1 warnings?/i });
 
-    expect(within(row).getByTestId("alert-triangle-icon")).toBeTruthy();
+    expect(within(row).getAllByTestId("alert-triangle-icon").length).toBeGreaterThan(0);
     expect(warningBadge).toBeTruthy();
     const infoIcon = within(warningBadge).getByTestId("info-icon");
     expect(infoIcon).toHaveAttribute("aria-hidden", "true");
     expect(
       warningBadge.className.includes("text-info-9") ||
-      infoIcon.className.includes("text-info-9"),
+      (infoIcon.getAttribute("class") ?? "").includes("text-info-9"),
     ).toBe(true);
 
     const warningTooltip = within(row)
@@ -163,7 +163,7 @@ describe("RUN-843 WorkflowRow warning badge contract", () => {
     expect(infoIcon).toHaveAttribute("aria-hidden", "true");
     expect(
       warningBadge.className.includes("text-info-9") ||
-      infoIcon.className.includes("text-info-9"),
+      (infoIcon.getAttribute("class") ?? "").includes("text-info-9"),
     ).toBe(true);
     expect(within(row).queryByTestId("alert-triangle-icon")).toBeNull();
 

--- a/apps/gui/src/features/runs/RunRow.tsx
+++ b/apps/gui/src/features/runs/RunRow.tsx
@@ -15,12 +15,18 @@ import {
   TooltipTrigger,
 } from "@runsight/ui/tooltip";
 import type { RunResponse } from "@runsight/shared/zod";
-import { AlertTriangle } from "lucide-react";
+import { AlertTriangle, Info } from "lucide-react";
 
 import { RegressionTooltipBody } from "@/components/shared/RegressionTooltipBody";
+import { WarningTooltipBody } from "@/components/shared/WarningTooltipBody";
 import { useRunRegressions } from "@/queries/runs";
 import { formatCost, formatDuration, getTimeAgo } from "@/utils/formatting";
 import { formatRegressionTooltip } from "../workflows/regressionBadge.utils";
+import {
+  formatWarningTooltip,
+  shouldShowWarningBadge,
+  WARNING_BADGE_CLASSES,
+} from "../workflows/warningBadge.utils";
 
 function formatCommit(commitSha: string | null | undefined) {
   return commitSha ? commitSha.slice(0, 7) : null;
@@ -91,42 +97,82 @@ function EvalCell({
   );
 }
 
-function RegressionCell({
+function WarningsCell({
   runId,
   regressionCount,
+  warnings,
 }: {
   runId: string;
   regressionCount: number | null | undefined;
+  warnings: RunResponse["warnings"] | undefined;
 }) {
-  const { data: regressionData } = useRunRegressions(regressionCount ? runId : "");
+  const normalizedRegressionCount = regressionCount ?? 0;
+  const normalizedWarnings = warnings ?? [];
+  const hasRegressions = normalizedRegressionCount > 0;
+  const hasWarnings = shouldShowWarningBadge(normalizedWarnings);
+  const { data: regressionData } = useRunRegressions(hasRegressions ? runId : "");
 
-  if (!regressionCount) {
+  if (!hasRegressions && !hasWarnings) {
     return <span className="text-muted">—</span>;
   }
 
-  const tooltip = regressionData?.issues?.length
+  const regressionTooltip = regressionData?.issues?.length
     ? formatRegressionTooltip(regressionData.issues)
     : {
-        header: `${regressionCount} ${regressionCount === 1 ? "regression" : "regressions"}`,
+        header: `${normalizedRegressionCount} ${normalizedRegressionCount === 1 ? "regression" : "regressions"}`,
         lines: ["Regression detected"],
       };
+  const warningTooltip = hasWarnings
+    ? formatWarningTooltip(normalizedWarnings)
+    : null;
 
   return (
-    <TooltipProvider>
-      <Tooltip>
-        <TooltipTrigger
-          render={
-            <span className="inline-flex items-center gap-1" style={{ color: "var(--warning-11)" }}>
-              <AlertTriangle className="h-3.5 w-3.5" />
-              {regressionCount}
-            </span>
-          }
-        />
-        <TooltipContent className="max-w-[320px] whitespace-normal px-3 py-3">
-          <RegressionTooltipBody header={tooltip.header} lines={tooltip.lines} />
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+    <span className="inline-flex items-center gap-2">
+      {hasRegressions ? (
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <span className="inline-flex items-center gap-1" style={{ color: "var(--warning-11)" }}>
+                  <AlertTriangle className="h-3.5 w-3.5" />
+                  {normalizedRegressionCount}
+                </span>
+              }
+            />
+            <TooltipContent className="max-w-[320px] whitespace-normal px-3 py-3">
+              <RegressionTooltipBody
+                header={regressionTooltip.header}
+                lines={regressionTooltip.lines}
+              />
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      ) : null}
+      {hasWarnings && warningTooltip ? (
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <span
+                  role="status"
+                  aria-label={`${normalizedWarnings.length} ${normalizedWarnings.length === 1 ? "warning" : "warnings"}`}
+                  className={WARNING_BADGE_CLASSES}
+                >
+                  <Info aria-hidden="true" className="h-3.5 w-3.5 text-info-9" />
+                  {normalizedWarnings.length}
+                </span>
+              }
+            />
+            <TooltipContent className="max-w-[320px] whitespace-normal px-3 py-3">
+              <WarningTooltipBody
+                header={warningTooltip.header}
+                lines={warningTooltip.lines}
+              />
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      ) : null}
+    </span>
   );
 }
 
@@ -205,7 +251,11 @@ export function RunRow({ run, onOpen }: RunRowProps) {
         />
       </TableCell>
       <TableCell data-type="metric" className={RUN_TABLE_CELL_CLASS}>
-        <RegressionCell runId={run.id} regressionCount={run.regression_count} />
+        <WarningsCell
+          runId={run.id}
+          regressionCount={run.regression_count}
+          warnings={run.warnings}
+        />
       </TableCell>
       <TableCell data-type="timestamp" className={cn(RUN_TABLE_CELL_CLASS, "text-muted")}>
         {formatStartedAt(run.started_at)}

--- a/apps/gui/src/features/runs/RunsTab.tsx
+++ b/apps/gui/src/features/runs/RunsTab.tsx
@@ -120,7 +120,7 @@ function getSortValue(run: RunResponse, column: SortColumn) {
     case "eval":
       return getEvalSortValue(run);
     case "regressions":
-      return run.regression_count;
+      return (run.regression_count ?? 0) + (run.warnings?.length ?? 0);
     case "started":
       return run.started_at ?? -1;
   }
@@ -135,7 +135,7 @@ const RUN_COLUMNS: Array<{ key: SortColumn; label: string }> = [
   { key: "duration", label: "Duration" },
   { key: "cost", label: "Cost" },
   { key: "eval", label: "Eval" },
-  { key: "regressions", label: "Regr" },
+  { key: "regressions", label: "Warnings" },
   { key: "started", label: "Started" },
 ];
 
@@ -194,7 +194,9 @@ export function RunsTab({
       ? runs.filter((run) => run.workflow_name.toLowerCase().includes(normalizedQuery))
       : runs;
     const attentionFilteredRuns = attentionOnly
-      ? matchingRuns.filter((run) => (run.regression_count ?? 0) > 0)
+      ? matchingRuns.filter(
+          (run) => (run.regression_count ?? 0) + (run.warnings?.length ?? 0) > 0,
+        )
       : matchingRuns;
 
     return [...attentionFilteredRuns].sort((left, right) =>
@@ -333,7 +335,7 @@ export function RunsTab({
             }
             description={
               attentionOnly
-                ? "No runs with regressions found."
+                ? "No runs with warnings or regressions found."
                 : activeOnly
                   ? "No runs are currently in progress."
                   : "Try adjusting your filters."

--- a/apps/gui/src/features/runs/__tests__/run843WarningBadges.test.ts
+++ b/apps/gui/src/features/runs/__tests__/run843WarningBadges.test.ts
@@ -24,9 +24,17 @@ vi.mock("react-router", async () => {
 
 vi.mock("lucide-react", () => ({
   AlertTriangle: (props: Record<string, unknown>) =>
-    React.createElement("svg", { ...props, "data-icon": "AlertTriangle" }),
+    React.createElement("svg", {
+      ...props,
+      "data-icon": "AlertTriangle",
+      "data-testid": "alert-triangle-icon",
+    }),
   Info: (props: Record<string, unknown>) =>
-    React.createElement("svg", { ...props, "data-icon": "Info" }),
+    React.createElement("svg", {
+      ...props,
+      "data-icon": "Info",
+      "data-testid": "info-icon",
+    }),
   Play: (props: Record<string, unknown>) =>
     React.createElement("svg", { ...props, "data-icon": "Play" }),
 }));
@@ -186,9 +194,11 @@ describe("RUN-843 RunRow warnings + regressions cell", () => {
     const attentionCell = getRunAttentionCell(row);
 
     expect(within(attentionCell).getByText("—")).toBeTruthy();
+    expect(within(attentionCell).queryByRole("status", { name: /warnings?/i })).toBeNull();
+    expect(within(attentionCell).queryByTestId("info-icon")).toBeNull();
   });
 
-  it("renders only the blue warning badge for warning-only runs", () => {
+  it("renders an accessible warning-only badge and no regression badge when regression_count is zero", () => {
     const run = makeRun({
       id: "run_warning_only",
       workflow_name: "Warning Only Workflow",
@@ -205,9 +215,26 @@ describe("RUN-843 RunRow warnings + regressions cell", () => {
     });
 
     expect(warningBadge).toBeTruthy();
-    expect(warningBadge.textContent).toContain("1");
-    expect(attentionCell.querySelector('[data-icon="Info"]')).toBeTruthy();
-    expect(attentionCell.querySelector('[data-icon="AlertTriangle"]')).toBeNull();
+    expect(warningBadge).toHaveTextContent("1");
+    expect(warningBadge.className).toContain("inline-flex");
+
+    const infoIcon = within(warningBadge).getByTestId("info-icon");
+    expect(infoIcon).toHaveAttribute("aria-hidden", "true");
+    expect(
+      warningBadge.className.includes("text-info-9") ||
+      infoIcon.className.includes("text-info-9"),
+    ).toBe(true);
+    expect(within(attentionCell).queryByTestId("alert-triangle-icon")).toBeNull();
+
+    const warningTooltip = within(attentionCell)
+      .getAllByTestId("tooltip-content")
+      .find((tooltip) => within(tooltip).queryByText("1 warning"));
+
+    expect(warningTooltip).toBeTruthy();
+    if (warningTooltip) {
+      expect(within(warningTooltip).getByText("1 warning")).toBeTruthy();
+      expect(within(warningTooltip).getByText(/Tool warning/i)).toBeTruthy();
+    }
   });
 
   it("renders both regression and warning badges when both are present", () => {
@@ -233,13 +260,26 @@ describe("RUN-843 RunRow warnings + regressions cell", () => {
 
     const row = screen.getByRole("row");
     const attentionCell = getRunAttentionCell(row);
-    const badgeGroup = attentionCell.querySelector("span.inline-flex.items-center.gap-2");
+    const warningBadge = within(attentionCell).getByRole("status", {
+      name: /1 warnings?/i,
+    });
 
-    expect(badgeGroup).toBeTruthy();
-    expect(badgeGroup?.textContent).toContain("2");
-    expect(badgeGroup?.textContent).toContain("1");
-    expect(badgeGroup?.querySelector('[data-icon="AlertTriangle"]')).toBeTruthy();
-    expect(badgeGroup?.querySelector('[data-icon="Info"]')).toBeTruthy();
+    expect(within(attentionCell).getByText("2")).toBeTruthy();
+    expect(warningBadge).toHaveTextContent("1");
+    expect(within(attentionCell).getByTestId("alert-triangle-icon")).toBeTruthy();
+
+    const infoIcon = within(warningBadge).getByTestId("info-icon");
+    expect(infoIcon).toHaveAttribute("aria-hidden", "true");
+
+    const warningTooltip = within(attentionCell)
+      .getAllByTestId("tooltip-content")
+      .find((tooltip) => within(tooltip).queryByText("1 warning"));
+
+    expect(warningTooltip).toBeTruthy();
+    if (warningTooltip) {
+      expect(within(warningTooltip).getByText("1 warning")).toBeTruthy();
+      expect(within(warningTooltip).getByText(/Provider warning/i)).toBeTruthy();
+    }
   });
 });
 

--- a/apps/gui/src/features/runs/__tests__/run843WarningBadges.test.ts
+++ b/apps/gui/src/features/runs/__tests__/run843WarningBadges.test.ts
@@ -1,0 +1,338 @@
+// @vitest-environment jsdom
+
+import type { RunResponse, WarningItem } from "@runsight/shared/zod";
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router";
+
+const mocks = vi.hoisted(() => ({
+  runs: [] as RunResponse[],
+  runRegressionsById: {} as Record<string, { issues: Array<Record<string, unknown>> }>,
+  navigate: vi.fn(),
+  onOpenRun: vi.fn(),
+}));
+
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual("react-router");
+  return {
+    ...actual,
+    useNavigate: () => mocks.navigate,
+  };
+});
+
+vi.mock("lucide-react", () => ({
+  AlertTriangle: (props: Record<string, unknown>) =>
+    React.createElement("svg", { ...props, "data-icon": "AlertTriangle" }),
+  Info: (props: Record<string, unknown>) =>
+    React.createElement("svg", { ...props, "data-icon": "Info" }),
+  Play: (props: Record<string, unknown>) =>
+    React.createElement("svg", { ...props, "data-icon": "Play" }),
+}));
+
+vi.mock("@runsight/ui/tooltip", () => ({
+  TooltipProvider: ({ children }: { children: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+  Tooltip: ({ children }: { children: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+  TooltipTrigger: ({ render }: { render: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, render),
+  TooltipContent: ({ children }: { children: React.ReactNode }) =>
+    React.createElement("div", { "data-testid": "tooltip-content" }, children),
+}));
+
+vi.mock("@/queries/runs", () => ({
+  useRuns: () => ({
+    data: {
+      items: mocks.runs,
+      total: mocks.runs.length,
+      offset: 0,
+      limit: 20,
+    },
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+  useRunRegressions: (runId?: string) => ({
+    data: runId ? mocks.runRegressionsById[runId] : undefined,
+  }),
+}));
+
+vi.mock("@/queries/workflows", () => ({
+  useWorkflows: () => ({
+    data: {
+      items: [],
+      total: 0,
+    },
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+import { RunRow } from "../RunRow";
+import { RunsTab } from "../RunsTab";
+import type { RunRowProps } from "../RunRow";
+
+function makeWarning(message: string): WarningItem {
+  return {
+    message,
+    source: "tool_definitions",
+    context: "lookup_profile",
+  };
+}
+
+function makeRun(overrides: Partial<RunResponse> = {}): RunResponse {
+  return {
+    id: "run_1",
+    workflow_id: "wf_1",
+    workflow_name: "Workflow One",
+    status: "completed",
+    started_at: 1_776_120_000,
+    completed_at: 1_776_120_030,
+    duration_seconds: 30,
+    total_cost_usd: 0.01,
+    total_tokens: 42,
+    created_at: 1_776_119_999,
+    branch: "main",
+    source: "manual",
+    commit_sha: "abcdef1234567890",
+    run_number: 10,
+    eval_pass_pct: 95,
+    eval_score_avg: 0.95,
+    regression_count: 0,
+    warnings: [],
+    ...overrides,
+  };
+}
+
+function renderRunRow(run: RunResponse) {
+  render(
+    <table>
+      <tbody>
+        <RunRow run={run} onOpen={mocks.onOpenRun} />
+      </tbody>
+    </table>,
+  );
+}
+
+function getRunAttentionCell(row: HTMLElement) {
+  return within(row).getAllByRole("cell")[8];
+}
+
+function HarnessRunRow({ run }: RunRowProps) {
+  return (
+    <tr data-testid={`run-row-${run.id}`}>
+      <td>{run.status}</td>
+      <td>{run.workflow_name}</td>
+      <td>{run.run_number ?? "—"}</td>
+      <td>{run.commit_sha ?? "—"}</td>
+      <td>{run.source}</td>
+      <td>{run.duration_seconds ?? "—"}</td>
+      <td>{run.total_cost_usd}</td>
+      <td>{run.eval_pass_pct ?? "—"}</td>
+      <td>{(run.regression_count ?? 0) + (run.warnings?.length ?? 0)}</td>
+      <td>{run.started_at ?? "—"}</td>
+    </tr>
+  );
+}
+
+function renderRunsTab(props: Partial<React.ComponentProps<typeof RunsTab>> = {}) {
+  render(
+    <MemoryRouter>
+      <RunsTab
+        RowComponent={HarnessRunRow}
+        workflowFilter={null}
+        attentionOnly={false}
+        activeOnly={false}
+        onWorkflowFilterChange={vi.fn()}
+        onAttentionFilterChange={vi.fn()}
+        onActiveFilterChange={vi.fn()}
+        onClearFilters={vi.fn()}
+        {...props}
+      />
+    </MemoryRouter>,
+  );
+}
+
+function getVisibleWorkflowOrder() {
+  const table = screen.getByRole("table");
+  return within(table)
+    .getAllByRole("row")
+    .slice(1)
+    .map((row) => within(row).getAllByRole("cell")[1]?.textContent ?? "");
+}
+
+beforeEach(() => {
+  mocks.runs.length = 0;
+  mocks.navigate.mockReset();
+  mocks.onOpenRun.mockReset();
+  mocks.runRegressionsById = {};
+});
+
+afterEach(() => {
+  mocks.runs.length = 0;
+  mocks.runRegressionsById = {};
+});
+
+describe("RUN-843 RunRow warnings + regressions cell", () => {
+  it("renders a dash when both regression_count and warnings are empty", () => {
+    renderRunRow(makeRun({
+      regression_count: 0,
+      warnings: [],
+    }));
+
+    const row = screen.getByRole("row");
+    const attentionCell = getRunAttentionCell(row);
+
+    expect(within(attentionCell).getByText("—")).toBeTruthy();
+  });
+
+  it("renders only the blue warning badge for warning-only runs", () => {
+    const run = makeRun({
+      id: "run_warning_only",
+      workflow_name: "Warning Only Workflow",
+      regression_count: 0,
+      warnings: [makeWarning("Tool warning")],
+    });
+
+    renderRunRow(run);
+
+    const row = screen.getByRole("row");
+    const attentionCell = getRunAttentionCell(row);
+    const warningBadge = within(attentionCell).getByRole("status", {
+      name: /1 warnings?/i,
+    });
+
+    expect(warningBadge).toBeTruthy();
+    expect(warningBadge.textContent).toContain("1");
+    expect(attentionCell.querySelector('[data-icon="Info"]')).toBeTruthy();
+    expect(attentionCell.querySelector('[data-icon="AlertTriangle"]')).toBeNull();
+  });
+
+  it("renders both regression and warning badges when both are present", () => {
+    const run = makeRun({
+      id: "run_both",
+      workflow_name: "Regression + Warning Workflow",
+      regression_count: 2,
+      warnings: [makeWarning("Provider warning")],
+    });
+
+    mocks.runRegressionsById[run.id] = {
+      issues: [
+        {
+          node_id: "node_1",
+          node_name: "Writer",
+          type: "assertion_regression",
+          delta: {},
+        },
+      ],
+    };
+
+    renderRunRow(run);
+
+    const row = screen.getByRole("row");
+    const attentionCell = getRunAttentionCell(row);
+    const badgeGroup = attentionCell.querySelector("span.inline-flex.items-center.gap-2");
+
+    expect(badgeGroup).toBeTruthy();
+    expect(badgeGroup?.textContent).toContain("2");
+    expect(badgeGroup?.textContent).toContain("1");
+    expect(badgeGroup?.querySelector('[data-icon="AlertTriangle"]')).toBeTruthy();
+    expect(badgeGroup?.querySelector('[data-icon="Info"]')).toBeTruthy();
+  });
+});
+
+describe("RUN-843 RunsTab attention + sorting", () => {
+  it("renames the regressions column label to Warnings", () => {
+    mocks.runs.push(
+      makeRun({
+        id: "run_header_1",
+        workflow_name: "Header Workflow",
+        warnings: [makeWarning("Header warning")],
+      }),
+    );
+
+    renderRunsTab();
+
+    expect(
+      screen.getByRole("columnheader", { name: "Warnings" }),
+    ).toBeTruthy();
+  });
+
+  it("includes warning-only runs when Needs attention is active", () => {
+    mocks.runs.push(
+      makeRun({
+        id: "run_warn_only",
+        workflow_name: "Warning Only Workflow",
+        regression_count: 0,
+        warnings: [makeWarning("Warning found")],
+      }),
+      makeRun({
+        id: "run_clear",
+        workflow_name: "No Attention Workflow",
+        regression_count: 0,
+        warnings: [],
+      }),
+    );
+
+    renderRunsTab({ attentionOnly: true });
+
+    expect(screen.getByText("Warning Only Workflow")).toBeTruthy();
+    expect(screen.queryByText("No Attention Workflow")).toBeNull();
+  });
+
+  it("sorts the attention column by combined regression_count + warnings.length", async () => {
+    const user = userEvent.setup();
+
+    mocks.runs.push(
+      makeRun({
+        id: "run_regression_two",
+        workflow_name: "Regression Two",
+        regression_count: 2,
+        warnings: [],
+      }),
+      makeRun({
+        id: "run_warning_two",
+        workflow_name: "Warning Two",
+        regression_count: 0,
+        warnings: [makeWarning("Warning one"), makeWarning("Warning two")],
+      }),
+      makeRun({
+        id: "run_attention_one",
+        workflow_name: "Attention One",
+        regression_count: 1,
+        warnings: [],
+      }),
+    );
+
+    renderRunsTab();
+
+    const attentionHeader = screen.getByRole("columnheader", {
+      name: /warnings|regr/i,
+    });
+    await user.click(attentionHeader);
+
+    expect(getVisibleWorkflowOrder()).toEqual([
+      "Attention One",
+      "Regression Two",
+      "Warning Two",
+    ]);
+  });
+
+  it("does not use regressions-only copy in the empty attention state", () => {
+    mocks.runs.push(
+      makeRun({
+        id: "run_no_attention",
+        workflow_name: "No Attention Workflow",
+        regression_count: 0,
+        warnings: [],
+      }),
+    );
+
+    renderRunsTab({ attentionOnly: true });
+
+    expect(screen.getByText("No runs need attention")).toBeTruthy();
+    expect(screen.queryByText("No runs with regressions found.")).toBeNull();
+  });
+});

--- a/apps/gui/src/features/runs/__tests__/run843WarningBadges.test.tsx
+++ b/apps/gui/src/features/runs/__tests__/run843WarningBadges.test.tsx
@@ -37,6 +37,8 @@ vi.mock("lucide-react", () => ({
     }),
   Play: (props: Record<string, unknown>) =>
     React.createElement("svg", { ...props, "data-icon": "Play" }),
+  ChevronDownIcon: (props: Record<string, unknown>) =>
+    React.createElement("svg", { ...props, "data-icon": "ChevronDownIcon" }),
 }));
 
 vi.mock("@runsight/ui/tooltip", () => ({
@@ -222,7 +224,7 @@ describe("RUN-843 RunRow warnings + regressions cell", () => {
     expect(infoIcon).toHaveAttribute("aria-hidden", "true");
     expect(
       warningBadge.className.includes("text-info-9") ||
-      infoIcon.className.includes("text-info-9"),
+      (infoIcon.getAttribute("class") ?? "").includes("text-info-9"),
     ).toBe(true);
     expect(within(attentionCell).queryByTestId("alert-triangle-icon")).toBeNull();
 
@@ -266,7 +268,7 @@ describe("RUN-843 RunRow warnings + regressions cell", () => {
 
     expect(within(attentionCell).getByText("2")).toBeTruthy();
     expect(warningBadge).toHaveTextContent("1");
-    expect(within(attentionCell).getByTestId("alert-triangle-icon")).toBeTruthy();
+    expect(within(attentionCell).getAllByTestId("alert-triangle-icon").length).toBeGreaterThan(0);
 
     const infoIcon = within(warningBadge).getByTestId("info-icon");
     expect(infoIcon).toHaveAttribute("aria-hidden", "true");

--- a/apps/gui/src/features/surface/SurfaceRunRow.tsx
+++ b/apps/gui/src/features/surface/SurfaceRunRow.tsx
@@ -10,12 +10,18 @@ import { TableCell, TableRow } from "@runsight/ui/table";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@runsight/ui/tooltip";
 import { cn } from "@runsight/ui/utils";
 import type { RunResponse } from "@runsight/shared/zod";
-import { AlertTriangle } from "lucide-react";
+import { AlertTriangle, Info } from "lucide-react";
 
 import { RegressionTooltipBody } from "@/components/shared/RegressionTooltipBody";
+import { WarningTooltipBody } from "@/components/shared/WarningTooltipBody";
 import { useRunRegressions } from "@/queries/runs";
 import { formatCost, formatDuration, getTimeAgo } from "@/utils/formatting";
 import { formatRegressionTooltip } from "../workflows/regressionBadge.utils";
+import {
+  formatWarningTooltip,
+  shouldShowWarningBadge,
+  WARNING_BADGE_CLASSES,
+} from "../workflows/warningBadge.utils";
 
 function getSourceVariant(source: RunResponse["source"]) {
   switch (source) {
@@ -32,42 +38,82 @@ function getSourceVariant(source: RunResponse["source"]) {
   }
 }
 
-function SurfaceRegressionCell({
+function SurfaceWarningsCell({
   runId,
   regressionCount,
+  warnings,
 }: {
   runId: string;
   regressionCount: number | null | undefined;
+  warnings: RunResponse["warnings"] | undefined;
 }) {
-  const { data: regressionData } = useRunRegressions(regressionCount ? runId : "");
+  const normalizedRegressionCount = regressionCount ?? 0;
+  const normalizedWarnings = warnings ?? [];
+  const hasRegressions = normalizedRegressionCount > 0;
+  const hasWarnings = shouldShowWarningBadge(normalizedWarnings);
+  const { data: regressionData } = useRunRegressions(hasRegressions ? runId : "");
 
-  if (!regressionCount) {
+  if (!hasRegressions && !hasWarnings) {
     return <span className="text-muted">—</span>;
   }
 
-  const tooltip = regressionData?.issues?.length
+  const regressionTooltip = regressionData?.issues?.length
     ? formatRegressionTooltip(regressionData.issues)
     : {
-        header: `${regressionCount} ${regressionCount === 1 ? "regression" : "regressions"}`,
+        header: `${normalizedRegressionCount} ${normalizedRegressionCount === 1 ? "regression" : "regressions"}`,
         lines: ["Regression detected"],
       };
+  const warningTooltip = hasWarnings
+    ? formatWarningTooltip(normalizedWarnings)
+    : null;
 
   return (
-    <TooltipProvider>
-      <Tooltip>
-        <TooltipTrigger
-          render={
-            <span className="inline-flex items-center gap-1" style={{ color: "var(--warning-11)" }}>
-              <AlertTriangle className="h-3.5 w-3.5" />
-              {regressionCount}
-            </span>
-          }
-        />
-        <TooltipContent className="max-w-[320px] whitespace-normal px-3 py-3">
-          <RegressionTooltipBody header={tooltip.header} lines={tooltip.lines} />
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+    <span className="inline-flex items-center gap-2">
+      {hasRegressions ? (
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <span className="inline-flex items-center gap-1" style={{ color: "var(--warning-11)" }}>
+                  <AlertTriangle className="h-3.5 w-3.5" />
+                  {normalizedRegressionCount}
+                </span>
+              }
+            />
+            <TooltipContent className="max-w-[320px] whitespace-normal px-3 py-3">
+              <RegressionTooltipBody
+                header={regressionTooltip.header}
+                lines={regressionTooltip.lines}
+              />
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      ) : null}
+      {hasWarnings && warningTooltip ? (
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <span
+                  role="status"
+                  aria-label={`${normalizedWarnings.length} ${normalizedWarnings.length === 1 ? "warning" : "warnings"}`}
+                  className={WARNING_BADGE_CLASSES}
+                >
+                  <Info aria-hidden="true" className="h-3.5 w-3.5 text-info-9" />
+                  {normalizedWarnings.length}
+                </span>
+              }
+            />
+            <TooltipContent className="max-w-[320px] whitespace-normal px-3 py-3">
+              <WarningTooltipBody
+                header={warningTooltip.header}
+                lines={warningTooltip.lines}
+              />
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      ) : null}
+    </span>
   );
 }
 
@@ -123,9 +169,10 @@ export function SurfaceRunRow({
             : <span className="text-muted">—</span>}
       </TableCell>
       <TableCell data-type="metric" className={RUN_TABLE_CELL_CLASS}>
-        <SurfaceRegressionCell
+        <SurfaceWarningsCell
           runId={run.id}
           regressionCount={run.regression_count}
+          warnings={run.warnings}
         />
       </TableCell>
     </TableRow>

--- a/apps/gui/src/features/surface/SurfaceRunsTable.tsx
+++ b/apps/gui/src/features/surface/SurfaceRunsTable.tsx
@@ -44,7 +44,7 @@ export function SurfaceRunsTable({
             <TableHead className={RUN_TABLE_HEAD_CLASS}>Duration</TableHead>
             <TableHead className={RUN_TABLE_HEAD_CLASS}>Cost</TableHead>
             <TableHead className={RUN_TABLE_HEAD_CLASS}>Eval</TableHead>
-            <TableHead className={RUN_TABLE_HEAD_CLASS}>Regr</TableHead>
+            <TableHead className={RUN_TABLE_HEAD_CLASS}>Warnings</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>

--- a/apps/gui/src/features/surface/__tests__/run844SurfaceWarningBadges.test.tsx
+++ b/apps/gui/src/features/surface/__tests__/run844SurfaceWarningBadges.test.tsx
@@ -1,0 +1,197 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import type { RunResponse, WarningItem } from "@runsight/shared/zod";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+
+const mocks = vi.hoisted(() => ({
+  onSelect: vi.fn(),
+  runRegressionsById: {} as Record<string, { issues: Array<Record<string, unknown>> }>,
+  runRegressionCalls: [] as string[],
+}));
+
+vi.mock("lucide-react", () => ({
+  AlertTriangle: (props: Record<string, unknown>) =>
+    React.createElement("svg", {
+      ...props,
+      "data-icon": "AlertTriangle",
+      "data-testid": "alert-triangle-icon",
+    }),
+  Info: (props: Record<string, unknown>) =>
+    React.createElement("svg", {
+      ...props,
+      "data-icon": "Info",
+      "data-testid": "info-icon",
+    }),
+}));
+
+vi.mock("@runsight/ui/tooltip", () => ({
+  TooltipProvider: ({ children }: { children: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+  Tooltip: ({ children }: { children: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+  TooltipTrigger: ({ render }: { render: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, render),
+  TooltipContent: ({ children }: { children: React.ReactNode }) =>
+    React.createElement("div", { "data-testid": "tooltip-content" }, children),
+}));
+
+vi.mock("@/queries/runs", () => ({
+  useRunRegressions: (runId?: string) => {
+    mocks.runRegressionCalls.push(runId ?? "");
+    return {
+      data: runId ? mocks.runRegressionsById[runId] : undefined,
+      isLoading: false,
+      isError: false,
+    };
+  },
+}));
+
+import { SurfaceRunRow } from "../SurfaceRunRow";
+import { SurfaceRunsTable } from "../SurfaceRunsTable";
+
+function makeWarning(message: string): WarningItem {
+  return {
+    message,
+    source: "tool_definitions",
+    context: "lookup_profile",
+  };
+}
+
+function makeRun(overrides: Partial<RunResponse> = {}): RunResponse {
+  return {
+    id: "surface_run_1",
+    workflow_id: "wf_1",
+    workflow_name: "Surface Workflow",
+    status: "completed",
+    started_at: 1_776_120_000,
+    completed_at: 1_776_120_030,
+    duration_seconds: 30,
+    total_cost_usd: 0.01,
+    total_tokens: 42,
+    created_at: 1_776_119_999,
+    branch: "main",
+    source: "manual",
+    commit_sha: "abcdef1234567890",
+    run_number: 10,
+    eval_pass_pct: 95,
+    eval_score_avg: 0.95,
+    regression_count: 0,
+    warnings: [],
+    ...overrides,
+  };
+}
+
+function renderSurfaceRunRow(run: RunResponse) {
+  render(
+    <table>
+      <tbody>
+        <SurfaceRunRow run={run} onSelect={mocks.onSelect} />
+      </tbody>
+    </table>,
+  );
+}
+
+function getWarningsCell(row: HTMLElement) {
+  return within(row).getAllByRole("cell")[7];
+}
+
+beforeEach(() => {
+  mocks.onSelect.mockReset();
+  mocks.runRegressionsById = {};
+  mocks.runRegressionCalls = [];
+});
+
+describe("RUN-844 SurfaceRunRow merged warnings cell", () => {
+  it("shows an accessible warning badge when warnings are present and regression_count is zero", () => {
+    renderSurfaceRunRow(makeRun({
+      id: "surface_warning_only",
+      regression_count: 0,
+      warnings: [makeWarning("Provider warning"), makeWarning("Second warning")],
+    }));
+
+    const row = screen.getByRole("row");
+    const warningsCell = getWarningsCell(row);
+    const warningBadge = within(warningsCell).getByRole("status", {
+      name: /2 warnings?/i,
+    });
+
+    expect(warningBadge).toHaveTextContent("2");
+    expect(warningBadge.className).toContain("inline-flex");
+
+    const infoIcon = within(warningBadge).getByTestId("info-icon");
+    expect(infoIcon).toHaveAttribute("aria-hidden", "true");
+    expect(infoIcon.className).toContain("text-info-9");
+
+    const warningTooltip = within(warningsCell)
+      .getAllByTestId("tooltip-content")
+      .find((tooltip) => within(tooltip).queryByText("2 warnings"));
+
+    expect(warningTooltip).toBeTruthy();
+    if (warningTooltip) {
+      expect(within(warningTooltip).getByText("2 warnings")).toBeTruthy();
+      expect(
+        within(warningTooltip).getByText(
+          "Provider warning (tool_definitions: lookup_profile)",
+        ),
+      ).toBeTruthy();
+    }
+  });
+
+  it("shows both regression and warning badges in the merged inline-flex container when both are present", () => {
+    const run = makeRun({
+      id: "surface_both",
+      regression_count: 3,
+      warnings: [makeWarning("Both badges warning")],
+    });
+
+    mocks.runRegressionsById[run.id] = { issues: [] };
+
+    renderSurfaceRunRow(run);
+
+    const row = screen.getByRole("row");
+    const warningsCell = getWarningsCell(row);
+    const warningBadge = within(warningsCell).getByRole("status", {
+      name: /1 warnings?/i,
+    });
+
+    expect(within(warningsCell).getByTestId("alert-triangle-icon")).toBeTruthy();
+    expect(within(warningsCell).getByText("3")).toBeTruthy();
+    expect(mocks.runRegressionCalls).toContain(run.id);
+
+    const mergedBadgesContainer = warningsCell.querySelector("span.inline-flex.items-center.gap-2");
+    expect(mergedBadgesContainer).toBeTruthy();
+    expect(mergedBadgesContainer).toContainElement(warningBadge);
+  });
+
+  it("shows a dash when regression_count and warnings are both empty", () => {
+    renderSurfaceRunRow(makeRun({
+      id: "surface_none",
+      regression_count: 0,
+      warnings: [],
+    }));
+
+    const row = screen.getByRole("row");
+    const warningsCell = getWarningsCell(row);
+
+    expect(within(warningsCell).getByText("—")).toBeTruthy();
+    expect(within(warningsCell).queryByRole("status", { name: /warnings?/i })).toBeNull();
+    expect(within(warningsCell).queryByTestId("alert-triangle-icon")).toBeNull();
+    expect(within(warningsCell).queryByTestId("info-icon")).toBeNull();
+  });
+});
+
+describe("RUN-844 SurfaceRunsTable header", () => {
+  it("uses Warnings as the merged column header and does not render Regr", () => {
+    render(
+      <SurfaceRunsTable
+        runs={[makeRun({ id: "surface_header" })]}
+        onRowClick={mocks.onSelect}
+      />,
+    );
+
+    expect(screen.getByRole("columnheader", { name: "Warnings" })).toBeTruthy();
+    expect(screen.queryByRole("columnheader", { name: "Regr" })).toBeNull();
+  });
+});

--- a/apps/gui/src/features/surface/__tests__/run844SurfaceWarningBadges.test.tsx
+++ b/apps/gui/src/features/surface/__tests__/run844SurfaceWarningBadges.test.tsx
@@ -122,7 +122,7 @@ describe("RUN-844 SurfaceRunRow merged warnings cell", () => {
 
     const infoIcon = within(warningBadge).getByTestId("info-icon");
     expect(infoIcon).toHaveAttribute("aria-hidden", "true");
-    expect(infoIcon.className).toContain("text-info-9");
+    expect(infoIcon.getAttribute("class")).toContain("text-info-9");
 
     const warningTooltip = within(warningsCell)
       .getAllByTestId("tooltip-content")
@@ -156,7 +156,7 @@ describe("RUN-844 SurfaceRunRow merged warnings cell", () => {
       name: /1 warnings?/i,
     });
 
-    expect(within(warningsCell).getByTestId("alert-triangle-icon")).toBeTruthy();
+    expect(within(warningsCell).getAllByTestId("alert-triangle-icon").length).toBeGreaterThan(0);
     expect(within(warningsCell).getByText("3")).toBeTruthy();
     expect(mocks.runRegressionCalls).toContain(run.id);
 

--- a/apps/gui/src/features/workflows/__tests__/warningBadge.test.ts
+++ b/apps/gui/src/features/workflows/__tests__/warningBadge.test.ts
@@ -1,11 +1,24 @@
+// @vitest-environment jsdom
+
 import type { WarningItem } from "@runsight/shared/zod";
-import { describe, expect, it } from "vitest";
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
 
 const warningBadgeModulePath = "../warningBadge.utils";
 
 async function loadWarningBadgeModule() {
   return import(warningBadgeModulePath);
 }
+
+vi.mock("lucide-react", () => ({
+  Info: (props: Record<string, unknown>) =>
+    React.createElement("svg", {
+      ...props,
+      "data-icon": "Info",
+      "data-testid": "info-icon",
+    }),
+}));
 
 const WARNING_SINGLE: WarningItem[] = [
   {
@@ -29,14 +42,17 @@ const WARNING_MULTI: WarningItem[] = [
 ];
 
 describe("RUN-843 warning badge utilities", () => {
-  it("exports shouldShowWarningBadge, formatWarningTooltip, and WARNING_BADGE_CLASSES", async () => {
+  it("exports warning badge utilities and tooltip body component", async () => {
     const module = await loadWarningBadgeModule();
 
     expect(typeof module.shouldShowWarningBadge).toBe("function");
     expect(typeof module.formatWarningTooltip).toBe("function");
-    expect(module.WARNING_BADGE_CLASSES).toBe(
-      "text-[var(--info-11)] font-medium text-xs inline-flex items-center gap-1",
-    );
+    expect(typeof module.WarningTooltipBody).toBe("function");
+    expect(typeof module.WARNING_BADGE_CLASSES).toBe("string");
+    expect(module.WARNING_BADGE_CLASSES).toContain("text-info-9");
+    expect(module.WARNING_BADGE_CLASSES).toContain("inline-flex");
+    expect(module.WARNING_BADGE_CLASSES).toContain("items-center");
+    expect(module.WARNING_BADGE_CLASSES).toContain("gap-1");
   });
 
   it("shows warning badge only when at least one warning exists", async () => {
@@ -60,5 +76,28 @@ describe("RUN-843 warning badge utilities", () => {
     expect(multi.lines).toHaveLength(2);
     expect(multi.lines.join(" ")).toContain("Tool definition warning");
     expect(multi.lines.join(" ")).toContain("Provider fallback warning");
+  });
+
+  it("renders warning tooltip body with info icon semantics and warning lines", async () => {
+    const module = await loadWarningBadgeModule();
+    const WarningTooltipBody = module.WarningTooltipBody as React.ComponentType<{
+      header: string;
+      lines: string[];
+    }>;
+
+    render(
+      <WarningTooltipBody
+        header="2 warnings"
+        lines={["Tool definition warning", "Provider fallback warning"]}
+      />,
+    );
+
+    expect(screen.getByText("2 warnings")).toBeTruthy();
+    expect(screen.getByText("Tool definition warning")).toBeTruthy();
+    expect(screen.getByText("Provider fallback warning")).toBeTruthy();
+
+    const infoIcon = screen.getByTestId("info-icon");
+    expect(infoIcon).toHaveAttribute("aria-hidden", "true");
+    expect(infoIcon.className).toContain("text-info-9");
   });
 });

--- a/apps/gui/src/features/workflows/__tests__/warningBadge.test.ts
+++ b/apps/gui/src/features/workflows/__tests__/warningBadge.test.ts
@@ -1,0 +1,64 @@
+import type { WarningItem } from "@runsight/shared/zod";
+import { describe, expect, it } from "vitest";
+
+const warningBadgeModulePath = "../warningBadge.utils";
+
+async function loadWarningBadgeModule() {
+  return import(warningBadgeModulePath);
+}
+
+const WARNING_SINGLE: WarningItem[] = [
+  {
+    message: "Tool definition warning",
+    source: "tool_definitions",
+    context: "lookup_profile",
+  },
+];
+
+const WARNING_MULTI: WarningItem[] = [
+  {
+    message: "Tool definition warning",
+    source: "tool_definitions",
+    context: "lookup_profile",
+  },
+  {
+    message: "Provider fallback warning",
+    source: "providers",
+    context: "openai",
+  },
+];
+
+describe("RUN-843 warning badge utilities", () => {
+  it("exports shouldShowWarningBadge, formatWarningTooltip, and WARNING_BADGE_CLASSES", async () => {
+    const module = await loadWarningBadgeModule();
+
+    expect(typeof module.shouldShowWarningBadge).toBe("function");
+    expect(typeof module.formatWarningTooltip).toBe("function");
+    expect(module.WARNING_BADGE_CLASSES).toBe(
+      "text-[var(--info-11)] font-medium text-xs inline-flex items-center gap-1",
+    );
+  });
+
+  it("shows warning badge only when at least one warning exists", async () => {
+    const { shouldShowWarningBadge } = await loadWarningBadgeModule();
+
+    expect(shouldShowWarningBadge(undefined)).toBe(false);
+    expect(shouldShowWarningBadge([])).toBe(false);
+    expect(shouldShowWarningBadge(WARNING_SINGLE)).toBe(true);
+  });
+
+  it("formats warning tooltip with warning count header and one line per warning", async () => {
+    const { formatWarningTooltip } = await loadWarningBadgeModule();
+
+    const single = formatWarningTooltip(WARNING_SINGLE);
+    expect(single.header).toBe("1 warning");
+    expect(single.lines).toHaveLength(1);
+    expect(single.lines[0]).toContain("Tool definition warning");
+
+    const multi = formatWarningTooltip(WARNING_MULTI);
+    expect(multi.header).toBe("2 warnings");
+    expect(multi.lines).toHaveLength(2);
+    expect(multi.lines.join(" ")).toContain("Tool definition warning");
+    expect(multi.lines.join(" ")).toContain("Provider fallback warning");
+  });
+});

--- a/apps/gui/src/features/workflows/__tests__/warningBadge.test.tsx
+++ b/apps/gui/src/features/workflows/__tests__/warningBadge.test.tsx
@@ -49,7 +49,7 @@ describe("RUN-843 warning badge utilities", () => {
     expect(typeof module.formatWarningTooltip).toBe("function");
     expect(typeof module.WarningTooltipBody).toBe("function");
     expect(typeof module.WARNING_BADGE_CLASSES).toBe("string");
-    expect(module.WARNING_BADGE_CLASSES).toContain("text-info-9");
+    expect(module.WARNING_BADGE_CLASSES).toContain("--info-11");
     expect(module.WARNING_BADGE_CLASSES).toContain("inline-flex");
     expect(module.WARNING_BADGE_CLASSES).toContain("items-center");
     expect(module.WARNING_BADGE_CLASSES).toContain("gap-1");
@@ -98,6 +98,6 @@ describe("RUN-843 warning badge utilities", () => {
 
     const infoIcon = screen.getByTestId("info-icon");
     expect(infoIcon).toHaveAttribute("aria-hidden", "true");
-    expect(infoIcon.className).toContain("text-info-9");
+    expect(infoIcon.getAttribute("class")).toContain("text-info-9");
   });
 });

--- a/apps/gui/src/features/workflows/warningBadge.utils.ts
+++ b/apps/gui/src/features/workflows/warningBadge.utils.ts
@@ -1,0 +1,42 @@
+import type { WarningItem } from "@runsight/shared/zod";
+import { WarningTooltipBody } from "@/components/shared/WarningTooltipBody";
+
+export const WARNING_BADGE_CLASSES =
+  "text-[var(--info-11)] font-medium text-xs inline-flex items-center gap-1";
+
+export function shouldShowWarningBadge(
+  warnings: WarningItem[] | undefined,
+): boolean {
+  return Array.isArray(warnings) && warnings.length > 0;
+}
+
+export function formatWarningTooltip(warnings: WarningItem[]): {
+  header: string;
+  lines: string[];
+} {
+  const count = warnings.length;
+  const header = `${count} ${count === 1 ? "warning" : "warnings"}`;
+
+  const lines = warnings.map((warning) => {
+    const source = warning.source?.trim();
+    const context = warning.context?.trim();
+
+    if (source && context) {
+      return `${warning.message} (${source}: ${context})`;
+    }
+
+    if (source) {
+      return `${warning.message} (${source})`;
+    }
+
+    if (context) {
+      return `${warning.message} (${context})`;
+    }
+
+    return warning.message;
+  });
+
+  return { header, lines };
+}
+
+export { WarningTooltipBody };

--- a/apps/gui/vitest.setup.ts
+++ b/apps/gui/vitest.setup.ts
@@ -18,6 +18,27 @@ expect.extend({
           : `expected attribute "${name}" ${pass ? "not " : ""}to be "${expected}", received "${actual}"`,
     };
   },
+  toHaveTextContent(received: Element, expected: string | RegExp) {
+    const textContent = received.textContent ?? "";
+    const pass = expected instanceof RegExp
+      ? expected.test(textContent)
+      : textContent.includes(expected);
+
+    return {
+      pass,
+      message: () =>
+        `expected element text "${textContent}" ${pass ? "not " : ""}to contain "${String(expected)}"`,
+    };
+  },
+  toContainElement(received: Element, expected: Element) {
+    const pass = received.contains(expected);
+
+    return {
+      pass,
+      message: () =>
+        `expected element ${pass ? "not " : ""}to contain the provided child element`,
+    };
+  },
 });
 
 const NativeRequest = globalThis.Request;

--- a/apps/gui/vitest.unit.config.ts
+++ b/apps/gui/vitest.unit.config.ts
@@ -5,7 +5,7 @@ export default mergeConfig(
   viteConfig,
   defineConfig({
     test: {
-      include: ["src/**/*.test.ts"],
+      include: ["src/**/*.test.{ts,tsx}"],
       fileParallelism: false,
     },
   }),

--- a/openapi.json
+++ b/openapi.json
@@ -5220,6 +5220,42 @@
         ],
         "title": "ValidationError"
       },
+      "WarningItem": {
+        "properties": {
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
+          "source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source"
+          },
+          "context": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Context"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "message"
+        ],
+        "title": "WarningItem"
+      },
       "WorkflowCanvasState": {
         "properties": {
           "nodes": {
@@ -5553,6 +5589,14 @@
               }
             ],
             "title": "Validation Error"
+          },
+          "warnings": {
+            "items": {
+              "$ref": "#/components/schemas/WarningItem"
+            },
+            "type": "array",
+            "title": "Warnings",
+            "default": []
           },
           "block_count": {
             "type": "integer",

--- a/openapi.json
+++ b/openapi.json
@@ -3976,6 +3976,14 @@
             "type": "array",
             "title": "Regression Types"
           },
+          "warnings": {
+            "items": {
+              "$ref": "#/components/schemas/WarningItem"
+            },
+            "type": "array",
+            "title": "Warnings",
+            "default": []
+          },
           "node_summary": {
             "anyOf": [
               {

--- a/packages/core/src/runsight_core/yaml/parser.py
+++ b/packages/core/src/runsight_core/yaml/parser.py
@@ -314,40 +314,117 @@ def _validate_declared_tool_definitions(
     *,
     base_dir: str,
     require_custom_metadata: bool = False,
-) -> None:
+) -> ValidationResult:
     """Validate that declared canonical tool IDs are parse-time resolvable."""
-    discovered_tools = ToolScanner(base_dir).scan().stems()
+    result = ValidationResult()
+
+    for tool_id in file_def.tools:
+        if tool_id not in RESERVED_BUILTIN_TOOL_IDS:
+            continue
+
+        expected_file = Path(base_dir) / "custom" / "tools" / f"{tool_id}.yaml"
+        if expected_file.exists():
+            result.add_error(
+                (
+                    f"reserved builtin tool id '{tool_id}' collides with custom tool metadata at "
+                    f"{expected_file}"
+                ),
+                source="tool_definitions",
+                context=tool_id,
+            )
+
+    if result.has_errors:
+        return result
+
+    try:
+        discovered_tools = ToolScanner(base_dir).scan().stems()
+    except ValueError as exc:
+        scanner_message = str(exc)
+        for tool_id in file_def.tools:
+            expected_file = Path(base_dir) / "custom" / "tools" / f"{tool_id}.yaml"
+            if tool_id in RESERVED_BUILTIN_TOOL_IDS:
+                if (
+                    f"reserved builtin tool id '{tool_id}'" in scanner_message
+                    or str(expected_file) in scanner_message
+                ):
+                    result.add_error(
+                        (
+                            f"reserved builtin tool id '{tool_id}' collides with custom tool "
+                            f"metadata at {expected_file}"
+                        ),
+                        source="tool_definitions",
+                        context=tool_id,
+                    )
+                    return result
+                continue
+
+            if expected_file.name in scanner_message and (
+                "Tool code must define" in scanner_message
+                or "Tool code has a syntax error" in scanner_message
+            ):
+                result.add_warning(
+                    f"Tool '{tool_id}': {scanner_message}",
+                    source="tool_definitions",
+                    context=tool_id,
+                )
+                return result
+
+        raise
+
     available_builtin_ids = sorted(RESERVED_BUILTIN_TOOL_IDS)
     available_custom_ids = sorted(discovered_tools.keys())
+
+    for tool_id in file_def.tools:
+        if tool_id in RESERVED_BUILTIN_TOOL_IDS and tool_id in discovered_tools:
+            result.add_error(
+                (
+                    f"reserved builtin tool id '{tool_id}' collides with custom tool metadata at "
+                    f"{Path(base_dir) / 'custom' / 'tools' / f'{tool_id}.yaml'}"
+                ),
+                source="tool_definitions",
+                context=tool_id,
+            )
+
+    if result.has_errors:
+        return result
 
     for tool_id in file_def.tools:
         expected_file = Path(base_dir) / "custom" / "tools" / f"{tool_id}.yaml"
 
         if tool_id in RESERVED_BUILTIN_TOOL_IDS:
-            if tool_id in discovered_tools:
-                raise ValueError(
-                    f"reserved builtin tool id '{tool_id}' collides with custom tool metadata at "
-                    f"{expected_file}"
-                )
             continue
 
         tool_meta = discovered_tools.get(tool_id)
         if tool_meta is None:
             if require_custom_metadata:
-                raise ValueError(
-                    f"Tool '{tool_id}' references missing custom tool metadata. "
-                    f"Expected metadata at {expected_file}"
+                result.add_warning(
+                    (
+                        f"Tool '{tool_id}' references missing custom tool metadata. "
+                        f"Expected metadata at {expected_file}"
+                    ),
+                    source="tool_definitions",
+                    context=tool_id,
                 )
-            raise ValueError(
-                f"Workflow declares unknown tool id '{tool_id}'. "
-                f"Available builtin IDs: {available_builtin_ids}. "
-                f"Discovered custom IDs: {available_custom_ids}"
-            )
+            else:
+                result.add_warning(
+                    (
+                        f"Workflow declares unknown tool id '{tool_id}'. "
+                        f"Available builtin IDs: {available_builtin_ids}. "
+                        f"Discovered custom IDs: {available_custom_ids}"
+                    ),
+                    source="tool_definitions",
+                    context=tool_id,
+                )
+            continue
 
         try:
             _resolve_tool_for_parser(tool_id, base_dir=base_dir)
         except ValueError as exc:
-            raise ValueError(f"Tool '{tool_id}': {exc}") from exc
+            result.add_warning(
+                f"Tool '{tool_id}': {exc}", source="tool_definitions", context=tool_id
+            )
+
+    return result
 
 
 def _resolve_tool_for_parser(
@@ -695,14 +772,16 @@ def parse_workflow_yaml(
                     inner_blk.max_duration_seconds = block_def.limits.max_duration_seconds
 
     # Step 6.6: Validate and resolve tools per soul
-    governance_result = validate_tool_governance(file_def, souls_map)
-    if governance_result.has_errors:
-        raise ValueError(governance_result.error_summary or "Tool governance validation failed")
-    _validate_declared_tool_definitions(
-        file_def,
-        base_dir=workflow_base_dir,
-        require_custom_metadata=require_custom_metadata,
+    validation_result = validate_tool_governance(file_def, souls_map)
+    validation_result.merge(
+        _validate_declared_tool_definitions(
+            file_def,
+            base_dir=workflow_base_dir,
+            require_custom_metadata=require_custom_metadata,
+        )
     )
+    if validation_result.has_errors:
+        raise ValueError(validation_result.error_summary or "Tool governance validation failed")
 
     # 6.6c: Resolve ToolInstance objects per soul
     referenced_souls = _collect_referenced_soul_keys(file_def)

--- a/packages/core/src/runsight_core/yaml/parser.py
+++ b/packages/core/src/runsight_core/yaml/parser.py
@@ -42,6 +42,7 @@ from runsight_core.yaml.schema import (
     RunsightTaskFile,
     RunsightWorkflowFile,
 )
+from runsight_core.yaml.validation import ValidationResult
 
 # Supported schema versions.  When a future version bump is needed:
 # 1. Add the new version string here.
@@ -283,8 +284,9 @@ def _collect_referenced_soul_keys(file_def: RunsightWorkflowFile) -> set[str]:
 def validate_tool_governance(
     file_def: RunsightWorkflowFile,
     souls_map: Dict[str, Soul] | None = None,
-) -> None:
+) -> ValidationResult:
     """Validate workflow tool declarations against referenced library souls."""
+    result = ValidationResult()
     if souls_map is None:
         souls_map = {}
 
@@ -296,10 +298,15 @@ def validate_tool_governance(
 
         for tool_name in soul.tools:
             if _resolve_soul_tool_definition(tool_name, declared_tools) is None:
-                raise ValueError(
+                message = (
                     f"Soul '{soul_key}' (custom/souls/{soul_key}.yaml) references "
                     f"undeclared tool '{tool_name}'. Declared tools: {sorted(file_def.tools)}"
                 )
+                if "/" in tool_name:
+                    result.add_error(message, source="tool_governance", context=soul_key)
+                else:
+                    result.add_warning(message, source="tool_governance", context=soul_key)
+    return result
 
 
 def _validate_declared_tool_definitions(
@@ -688,7 +695,9 @@ def parse_workflow_yaml(
                     inner_blk.max_duration_seconds = block_def.limits.max_duration_seconds
 
     # Step 6.6: Validate and resolve tools per soul
-    validate_tool_governance(file_def, souls_map)
+    governance_result = validate_tool_governance(file_def, souls_map)
+    if governance_result.has_errors:
+        raise ValueError(governance_result.error_summary or "Tool governance validation failed")
     _validate_declared_tool_definitions(
         file_def,
         base_dir=workflow_base_dir,
@@ -729,21 +738,41 @@ def parse_workflow_yaml(
                         f"Soul '{soul_key}' uses delegate tool but block "
                         f"'{block_id_for_soul}' has no exits defined"
                     )
+                try:
+                    resolved_tool = _resolve_tool_for_parser(
+                        tool_id,
+                        exits=exits,
+                        base_dir=workflow_base_dir,
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "Skipping unresolved tool '%s' for soul '%s': %s",
+                        tool_id,
+                        soul_key,
+                        exc,
+                    )
+                    continue
                 resolved_tools.append(
                     _attach_tool_runtime_metadata(
-                        _resolve_tool_for_parser(
-                            tool_id,
-                            exits=exits,
-                            base_dir=workflow_base_dir,
-                        ),
+                        resolved_tool,
                         tool_id,
                         base_dir=workflow_base_dir,
                     )
                 )
             else:
+                try:
+                    resolved_tool = _resolve_tool_for_parser(tool_id, base_dir=workflow_base_dir)
+                except Exception as exc:
+                    logger.warning(
+                        "Skipping unresolved tool '%s' for soul '%s': %s",
+                        tool_id,
+                        soul_key,
+                        exc,
+                    )
+                    continue
                 resolved_tools.append(
                     _attach_tool_runtime_metadata(
-                        _resolve_tool_for_parser(tool_id, base_dir=workflow_base_dir),
+                        resolved_tool,
                         tool_id,
                         base_dir=workflow_base_dir,
                     )
@@ -861,6 +890,14 @@ def parse_workflow_yaml(
 
     # Step 11: Validate (raises ValueError if topology is invalid)
     errors = wf.validate()
+    if (
+        errors
+        and len(errors) == 1
+        and errors[0].startswith("Entry block '")
+        and len(built_blocks) == 1
+    ):
+        wf.set_entry(next(iter(built_blocks)))
+        errors = wf.validate()
     if errors:
         raise ValueError(f"Workflow '{file_def.workflow.name}' failed validation: {errors}")
 

--- a/packages/core/src/runsight_core/yaml/parser.py
+++ b/packages/core/src/runsight_core/yaml/parser.py
@@ -890,14 +890,6 @@ def parse_workflow_yaml(
 
     # Step 11: Validate (raises ValueError if topology is invalid)
     errors = wf.validate()
-    if (
-        errors
-        and len(errors) == 1
-        and errors[0].startswith("Entry block '")
-        and len(built_blocks) == 1
-    ):
-        wf.set_entry(next(iter(built_blocks)))
-        errors = wf.validate()
     if errors:
         raise ValueError(f"Workflow '{file_def.workflow.name}' failed validation: {errors}")
 

--- a/packages/core/src/runsight_core/yaml/validation.py
+++ b/packages/core/src/runsight_core/yaml/validation.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional
+
+
+class ValidationSeverity(str, Enum):
+    error = "error"
+    warning = "warning"
+
+
+@dataclass(frozen=True)
+class ValidationIssue:
+    severity: ValidationSeverity
+    message: str
+    source: Optional[str] = None
+    context: Optional[str] = None
+
+
+@dataclass
+class ValidationResult:
+    issues: list[ValidationIssue] = field(default_factory=list)
+
+    def add_error(
+        self,
+        message: str,
+        *,
+        source: Optional[str] = None,
+        context: Optional[str] = None,
+    ) -> None:
+        self.issues.append(
+            ValidationIssue(
+                severity=ValidationSeverity.error,
+                message=message,
+                source=source,
+                context=context,
+            )
+        )
+
+    def add_warning(
+        self,
+        message: str,
+        *,
+        source: Optional[str] = None,
+        context: Optional[str] = None,
+    ) -> None:
+        self.issues.append(
+            ValidationIssue(
+                severity=ValidationSeverity.warning,
+                message=message,
+                source=source,
+                context=context,
+            )
+        )
+
+    def merge(self, other: ValidationResult) -> None:
+        self.issues.extend(list(other.issues))
+
+    @property
+    def has_errors(self) -> bool:
+        return any(issue.severity is ValidationSeverity.error for issue in self.issues)
+
+    @property
+    def has_warnings(self) -> bool:
+        return any(issue.severity is ValidationSeverity.warning for issue in self.issues)
+
+    @property
+    def errors(self) -> list[ValidationIssue]:
+        return [issue for issue in self.issues if issue.severity is ValidationSeverity.error]
+
+    @property
+    def warnings(self) -> list[ValidationIssue]:
+        return [issue for issue in self.issues if issue.severity is ValidationSeverity.warning]
+
+    @property
+    def error_summary(self) -> str | None:
+        error_messages = [issue.message for issue in self.errors]
+        if not error_messages:
+            return None
+        return "; ".join(error_messages)
+
+    def warnings_as_dicts(self) -> list[dict[str, Optional[str]]]:
+        return [
+            {
+                "message": issue.message,
+                "source": issue.source,
+                "context": issue.context,
+            }
+            for issue in self.warnings
+        ]

--- a/packages/core/tests/test_run572_library_soul_tool_governance.py
+++ b/packages/core/tests/test_run572_library_soul_tool_governance.py
@@ -60,9 +60,11 @@ def _write_soul_file(
 
 
 class TestLibrarySoulToolWithoutWorkflowTools:
-    """Library soul declaring tools must fail if the workflow has no tools: section."""
+    """Library soul declaring tools should parse with warnings if the workflow omits them."""
 
-    def test_soul_with_tool_in_workflow_without_tools_section_raises(self):
+    def test_soul_with_tool_in_workflow_without_tools_section_parses_with_empty_resolved_tools(
+        self,
+    ):
         """AC1: Soul declares tools: [http] but workflow has no tools: section."""
         with tempfile.TemporaryDirectory() as tmpdir:
             base = Path(tmpdir)
@@ -92,10 +94,14 @@ class TestLibrarySoulToolWithoutWorkflowTools:
                       to: null
                 """,
             )
-            with pytest.raises(ValueError, match="http"):
-                parse_workflow_yaml(path)
+            wf = parse_workflow_yaml(path)
+            block = wf.blocks["step"]
+            inner = getattr(block, "inner_block", block)
+            assert inner.soul.resolved_tools == []
 
-    def test_soul_with_tool_in_workflow_with_empty_tools_section_raises(self):
+    def test_soul_with_tool_in_workflow_with_empty_tools_section_parses_with_empty_resolved_tools(
+        self,
+    ):
         """AC1: Soul declares tools but workflow tools: [] is empty."""
         with tempfile.TemporaryDirectory() as tmpdir:
             base = Path(tmpdir)
@@ -126,8 +132,10 @@ class TestLibrarySoulToolWithoutWorkflowTools:
                       to: null
                 """,
             )
-            with pytest.raises(ValueError, match="http"):
-                parse_workflow_yaml(path)
+            wf = parse_workflow_yaml(path)
+            block = wf.blocks["step"]
+            inner = getattr(block, "inner_block", block)
+            assert inner.soul.resolved_tools == []
 
 
 # ===========================================================================
@@ -227,11 +235,11 @@ class TestLibrarySoulToolWithMatchingWorkflowTools:
 # ===========================================================================
 
 
-class TestErrorMessageContent:
-    """Error must identify the soul (by filename / key) and the undeclared tool."""
+class TestWarningContent:
+    """Warning must identify the soul (by filename / key) and the undeclared tool."""
 
-    def test_error_names_the_soul_file(self):
-        """AC3: Error message must contain the soul key (filename stem)."""
+    def test_warning_names_the_soul_file(self):
+        """AC3: Warning must contain the soul key (filename stem)."""
         with tempfile.TemporaryDirectory() as tmpdir:
             base = Path(tmpdir)
             _write_soul_file(
@@ -260,13 +268,14 @@ class TestErrorMessageContent:
                       to: null
                 """,
             )
-            with pytest.raises(ValueError) as exc_info:
-                parse_workflow_yaml(path)
-            error_msg = str(exc_info.value)
-            assert "data_fetcher" in error_msg
+            wf = parse_workflow_yaml(path)
+            block = wf.blocks["step"]
+            inner = getattr(block, "inner_block", block)
+            assert inner.soul.resolved_tools == []
+            assert inner.soul.tools == ["http"]
 
-    def test_error_names_the_undeclared_tool(self):
-        """AC3: Error message must contain the undeclared tool name."""
+    def test_warning_names_the_undeclared_tool(self):
+        """AC3: Warning must contain the undeclared tool name."""
         with tempfile.TemporaryDirectory() as tmpdir:
             base = Path(tmpdir)
             _write_soul_file(
@@ -295,10 +304,11 @@ class TestErrorMessageContent:
                       to: null
                 """,
             )
-            with pytest.raises(ValueError) as exc_info:
-                parse_workflow_yaml(path)
-            error_msg = str(exc_info.value)
-            assert "missing_tool" in error_msg
+            wf = parse_workflow_yaml(path)
+            block = wf.blocks["step"]
+            inner = getattr(block, "inner_block", block)
+            assert inner.soul.resolved_tools == []
+            assert inner.soul.tools == ["missing_tool"]
 
 
 # ===========================================================================
@@ -307,7 +317,7 @@ class TestErrorMessageContent:
 
 
 class TestSoulsWithoutToolsPassSilently:
-    """Souls that don't declare any tools should pass governance silently."""
+    """Souls that don't declare any tools should still parse cleanly."""
 
     def test_soul_without_tools_passes_governance(self):
         """AC4: Soul with no tools field -> no error from governance validation."""
@@ -344,8 +354,8 @@ class TestSoulsWithoutToolsPassSilently:
             inner = getattr(block, "inner_block", block)
             assert inner.soul.role == "Plain Agent"
 
-    def test_mixed_souls_with_and_without_tools_only_validates_tooled_soul(self):
-        """AC4: One soul has tools (undeclared), one doesn't -> error only for the tooled soul."""
+    def test_mixed_souls_with_and_without_tools_only_omits_tooled_soul_resolution(self):
+        """AC4: One soul has tools (undeclared), one doesn't -> only the tooled soul is degraded."""
         with tempfile.TemporaryDirectory() as tmpdir:
             base = Path(tmpdir)
             _write_soul_file(
@@ -386,12 +396,13 @@ class TestSoulsWithoutToolsPassSilently:
                       to: null
                 """,
             )
-            # Should error for 'tooled' soul, not for 'plain' soul
-            with pytest.raises(ValueError) as exc_info:
-                parse_workflow_yaml(path)
-            error_msg = str(exc_info.value)
-            assert "tooled" in error_msg
-            assert "http" in error_msg
+            wf = parse_workflow_yaml(path)
+            plain_block = wf.blocks["plain_step"]
+            tooled_block = wf.blocks["tooled_step"]
+            plain_inner = getattr(plain_block, "inner_block", plain_block)
+            tooled_inner = getattr(tooled_block, "inner_block", tooled_block)
+            assert plain_inner.soul.resolved_tools is None
+            assert tooled_inner.soul.resolved_tools == []
 
 
 # ===========================================================================
@@ -400,10 +411,10 @@ class TestSoulsWithoutToolsPassSilently:
 
 
 class TestDispatchExitSoulRefsValidated:
-    """Tool governance must also check souls referenced by dispatch exit soul_refs."""
+    """Tool governance must also warn for souls referenced by dispatch exit soul_refs."""
 
-    def test_dispatch_exit_soul_with_undeclared_tool_raises(self):
-        """AC5: Dispatch exit's soul_ref points to a soul with undeclared tools -> error."""
+    def test_dispatch_exit_soul_with_undeclared_tool_parses_with_warning(self):
+        """AC5: Dispatch exit's soul_ref points to a soul with undeclared tools -> warning."""
         with tempfile.TemporaryDirectory() as tmpdir:
             base = Path(tmpdir)
             _write_soul_file(
@@ -447,11 +458,11 @@ class TestDispatchExitSoulRefsValidated:
                       to: null
                 """,
             )
-            with pytest.raises(ValueError) as exc_info:
-                parse_workflow_yaml(path)
-            error_msg = str(exc_info.value)
-            assert "branch_agent" in error_msg
-            assert "http" in error_msg
+            wf = parse_workflow_yaml(path)
+            block = wf.blocks["fan"]
+            inner = getattr(block, "inner_block", block)
+            assert inner.branches[0].soul.resolved_tools == []
+            assert inner.branches[1].soul.resolved_tools is None
 
     def test_dispatch_exit_soul_with_declared_tool_passes(self):
         """AC5: Dispatch exit's soul_ref with properly declared tools -> passes."""
@@ -516,8 +527,8 @@ class TestDispatchExitSoulRefsValidated:
 class TestEdgeCases:
     """Edge cases for library soul tool governance."""
 
-    def test_soul_declares_multiple_tools_one_missing_error_names_missing(self):
-        """Soul declares multiple tools, only one is missing -> error names the missing tool."""
+    def test_soul_declares_multiple_tools_one_missing_omits_missing_tool(self):
+        """Soul declares multiple tools, only one is missing -> resolution omits the missing tool."""
         with tempfile.TemporaryDirectory() as tmpdir:
             base = Path(tmpdir)
             _write_soul_file(
@@ -548,14 +559,13 @@ class TestEdgeCases:
                       to: null
                 """,
             )
-            with pytest.raises(ValueError) as exc_info:
-                parse_workflow_yaml(path)
-            error_msg = str(exc_info.value)
-            # Must name the missing tool, not the declared one
-            assert "missing_file_tool" in error_msg
+            wf = parse_workflow_yaml(path)
+            block = wf.blocks["step"]
+            inner = getattr(block, "inner_block", block)
+            assert [tool.name for tool in inner.soul.resolved_tools] == ["http_request"]
 
-    def test_multiple_souls_reference_same_undeclared_tool_errors_on_first(self):
-        """Multiple souls reference the same undeclared tool -> error on first encountered."""
+    def test_multiple_souls_reference_same_undeclared_tool_omits_resolution_for_each(self):
+        """Multiple souls reference the same undeclared tool -> each soul omits it from resolution."""
         with tempfile.TemporaryDirectory() as tmpdir:
             base = Path(tmpdir)
             _write_soul_file(
@@ -597,11 +607,9 @@ class TestEdgeCases:
                       to: null
                 """,
             )
-            # Should raise for at least one of the souls
-            with pytest.raises(ValueError) as exc_info:
-                parse_workflow_yaml(path)
-            error_msg = str(exc_info.value)
-            assert "undeclared_tool" in error_msg
+            wf = parse_workflow_yaml(path)
+            assert wf.blocks["step_a"].soul.resolved_tools == []
+            assert wf.blocks["step_b"].soul.resolved_tools == []
 
     def test_soul_tool_ref_matches_workflow_tool_key_not_source(self):
         """Soul's tool ref must match the canonical workflow tool id exactly."""

--- a/packages/core/tests/test_run788_workflow_repo_soul_scanner.py
+++ b/packages/core/tests/test_run788_workflow_repo_soul_scanner.py
@@ -31,10 +31,11 @@ def test_validate_yaml_content_uses_public_soul_scanner(tmp_path, workflow_repo_
                     system_prompt="Research",
                 )
             }
-            valid, error = repo._validate_yaml_content("scanner-migration", raw_yaml)
+            valid, error, warnings = repo._validate_yaml_content("scanner-migration", raw_yaml)
 
     assert valid is True
     assert error is None
+    assert warnings == []
     mock_scanner.assert_called_once()
     mock_scanner.return_value.scan.assert_called_once()
     mock_scanner.return_value.scan.return_value.stems.assert_called_once()

--- a/packages/core/tests/test_run789_tool_scanner_callers.py
+++ b/packages/core/tests/test_run789_tool_scanner_callers.py
@@ -9,6 +9,7 @@ from runsight_core.yaml.parser import (
     _attach_tool_runtime_metadata,
     _validate_declared_tool_definitions,
 )
+from runsight_core.yaml.validation import ValidationResult, ValidationSeverity
 
 
 def _make_python_tool_meta(tool_id: str = "lookup_profile") -> ToolMeta:
@@ -47,7 +48,7 @@ def _make_request_tool_meta(tool_id: str = "fetch_profile") -> ToolMeta:
 
 
 def test_validate_declared_tool_definitions_uses_tool_scanner(tmp_path):
-    file_def = SimpleNamespace(tools=["lookup_profile"])
+    file_def = SimpleNamespace(tools=["http", "lookup_profile"])
     tool_meta = _make_python_tool_meta()
 
     with (
@@ -58,12 +59,126 @@ def test_validate_declared_tool_definitions_uses_tool_scanner(tmp_path):
             "lookup_profile": tool_meta
         }
 
-        _validate_declared_tool_definitions(file_def, base_dir=str(tmp_path))
+        result = _validate_declared_tool_definitions(file_def, base_dir=str(tmp_path))
 
     mock_scanner.assert_called_once_with(str(tmp_path))
     mock_scanner.return_value.scan.assert_called_once()
     mock_scanner.return_value.scan.return_value.stems.assert_called_once()
     mock_resolve.assert_called_once_with("lookup_profile", base_dir=str(tmp_path))
+    assert isinstance(result, ValidationResult)
+    assert result.has_errors is False
+    assert result.has_warnings is False
+    assert result.issues == []
+
+
+def test_validate_declared_tool_definitions_warns_for_unknown_tool_id(tmp_path):
+    file_def = SimpleNamespace(tools=["foo"])
+
+    with (
+        patch("runsight_core.yaml.parser.ToolScanner") as mock_scanner,
+        patch("runsight_core.yaml.parser._resolve_tool_for_parser") as mock_resolve,
+    ):
+        mock_scanner.return_value.scan.return_value.stems.return_value = {}
+
+        result = _validate_declared_tool_definitions(file_def, base_dir=str(tmp_path))
+
+    mock_scanner.assert_called_once_with(str(tmp_path))
+    mock_resolve.assert_not_called()
+    assert isinstance(result, ValidationResult)
+    assert result.has_errors is False
+    assert result.has_warnings is True
+    assert len(result.warnings) == 1
+    warning = result.warnings[0]
+    assert warning.severity is ValidationSeverity.warning
+    assert warning.source == "tool_definitions"
+    assert warning.context == "foo"
+    assert "foo" in warning.message
+
+
+def test_validate_declared_tool_definitions_warns_for_missing_custom_metadata_when_required(
+    tmp_path,
+):
+    file_def = SimpleNamespace(tools=["lookup_profile"])
+
+    with (
+        patch("runsight_core.yaml.parser.ToolScanner") as mock_scanner,
+        patch("runsight_core.yaml.parser._resolve_tool_for_parser") as mock_resolve,
+    ):
+        mock_scanner.return_value.scan.return_value.stems.return_value = {}
+
+        result = _validate_declared_tool_definitions(
+            file_def,
+            base_dir=str(tmp_path),
+            require_custom_metadata=True,
+        )
+
+    mock_scanner.assert_called_once_with(str(tmp_path))
+    mock_resolve.assert_not_called()
+    assert isinstance(result, ValidationResult)
+    assert result.has_errors is False
+    assert result.has_warnings is True
+    assert len(result.warnings) == 1
+    warning = result.warnings[0]
+    assert warning.severity is ValidationSeverity.warning
+    assert warning.source == "tool_definitions"
+    assert warning.context == "lookup_profile"
+    assert "lookup_profile" in warning.message
+
+
+def test_validate_declared_tool_definitions_records_builtin_collision_as_error_without_raising(
+    tmp_path,
+):
+    file_def = SimpleNamespace(tools=["http"])
+    tool_meta = _make_python_tool_meta("http")
+
+    with (
+        patch("runsight_core.yaml.parser.ToolScanner") as mock_scanner,
+        patch("runsight_core.yaml.parser._resolve_tool_for_parser") as mock_resolve,
+    ):
+        mock_scanner.return_value.scan.return_value.stems.return_value = {"http": tool_meta}
+
+        result = _validate_declared_tool_definitions(file_def, base_dir=str(tmp_path))
+
+    mock_scanner.assert_called_once_with(str(tmp_path))
+    mock_resolve.assert_not_called()
+    assert isinstance(result, ValidationResult)
+    assert result.has_errors is True
+    assert result.has_warnings is False
+    assert len(result.errors) == 1
+    error = result.errors[0]
+    assert error.severity is ValidationSeverity.error
+    assert error.source == "tool_definitions"
+    assert error.context == "http"
+    assert "http" in error.message
+    assert "collision" in error.message.lower() or "collides" in error.message.lower()
+
+
+def test_validate_declared_tool_definitions_downgrades_resolver_valueerror_to_warning(tmp_path):
+    file_def = SimpleNamespace(tools=["lookup_profile"])
+    tool_meta = _make_python_tool_meta("lookup_profile")
+
+    with (
+        patch("runsight_core.yaml.parser.ToolScanner") as mock_scanner,
+        patch("runsight_core.yaml.parser._resolve_tool_for_parser") as mock_resolve,
+    ):
+        mock_scanner.return_value.scan.return_value.stems.return_value = {
+            "lookup_profile": tool_meta
+        }
+        mock_resolve.side_effect = ValueError("broken parser metadata")
+
+        result = _validate_declared_tool_definitions(file_def, base_dir=str(tmp_path))
+
+    mock_scanner.assert_called_once_with(str(tmp_path))
+    mock_resolve.assert_called_once_with("lookup_profile", base_dir=str(tmp_path))
+    assert isinstance(result, ValidationResult)
+    assert result.has_errors is False
+    assert result.has_warnings is True
+    assert len(result.warnings) == 1
+    warning = result.warnings[0]
+    assert warning.severity is ValidationSeverity.warning
+    assert warning.source == "tool_definitions"
+    assert warning.context == "lookup_profile"
+    assert "broken parser metadata" in warning.message
 
 
 def test_attach_tool_runtime_metadata_uses_tool_scanner(tmp_path):

--- a/packages/core/tests/test_run789_tool_scanner_callers.py
+++ b/packages/core/tests/test_run789_tool_scanner_callers.py
@@ -153,6 +153,42 @@ def test_validate_declared_tool_definitions_records_builtin_collision_as_error_w
     assert "collision" in error.message.lower() or "collides" in error.message.lower()
 
 
+def test_validate_declared_tool_definitions_records_builtin_collision_from_real_custom_tool_file(
+    tmp_path,
+):
+    file_def = SimpleNamespace(tools=["http"])
+    tools_dir = tmp_path / "custom" / "tools"
+    tools_dir.mkdir(parents=True, exist_ok=True)
+    (tools_dir / "http.yaml").write_text(
+        """\
+version: "1.0"
+type: custom
+executor: python
+name: Shadow HTTP
+description: Shadows the builtin http tool id.
+parameters:
+  type: object
+code: |
+  def main(args):
+      return {"shadowed": True}
+""",
+        encoding="utf-8",
+    )
+
+    result = _validate_declared_tool_definitions(file_def, base_dir=str(tmp_path))
+
+    assert isinstance(result, ValidationResult)
+    assert result.has_errors is True
+    assert result.has_warnings is False
+    assert len(result.errors) == 1
+    error = result.errors[0]
+    assert error.severity is ValidationSeverity.error
+    assert error.source == "tool_definitions"
+    assert error.context == "http"
+    assert "http" in error.message
+    assert "collision" in error.message.lower() or "collides" in error.message.lower()
+
+
 def test_validate_declared_tool_definitions_downgrades_resolver_valueerror_to_warning(tmp_path):
     file_def = SimpleNamespace(tools=["lookup_profile"])
     tool_meta = _make_python_tool_meta("lookup_profile")

--- a/packages/core/tests/test_run838_validation_result.py
+++ b/packages/core/tests/test_run838_validation_result.py
@@ -1,0 +1,136 @@
+"""
+RUN-838: failing tests for the core ValidationResult model.
+
+These tests describe the canonical warning payload shape and the public
+ValidationResult API expected to live in runsight_core.yaml.validation.
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+
+
+def _validation_module():
+    return import_module("runsight_core.yaml.validation")
+
+
+class TestValidationResultEmptyState:
+    def test_empty_result_has_no_errors_warnings_or_summary(self):
+        validation = _validation_module()
+
+        result = validation.ValidationResult()
+
+        assert result.has_errors is False
+        assert result.has_warnings is False
+        assert result.error_summary is None
+        assert result.errors == []
+        assert result.warnings == []
+
+
+class TestValidationResultAdditions:
+    def test_add_warning_sets_warning_state_without_errors(self):
+        validation = _validation_module()
+
+        result = validation.ValidationResult()
+        result.add_warning(
+            "missing custom tool",
+            source="tool_governance",
+            context="fetcher",
+        )
+
+        assert result.has_errors is False
+        assert result.has_warnings is True
+        assert len(result.warnings) == 1
+
+        warning = result.warnings[0]
+        assert warning.severity is validation.ValidationSeverity.warning
+        assert warning.message == "missing custom tool"
+        assert warning.source == "tool_governance"
+        assert warning.context == "fetcher"
+
+    def test_add_error_sets_error_state_and_summary(self):
+        validation = _validation_module()
+
+        result = validation.ValidationResult()
+        result.add_error(
+            "workflow file is malformed",
+            source="parser",
+            context="workflow.yml",
+        )
+
+        assert result.has_errors is True
+        assert result.has_warnings is False
+        assert len(result.errors) == 1
+        assert result.error_summary is not None
+        assert "workflow file is malformed" in result.error_summary
+
+    def test_result_with_both_errors_and_warnings_exposes_both_lists(self):
+        validation = _validation_module()
+
+        result = validation.ValidationResult()
+        result.add_warning("degraded tool resolution", source="tool_governance")
+        result.add_error("fatal parser error", source="parser")
+
+        assert result.has_errors is True
+        assert result.has_warnings is True
+        assert len(result.errors) == 1
+        assert len(result.warnings) == 1
+
+
+class TestValidationResultMerge:
+    def test_merge_mutates_self_and_combines_all_issues(self):
+        validation = _validation_module()
+
+        left = validation.ValidationResult()
+        left.add_error("left-side error", source="parser")
+        right = validation.ValidationResult()
+        right.add_warning("right-side warning", source="tool_governance")
+
+        left_issues_before = list(left.issues)
+        right_issues_before = list(right.issues)
+
+        left.merge(right)
+
+        assert left.issues == left_issues_before + right_issues_before
+        assert left.has_errors is True
+        assert left.has_warnings is True
+        assert right.issues == right_issues_before
+
+
+class TestValidationResultSerialization:
+    def test_warnings_as_dicts_serializes_warning_issues_only(self):
+        validation = _validation_module()
+
+        result = validation.ValidationResult()
+        result.add_warning(
+            "declared custom tool missing",
+            source="tool_governance",
+            context="fetcher",
+        )
+        result.add_error("fatal parser error", source="parser", context="workflow.yml")
+
+        warnings = result.warnings_as_dicts()
+
+        assert warnings == [
+            {
+                "message": "declared custom tool missing",
+                "source": "tool_governance",
+                "context": "fetcher",
+            }
+        ]
+
+    def test_warnings_as_dicts_preserves_none_fields(self):
+        validation = _validation_module()
+
+        result = validation.ValidationResult()
+        result.add_warning("warning without extra context")
+
+        warnings = result.warnings_as_dicts()
+
+        assert warnings == [
+            {
+                "message": "warning without extra context",
+                "source": None,
+                "context": None,
+            }
+        ]

--- a/packages/core/tests/test_tool_integration.py
+++ b/packages/core/tests/test_tool_integration.py
@@ -821,10 +821,10 @@ class TestRequiredToolCalls:
 
 
 class TestParseValidation:
-    """parse_workflow_yaml must raise ValueError for bad tool configurations."""
+    """parse_workflow_yaml must tolerate undeclared soul tools as warnings."""
 
-    def test_soul_references_undeclared_tool_raises_value_error(self) -> None:
-        """Soul referencing tool not in tools: section -> ValueError."""
+    def test_soul_references_undeclared_tool_parses_with_empty_resolved_tools(self) -> None:
+        """Soul referencing tool not in tools: section -> warning and omission."""
         yaml_dict = _workflow_dict(
             tools=["http"],
             souls={
@@ -840,11 +840,12 @@ class TestParseValidation:
             blocks={"step": {"type": "linear", "soul_ref": "agent"}},
         )
 
-        with pytest.raises(ValueError, match="undeclared tool"):
-            parse_workflow_yaml(yaml_dict)
+        workflow = parse_workflow_yaml(yaml_dict)
+        soul = workflow.blocks["step"].soul
+        assert soul.resolved_tools == []
 
-    def test_undeclared_tool_error_mentions_soul_name(self) -> None:
-        """ValueError for undeclared tool must mention the soul's key."""
+    def test_undeclared_tool_warning_mentions_soul_name(self) -> None:
+        """Warning for undeclared tool must still identify the soul's key."""
         yaml_dict = _workflow_dict(
             tools=["http"],
             souls={
@@ -860,8 +861,9 @@ class TestParseValidation:
             blocks={"step": {"type": "linear", "soul_ref": "my_special_soul"}},
         )
 
-        with pytest.raises(ValueError, match="my_special_soul"):
-            parse_workflow_yaml(yaml_dict)
+        workflow = parse_workflow_yaml(yaml_dict)
+        soul = workflow.blocks["step"].soul
+        assert soul.resolved_tools == []
 
     def test_unknown_tool_id_raises_value_error(self) -> None:
         """Workflow tool IDs not found in the builtin registry or discovered custom tools should fail."""
@@ -1998,8 +2000,8 @@ workflow:
             "fetch_answer",
         }
 
-    def test_undeclared_tool_raises_actionable_valueerror(self, tmp_path: Path) -> None:
-        """RUN-532 AC4: governance errors should stay actionable in the end-to-end parse path."""
+    def test_undeclared_tool_parses_with_empty_resolved_tools(self, tmp_path: Path) -> None:
+        """RUN-532 AC4: undeclared soul tools should parse and be omitted from resolution."""
         workflow_path = _write_workflow_file(
             tmp_path,
             """\
@@ -2028,11 +2030,9 @@ workflow:
 """,
         )
 
-        with pytest.raises(
-            ValueError,
-            match=r"agent.*undeclared tool 'missing_tool'.*Declared tools: \[\]",
-        ):
-            parse_workflow_yaml(str(workflow_path))
+        workflow = parse_workflow_yaml(str(workflow_path))
+        soul = workflow.blocks["step"].soul
+        assert soul.resolved_tools == []
 
     @pytest.mark.asyncio
     async def test_ipc_tool_call_round_trip_returns_engine_tool_output(

--- a/packages/core/tests/test_tool_integration.py
+++ b/packages/core/tests/test_tool_integration.py
@@ -865,8 +865,8 @@ class TestParseValidation:
         soul = workflow.blocks["step"].soul
         assert soul.resolved_tools == []
 
-    def test_unknown_tool_id_raises_value_error(self) -> None:
-        """Workflow tool IDs not found in the builtin registry or discovered custom tools should fail."""
+    def test_unknown_tool_id_parses_with_empty_resolved_tools(self) -> None:
+        """Unknown workflow tool IDs should parse and leave the authored tool list intact."""
         yaml_dict = _workflow_dict(
             tools=["does_not_exist"],
             souls={
@@ -882,11 +882,13 @@ class TestParseValidation:
             blocks={"step": {"type": "linear", "soul_ref": "agent"}},
         )
 
-        with pytest.raises(ValueError):
-            parse_workflow_yaml(yaml_dict)
+        workflow = parse_workflow_yaml(yaml_dict)
+        soul = workflow.blocks["step"].soul
+        assert soul.tools == ["does_not_exist"]
+        assert soul.resolved_tools == []
 
-    def test_unknown_tool_id_error_mentions_id_string(self) -> None:
-        """ValueError for an unknown workflow tool ID must include the offending ID string."""
+    def test_unknown_tool_id_warning_keeps_authored_tool_id(self) -> None:
+        """Unknown workflow tool IDs should still be reported through the authored tool id."""
         yaml_dict = _workflow_dict(
             tools=["mystery_281"],
             souls={
@@ -902,8 +904,10 @@ class TestParseValidation:
             blocks={"step": {"type": "linear", "soul_ref": "agent"}},
         )
 
-        with pytest.raises(ValueError, match="mystery_281"):
-            parse_workflow_yaml(yaml_dict)
+        workflow = parse_workflow_yaml(yaml_dict)
+        soul = workflow.blocks["step"].soul
+        assert soul.tools == ["mystery_281"]
+        assert soul.resolved_tools == []
 
 
 class TestCanonicalWorkflowToolIdIntegration:

--- a/packages/core/tests/unit/test_parser_tool_validation.py
+++ b/packages/core/tests/unit/test_parser_tool_validation.py
@@ -22,6 +22,7 @@ from pydantic import ValidationError
 from runsight_core.tools import ToolInstance
 from runsight_core.yaml.parser import _resolve_soul_tool_definition, parse_workflow_yaml
 from runsight_core.yaml.schema import RunsightWorkflowFile
+from runsight_core.yaml.validation import ValidationResult
 
 # ---------------------------------------------------------------------------
 # Helper: minimal YAML builder for tool-validation tests
@@ -193,11 +194,9 @@ souls:
       to: null""",
         )
 
-        with pytest.raises(
-            ValueError,
-            match=r"undeclared tool 'http'.*Declared tools: \[\]",
-        ):
-            parse_workflow_yaml(yaml_str)
+        workflow = parse_workflow_yaml(yaml_str)
+        soul = workflow.blocks["my_block"].soul
+        assert soul.resolved_tools == []
 
 
 # ===========================================================================
@@ -274,7 +273,12 @@ souls:
         )
         file_def = RunsightWorkflowFile.model_validate(raw)
 
-        parser_module.validate_tool_governance(file_def)
+        result = parser_module.validate_tool_governance(file_def)
+
+        assert isinstance(result, ValidationResult)
+        assert result.issues == []
+        assert result.has_errors is False
+        assert result.has_warnings is False
 
 
 # ===========================================================================
@@ -392,8 +396,9 @@ souls:
       to: null""",
         )
 
-        with pytest.raises(ValueError, match=r"undeclared tool 'http'.*Declared tools: \[\]"):
-            parse_workflow_yaml(yaml_str)
+        workflow = parse_workflow_yaml(yaml_str)
+        soul = workflow.blocks["my_block"].soul
+        assert soul.resolved_tools == []
 
     def test_missing_custom_tool_id_raises_actionable_valueerror(self, tmp_path):
         """Custom IDs declared in the workflow must resolve to checkout-local metadata files."""
@@ -533,15 +538,15 @@ souls:
 
 
 # ===========================================================================
-# AC2: Soul references undeclared tool -> ValueError at parse time
+# AC2: Soul references undeclared tool -> warning at parse time
 # ===========================================================================
 
 
 class TestUndeclaredToolReference:
-    """Soul referencing a tool not in the tools section raises ValueError."""
+    """Soul referencing a tool not in the tools section should parse with warnings."""
 
-    def test_soul_references_undeclared_tool_raises_valueerror(self):
-        """AC2: Soul references tool 'foo' not in tools section -> ValueError."""
+    def test_soul_references_undeclared_tool_parses_with_empty_resolved_tools(self):
+        """AC2: Soul references tool 'foo' not in tools section -> warning and omission."""
         yaml_str = _make_yaml(
             tools="""\
 tools:
@@ -563,11 +568,13 @@ souls:
       to: null""",
         )
 
-        with pytest.raises(ValueError, match="undeclared tool"):
-            parse_workflow_yaml(yaml_str)
+        workflow = parse_workflow_yaml(yaml_str)
+        soul = workflow.blocks["my_block"].soul
 
-    def test_undeclared_tool_error_mentions_soul_name(self):
-        """AC2: Error message includes the soul name and declared tool keys."""
+        assert soul.resolved_tools == []
+
+    def test_undeclared_tool_warning_keeps_workflow_parseable_for_library_souls(self):
+        """AC2: A library soul with an undeclared tool should still parse successfully."""
         yaml_str = _make_yaml(
             tools="""\
 tools:
@@ -590,8 +597,10 @@ souls:
       to: null""",
         )
 
-        with pytest.raises(ValueError, match="researcher_agent"):
-            parse_workflow_yaml(yaml_str)
+        workflow = parse_workflow_yaml(yaml_str)
+        soul = workflow.blocks["my_block"].soul
+
+        assert soul.resolved_tools == []
 
     def test_direct_system_tool_source_still_rejected_for_soul_level_assignment(self):
         """System-owned tools like runsight/delegate must not be directly assignable on souls."""

--- a/packages/core/tests/unit/test_parser_tool_validation.py
+++ b/packages/core/tests/unit/test_parser_tool_validation.py
@@ -348,8 +348,8 @@ souls:
         with pytest.raises(ValueError, match=r"duplicate.*http"):
             parse_workflow_yaml(yaml_str)
 
-    def test_unknown_workflow_tool_id_raises_explicit_valueerror(self):
-        """Unknown workflow tool IDs must be rejected during parser validation."""
+    def test_unknown_workflow_tool_id_parses_with_empty_resolved_tools(self):
+        """Unknown declared tool IDs should warn and leave the workflow parseable."""
         yaml_str = _make_yaml(
             tools="""\
 tools:
@@ -371,8 +371,11 @@ souls:
       to: null""",
         )
 
-        with pytest.raises(ValueError, match=r"unknown tool id 'missing_lookup'"):
-            parse_workflow_yaml(yaml_str)
+        workflow = parse_workflow_yaml(yaml_str)
+        soul = workflow.blocks["my_block"].soul
+
+        assert soul.tools == ["missing_lookup"]
+        assert soul.resolved_tools == []
 
     def test_empty_tools_list_with_soul_reference_raises_undeclared_tool_error(self):
         """Souls still need workflow-declared IDs even when the whitelist is explicitly empty."""
@@ -400,8 +403,8 @@ souls:
         soul = workflow.blocks["my_block"].soul
         assert soul.resolved_tools == []
 
-    def test_missing_custom_tool_id_raises_actionable_valueerror(self, tmp_path):
-        """Custom IDs declared in the workflow must resolve to checkout-local metadata files."""
+    def test_missing_custom_tool_id_parses_with_empty_resolved_tools(self, tmp_path):
+        """Missing custom metadata should warn without making the workflow unparseable."""
         workflow_file = _write_workflow_file(
             tmp_path,
             _make_yaml(
@@ -426,11 +429,11 @@ souls:
             ),
         )
 
-        with pytest.raises(
-            ValueError,
-            match=r"lookup_profile.*custom/tools/lookup_profile\.yaml",
-        ):
-            parse_workflow_yaml(workflow_file)
+        workflow = parse_workflow_yaml(workflow_file)
+        soul = workflow.blocks["my_block"].soul
+
+        assert soul.tools == ["lookup_profile"]
+        assert soul.resolved_tools == []
 
     def test_reserved_builtin_id_collision_with_custom_slug_raises_valueerror(self, tmp_path):
         """Reserved builtin IDs must reject custom tool files that try to reuse the same slug."""
@@ -632,15 +635,15 @@ souls:
 
 
 # ===========================================================================
-# AC3: Unknown tool IDs -> ValueError at parse time
+# AC3: Unknown tool IDs -> warning at parse time
 # ===========================================================================
 
 
 class TestUnknownToolIdStrings:
-    """Source-like workflow entries must fail as unknown canonical IDs."""
+    """Unknown workflow tool IDs should warn instead of aborting parse."""
 
-    def test_legacy_builtin_source_string_in_workflow_tools_raises_valueerror(self):
-        """Old source strings must not be accepted as workflow tool IDs."""
+    def test_legacy_builtin_source_string_parses_with_empty_resolved_tools(self):
+        """Legacy source-like tool IDs should warn and be skipped."""
         yaml_str = _make_yaml(
             tools="""\
 tools:
@@ -662,11 +665,14 @@ souls:
       to: null""",
         )
 
-        with pytest.raises(ValueError, match=r"unknown tool id 'runsight/unknown'"):
-            parse_workflow_yaml(yaml_str)
+        workflow = parse_workflow_yaml(yaml_str)
+        soul = workflow.blocks["my_block"].soul
 
-    def test_unknown_tool_id_error_mentions_available_canonical_ids(self):
-        """Unknown ID errors should point callers back to the canonical whitelist."""
+        assert soul.tools == ["runsight/unknown"]
+        assert soul.resolved_tools == []
+
+    def test_unknown_tool_id_parses_with_empty_resolved_tools(self):
+        """Unknown canonical IDs should warn and keep the workflow parseable."""
         yaml_str = _make_yaml(
             tools="""\
 tools:
@@ -688,8 +694,11 @@ souls:
       to: null""",
         )
 
-        with pytest.raises(ValueError, match="Available"):
-            parse_workflow_yaml(yaml_str)
+        workflow = parse_workflow_yaml(yaml_str)
+        soul = workflow.blocks["my_block"].soul
+
+        assert soul.tools == ["runsight/nonexistent"]
+        assert soul.resolved_tools == []
 
 
 # ===========================================================================
@@ -700,8 +709,8 @@ souls:
 class TestCanonicalDiscoveredToolValidation:
     """Parser validation should stay actionable with ID-only workflow authoring."""
 
-    def test_custom_tool_missing_yaml_file_raises_actionable_valueerror(self, tmp_path):
-        """A declared custom tool ID should fail when its custom/tools YAML is missing."""
+    def test_custom_tool_missing_yaml_file_parses_with_empty_resolved_tools(self, tmp_path):
+        """Missing custom tool metadata should surface as a warning, not a hard failure."""
         workflow_file = _write_workflow_file(
             tmp_path,
             _make_yaml(
@@ -726,11 +735,14 @@ souls:
             ),
         )
 
-        with pytest.raises(ValueError, match=r"missing_lookup.*custom/tools.*yaml"):
-            parse_workflow_yaml(workflow_file)
+        workflow = parse_workflow_yaml(workflow_file)
+        soul = workflow.blocks["my_block"].soul
+
+        assert soul.tools == ["missing_lookup"]
+        assert soul.resolved_tools == []
 
     @pytest.mark.parametrize(
-        ("slug", "tool_yaml", "expected_message"),
+        ("slug", "tool_yaml"),
         [
             (
                 "blocked_import_tool",
@@ -748,7 +760,6 @@ souls:
                   def main(args):
                       return {}
                 """,
-                r"blocked_import_tool.*not allowed",
             ),
             (
                 "missing_main_tool",
@@ -764,14 +775,13 @@ souls:
                   def helper(args):
                       return {}
                 """,
-                r"missing_main_tool.*main",
             ),
         ],
     )
-    def test_custom_tool_invalid_code_raises_actionable_valueerror(
-        self, tmp_path, slug, tool_yaml, expected_message
+    def test_custom_tool_invalid_code_parses_with_empty_resolved_tools(
+        self, tmp_path, slug, tool_yaml
     ):
-        """Blocked imports and missing main() should fail for discovered custom tool IDs."""
+        """Invalid discovered custom tools should warn and be skipped."""
         _write_custom_tool_file(tmp_path, slug, tool_yaml)
         workflow_file = _write_workflow_file(
             tmp_path,
@@ -797,8 +807,11 @@ souls:
             ),
         )
 
-        with pytest.raises(ValueError, match=expected_message):
-            parse_workflow_yaml(workflow_file)
+        workflow = parse_workflow_yaml(workflow_file)
+        soul = workflow.blocks["my_block"].soul
+
+        assert soul.tools == [slug]
+        assert soul.resolved_tools == []
 
     def test_valid_builtin_and_discovered_custom_tool_ids_parse_successfully(self, tmp_path):
         """A workflow mixing canonical builtin and discovered custom IDs should parse cleanly."""

--- a/packages/core/tests/unit/test_run839_tool_governance_validation_result.py
+++ b/packages/core/tests/unit/test_run839_tool_governance_validation_result.py
@@ -50,6 +50,7 @@ def _load_file_def(yaml_str: str) -> RunsightWorkflowFile:
 class TestValidateToolGovernanceResultContract:
     def test_returns_validation_result_with_warning_metadata_for_undeclared_tool(self):
         yaml_str = _make_yaml(
+            entry="ingest",
             tools="""\
 tools:
   - http""",
@@ -177,6 +178,7 @@ class TestWorkflowParserToolGovernanceWarnings:
         self, tmp_path: Path
     ):
         yaml_str = _make_yaml(
+            entry="ingest",
             tools="""\
 tools:
   - http""",
@@ -209,6 +211,7 @@ souls:
         self, tmp_path: Path
     ):
         yaml_str = _make_yaml(
+            entry="ingest",
             tools="""\
 tools: []""",
             souls="""\
@@ -238,6 +241,7 @@ souls:
         self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, tmp_path: Path
     ):
         yaml_str = _make_yaml(
+            entry="route",
             tools="""\
 tools:
   - http

--- a/packages/core/tests/unit/test_run839_tool_governance_validation_result.py
+++ b/packages/core/tests/unit/test_run839_tool_governance_validation_result.py
@@ -266,7 +266,9 @@ souls:
         workflow_file = _write_workflow_file(tmp_path, yaml_str)
 
         monkeypatch.setattr(
-            parser_module, "_validate_declared_tool_definitions", lambda *args, **kwargs: None
+            parser_module,
+            "_validate_declared_tool_definitions",
+            lambda *args, **kwargs: ValidationResult(),
         )
 
         def _fake_resolve_tool_for_parser(

--- a/packages/core/tests/unit/test_run839_tool_governance_validation_result.py
+++ b/packages/core/tests/unit/test_run839_tool_governance_validation_result.py
@@ -1,0 +1,287 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from textwrap import dedent
+from types import SimpleNamespace
+
+import pytest
+import runsight_core.yaml.parser as parser_module
+import yaml
+from runsight_core.yaml.parser import parse_workflow_yaml, validate_tool_governance
+from runsight_core.yaml.schema import RunsightWorkflowFile
+from runsight_core.yaml.validation import ValidationResult, ValidationSeverity
+
+
+def _make_yaml(
+    *,
+    tools: str = "",
+    souls: str = "",
+    blocks: str = "",
+    transitions: str = "",
+    entry: str = "my_block",
+) -> str:
+    return f"""\
+version: "1.0"
+config:
+  model_name: gpt-4o
+{tools}
+{souls}
+blocks:
+{blocks}
+workflow:
+  name: run_839_tool_governance_test
+  entry: {entry}
+  transitions:
+{transitions}
+"""
+
+
+def _write_workflow_file(tmp_path: Path, yaml_str: str) -> str:
+    workflow_file = tmp_path / "workflow.yaml"
+    workflow_file.write_text(dedent(yaml_str), encoding="utf-8")
+    return str(workflow_file)
+
+
+def _load_file_def(yaml_str: str) -> RunsightWorkflowFile:
+    return RunsightWorkflowFile.model_validate(yaml.safe_load(dedent(yaml_str)))
+
+
+class TestValidateToolGovernanceResultContract:
+    def test_returns_validation_result_with_warning_metadata_for_undeclared_tool(self):
+        yaml_str = _make_yaml(
+            tools="""\
+tools:
+  - http""",
+            souls="""\
+souls:
+  fetcher:
+    id: fetcher
+    role: Fetcher
+    system_prompt: Fetch data.
+    tools:
+      - http
+      - scraper""",
+            blocks="""\
+  ingest:
+    type: linear
+    soul_ref: fetcher""",
+            transitions="""\
+    - from: ingest
+      to: null""",
+        )
+        file_def = _load_file_def(yaml_str)
+
+        result = validate_tool_governance(file_def, file_def.souls)
+
+        assert isinstance(result, ValidationResult)
+        assert result.has_errors is False
+        assert result.has_warnings is True
+        assert result.issues == result.warnings
+        assert len(result.warnings) == 1
+        issue = result.warnings[0]
+        assert issue.severity is ValidationSeverity.warning
+        assert issue.source == "tool_governance"
+        assert issue.context == "fetcher"
+        assert "fetcher" in issue.message
+        assert "scraper" in issue.message
+        assert result.warnings_as_dicts() == [
+            {
+                "message": issue.message,
+                "source": "tool_governance",
+                "context": "fetcher",
+            }
+        ]
+
+    def test_returns_empty_result_when_every_referenced_tool_is_declared(self):
+        yaml_str = _make_yaml(
+            tools="""\
+tools:
+  - http
+  - file_io""",
+            souls="""\
+souls:
+  builder:
+    id: builder
+    role: Builder
+    system_prompt: Build things.
+    tools:
+      - http
+      - file_io""",
+            blocks="""\
+  build:
+    type: linear
+    soul_ref: builder""",
+            transitions="""\
+    - from: build
+      to: null""",
+        )
+        file_def = _load_file_def(yaml_str)
+
+        result = validate_tool_governance(file_def, file_def.souls)
+
+        assert isinstance(result, ValidationResult)
+        assert result.issues == []
+        assert result.has_errors is False
+        assert result.has_warnings is False
+        assert result.error_summary is None
+        assert result.warnings_as_dicts() == []
+
+    def test_returns_one_warning_per_soul_tool_pair(self):
+        yaml_str = _make_yaml(
+            tools="""\
+tools:
+  - http""",
+            souls="""\
+souls:
+  fetcher:
+    id: fetcher
+    role: Fetcher
+    system_prompt: Fetch data.
+    tools:
+      - scraper
+  archiver:
+    id: archiver
+    role: Archiver
+    system_prompt: Archive data.
+    tools:
+      - scraper""",
+            blocks="""\
+  ingest:
+    type: linear
+    soul_ref: fetcher
+  archive:
+    type: linear
+    soul_ref: archiver""",
+            transitions="""\
+    - from: ingest
+      to: archive
+    - from: archive
+      to: null""",
+        )
+        file_def = _load_file_def(yaml_str)
+
+        result = validate_tool_governance(file_def, file_def.souls)
+
+        assert isinstance(result, ValidationResult)
+        assert len(result.warnings) == 2
+        assert {(issue.context, issue.source) for issue in result.warnings} == {
+            ("fetcher", "tool_governance"),
+            ("archiver", "tool_governance"),
+        }
+        assert all("scraper" in issue.message for issue in result.warnings)
+
+
+class TestWorkflowParserToolGovernanceWarnings:
+    def test_parse_workflow_yaml_keeps_workflow_parseable_when_one_soul_tool_is_undeclared(
+        self, tmp_path: Path
+    ):
+        yaml_str = _make_yaml(
+            tools="""\
+tools:
+  - http""",
+            souls="""\
+souls:
+  fetcher:
+    id: fetcher
+    role: Fetcher
+    system_prompt: Fetch data.
+    tools:
+      - http
+      - scraper""",
+            blocks="""\
+  ingest:
+    type: linear
+    soul_ref: fetcher""",
+            transitions="""\
+    - from: ingest
+      to: null""",
+        )
+        workflow_file = _write_workflow_file(tmp_path, yaml_str)
+
+        workflow = parse_workflow_yaml(workflow_file)
+
+        soul = workflow.blocks["ingest"].soul
+        assert soul.resolved_tools is not None
+        assert [tool.name for tool in soul.resolved_tools] == ["http_request"]
+
+    def test_parse_workflow_yaml_returns_empty_resolved_tools_when_all_soul_tools_are_unavailable(
+        self, tmp_path: Path
+    ):
+        yaml_str = _make_yaml(
+            tools="""\
+tools: []""",
+            souls="""\
+souls:
+  fetcher:
+    id: fetcher
+    role: Fetcher
+    system_prompt: Fetch data.
+    tools:
+      - scraper""",
+            blocks="""\
+  ingest:
+    type: linear
+    soul_ref: fetcher""",
+            transitions="""\
+    - from: ingest
+      to: null""",
+        )
+        workflow_file = _write_workflow_file(tmp_path, yaml_str)
+
+        workflow = parse_workflow_yaml(workflow_file)
+
+        soul = workflow.blocks["ingest"].soul
+        assert soul.resolved_tools == []
+
+    def test_parse_workflow_yaml_skips_one_failed_tool_resolution_and_logs_warning(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, tmp_path: Path
+    ):
+        yaml_str = _make_yaml(
+            tools="""\
+tools:
+  - http
+  - file_io""",
+            souls="""\
+souls:
+  router:
+    id: router
+    role: Router
+    system_prompt: Route requests.
+    tools:
+      - http
+      - file_io""",
+            blocks="""\
+  route:
+    type: linear
+    soul_ref: router""",
+            transitions="""\
+    - from: route
+      to: null""",
+        )
+        workflow_file = _write_workflow_file(tmp_path, yaml_str)
+
+        monkeypatch.setattr(
+            parser_module, "_validate_declared_tool_definitions", lambda *args, **kwargs: None
+        )
+
+        def _fake_resolve_tool_for_parser(
+            tool_id: str, *, base_dir: str, exits: object | None = None
+        ):
+            if tool_id == "file_io":
+                raise ValueError("synthetic tool resolution failure")
+            return SimpleNamespace(name="http_request", description="ok", parameters={})
+
+        monkeypatch.setattr(
+            parser_module, "_resolve_tool_for_parser", _fake_resolve_tool_for_parser
+        )
+
+        with caplog.at_level(logging.WARNING, logger="runsight_core.yaml.parser"):
+            workflow = parse_workflow_yaml(workflow_file)
+
+        soul = workflow.blocks["route"].soul
+        assert [tool.name for tool in soul.resolved_tools] == ["http_request"]
+        assert any(
+            record.levelno == logging.WARNING and "file_io" in record.message
+            for record in caplog.records
+        )

--- a/packages/shared/src/__tests__/codegen.test.ts
+++ b/packages/shared/src/__tests__/codegen.test.ts
@@ -589,6 +589,24 @@ describe("RUN-842: generated API types stay aligned for run warnings", () => {
       $ref: "#/components/schemas/WarningItem",
     });
   });
+
+  it("keeps a single canonical WarningItem component (no duplicate warning schemas)", () => {
+    const snapshot = readCommittedOpenApiSnapshot();
+    const schemas = snapshot.components as Record<string, unknown> | undefined;
+    const schemaMap = (schemas?.schemas ?? {}) as Record<string, Record<string, unknown>>;
+
+    const warningLikeNames = Object.keys(schemaMap)
+      .filter((name) => name.toLowerCase().includes("warningitem"))
+      .sort();
+    expect(warningLikeNames).toEqual(["WarningItem"]);
+
+    const runResponse = schemaMap.RunResponse;
+    const runProperties = (runResponse?.properties ?? {}) as Record<string, unknown>;
+    const runWarnings = runProperties.warnings as Record<string, unknown> | undefined;
+    expect(runWarnings?.items).toMatchObject({
+      $ref: "#/components/schemas/WarningItem",
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/shared/src/__tests__/codegen.test.ts
+++ b/packages/shared/src/__tests__/codegen.test.ts
@@ -70,6 +70,10 @@ function extractSchemaFieldNames(source: string, schemaName: string): string[] {
     });
 }
 
+function readCommittedOpenApiSnapshot(): Record<string, unknown> {
+  return JSON.parse(readFileSync(resolve(REPO_ROOT, "openapi.json"), "utf8"));
+}
+
 function buildFreshSchemaSnapshot(): {
   runCreate: SchemaFieldSnapshot;
   runResponse: SchemaFieldSnapshot;
@@ -539,12 +543,46 @@ describe("RUN-840: generated API types stay aligned for workflow warnings", () =
     expect(fields).not.toContain("code");
   });
 
+  it("keeps RunResponse free of workflow warning fields in generated API types", () => {
+    const fields = extractApiComponentFieldNames(apiSource, "RunResponse");
+    expect(fields).not.toContain("warnings");
+  });
+
   it("declares WarningItem with the canonical workflow warning fields", () => {
     const fields = extractApiComponentFieldNames(apiSource, "WarningItem");
     expect(fields).toEqual(
       expect.arrayContaining(["message", "source", "context"]),
     );
     expect(fields).toHaveLength(3);
+  });
+
+  it("pins the committed openapi.json workflow warning contract without widening runs", () => {
+    const snapshot = readCommittedOpenApiSnapshot();
+    const schemas = snapshot.components as Record<string, unknown> | undefined;
+    const schemaMap = (schemas?.schemas ?? {}) as Record<string, Record<string, unknown>>;
+
+    const warningItem = schemaMap.WarningItem;
+    expect(warningItem).toBeDefined();
+    expect(Object.keys((warningItem?.properties ?? {}) as Record<string, unknown>).sort()).toEqual([
+      "context",
+      "message",
+      "source",
+    ]);
+
+    const workflowResponse = schemaMap.WorkflowResponse;
+    expect(workflowResponse).toBeDefined();
+    const workflowWarnings = (workflowResponse?.properties ?? {}) as Record<string, unknown>;
+    expect(workflowWarnings).toHaveProperty("warnings");
+    const warningsProperty = workflowWarnings.warnings as Record<string, unknown>;
+    expect(warningsProperty?.items).toMatchObject({
+      $ref: "#/components/schemas/WarningItem",
+    });
+
+    const runResponse = schemaMap.RunResponse;
+    expect(runResponse).toBeDefined();
+    expect((runResponse?.properties ?? {}) as Record<string, unknown>).not.toHaveProperty(
+      "warnings",
+    );
   });
 });
 

--- a/packages/shared/src/__tests__/codegen.test.ts
+++ b/packages/shared/src/__tests__/codegen.test.ts
@@ -532,7 +532,7 @@ describe("RUN-823: custom YAML request schemas are strict", () => {
   });
 });
 
-describe("RUN-840: generated API types stay aligned for workflow warnings", () => {
+describe("RUN-842: generated API types stay aligned for run warnings", () => {
   const apiSource = readFileSync(resolve(GENERATED_DIR, "api.ts"), "utf8");
 
   it("declares WorkflowResponse warnings in the generated API component namespace", () => {
@@ -543,9 +543,11 @@ describe("RUN-840: generated API types stay aligned for workflow warnings", () =
     expect(fields).not.toContain("code");
   });
 
-  it("keeps RunResponse free of workflow warning fields in generated API types", () => {
+  it("declares RunResponse warnings in the generated API component namespace", () => {
     const fields = extractApiComponentFieldNames(apiSource, "RunResponse");
-    expect(fields).not.toContain("warnings");
+    expect(fields).toEqual(
+      expect.arrayContaining(["id", "workflow_id", "status", "warnings"]),
+    );
   });
 
   it("declares WarningItem with the canonical workflow warning fields", () => {
@@ -556,7 +558,7 @@ describe("RUN-840: generated API types stay aligned for workflow warnings", () =
     expect(fields).toHaveLength(3);
   });
 
-  it("pins the committed openapi.json workflow warning contract without widening runs", () => {
+  it("pins the committed openapi.json run warning contract", () => {
     const snapshot = readCommittedOpenApiSnapshot();
     const schemas = snapshot.components as Record<string, unknown> | undefined;
     const schemaMap = (schemas?.schemas ?? {}) as Record<string, Record<string, unknown>>;
@@ -580,9 +582,12 @@ describe("RUN-840: generated API types stay aligned for workflow warnings", () =
 
     const runResponse = schemaMap.RunResponse;
     expect(runResponse).toBeDefined();
-    expect((runResponse?.properties ?? {}) as Record<string, unknown>).not.toHaveProperty(
-      "warnings",
-    );
+    const runProperties = (runResponse?.properties ?? {}) as Record<string, unknown>;
+    const runWarnings = runProperties.warnings as Record<string, unknown> | undefined;
+    expect(runWarnings).toBeDefined();
+    expect(runWarnings?.items).toMatchObject({
+      $ref: "#/components/schemas/WarningItem",
+    });
   });
 });
 

--- a/packages/shared/src/__tests__/codegen.test.ts
+++ b/packages/shared/src/__tests__/codegen.test.ts
@@ -528,6 +528,26 @@ describe("RUN-823: custom YAML request schemas are strict", () => {
   });
 });
 
+describe("RUN-840: generated API types stay aligned for workflow warnings", () => {
+  const apiSource = readFileSync(resolve(GENERATED_DIR, "api.ts"), "utf8");
+
+  it("declares WorkflowResponse warnings in the generated API component namespace", () => {
+    const fields = extractApiComponentFieldNames(apiSource, "WorkflowResponse");
+    expect(fields).toEqual(
+      expect.arrayContaining(["id", "valid", "warnings"]),
+    );
+    expect(fields).not.toContain("code");
+  });
+
+  it("declares WarningItem with the canonical workflow warning fields", () => {
+    const fields = extractApiComponentFieldNames(apiSource, "WarningItem");
+    expect(fields).toEqual(
+      expect.arrayContaining(["message", "source", "context"]),
+    );
+    expect(fields).toHaveLength(3);
+  });
+});
+
 // ---------------------------------------------------------------------------
 // 4. package.json has codegen scripts
 // ---------------------------------------------------------------------------

--- a/packages/shared/src/__tests__/codegen.test.ts
+++ b/packages/shared/src/__tests__/codegen.test.ts
@@ -76,6 +76,7 @@ function buildFreshSchemaSnapshot(): {
   soulCreate: SchemaFieldSnapshot;
   soulResponse: SchemaFieldSnapshot;
   soulUpdate: SchemaFieldSnapshot;
+  workflowResponse: SchemaFieldSnapshot;
 } {
   const workdir = mkdtempSync(join(tmpdir(), "runsight-zod-"));
   const openapiPath = resolve(workdir, "openapi.json");
@@ -130,6 +131,10 @@ function buildFreshSchemaSnapshot(): {
       soulUpdate: {
         fresh: extractSchemaFieldNames(freshZod, "SoulUpdate"),
         committed: extractSchemaFieldNames(committedZod, "SoulUpdate"),
+      },
+      workflowResponse: {
+        fresh: extractSchemaFieldNames(freshZod, "WorkflowResponse"),
+        committed: extractSchemaFieldNames(committedZod, "WorkflowResponse"),
       },
     };
   } finally {
@@ -202,6 +207,27 @@ describe("RUN-134: Generated types export expected interfaces", () => {
     );
     expect(fields).not.toContain("slug");
     expect(fields).not.toContain("type");
+  });
+});
+
+describe("RUN-840: generated workflow warning contracts stay in sync", () => {
+  it("generated WorkflowResponse schemas include warnings in fresh and committed output", () => {
+    const snapshot = buildFreshSchemaSnapshot();
+
+    expect(snapshot.workflowResponse.fresh).toEqual(
+      expect.arrayContaining(["id", "valid", "warnings"]),
+    );
+    expect(snapshot.workflowResponse.committed).toEqual(
+      expect.arrayContaining(["id", "valid", "warnings"]),
+    );
+  });
+
+  it("committed Zod source exports WarningItemSchema for workflow warnings", () => {
+    const zodSource = readFileSync(COMMITTED_ZOD_PATH, "utf8");
+
+    expect(zodSource).toContain("WarningItemSchema");
+    expect(zodSource).toContain("WorkflowResponseSchema");
+    expect(zodSource).toContain("warnings");
   });
 });
 

--- a/packages/shared/src/__tests__/run840_workflow_warning_contract.test.ts
+++ b/packages/shared/src/__tests__/run840_workflow_warning_contract.test.ts
@@ -85,4 +85,10 @@ describe("RUN-840 workflow warning contract", () => {
       }).success,
     ).toBe(false);
   });
+
+  it("RunResponseSchema stays free of workflow warning fields", () => {
+    const runSchema = getSchema("RunResponseSchema");
+
+    expect(runSchema.shape).not.toHaveProperty("warnings");
+  });
 });

--- a/packages/shared/src/__tests__/run840_workflow_warning_contract.test.ts
+++ b/packages/shared/src/__tests__/run840_workflow_warning_contract.test.ts
@@ -27,12 +27,21 @@ describe("RUN-840 workflow warning contract", () => {
   it("exports WarningItemSchema with canonical warning payload fields", () => {
     const warningSchema = getSchema("WarningItemSchema");
 
-    expect(Object.keys(warningSchema.shape)).toEqual(
-      expect.arrayContaining(["message", "source", "context"]),
-    );
+    expect(Object.keys(warningSchema.shape).sort()).toEqual([
+      "context",
+      "message",
+      "source",
+    ]);
     expect(warningSchema.parse(warningPayload)).toEqual(
       expect.objectContaining(warningPayload),
     );
+    expect(
+      warningSchema.safeParse({
+        ...warningPayload,
+        code: "W001",
+        severity: "warning",
+      }).success,
+    ).toBe(false);
   });
 
   it("WorkflowResponseSchema declares warnings and parses warning payloads", () => {
@@ -50,5 +59,30 @@ describe("RUN-840 workflow warning contract", () => {
     expect((parsed as { warnings: unknown[] }).warnings[0]).toEqual(
       expect.objectContaining(warningPayload),
     );
+
+    const nullContextResult = workflowSchema.safeParse({
+      id: "wf_1",
+      warnings: [
+        {
+          message: "Tool definition warning",
+          source: "tool_definitions",
+          context: null,
+        },
+      ],
+    });
+
+    expect(nullContextResult.success).toBe(true);
+    expect(
+      workflowSchema.safeParse({
+        id: "wf_1",
+        warnings: [
+          {
+            message: "Tool definition warning",
+            source: "tool_definitions",
+            context: { tool_id: "lookup_profile" },
+          },
+        ],
+      }).success,
+    ).toBe(false);
   });
 });

--- a/packages/shared/src/__tests__/run840_workflow_warning_contract.test.ts
+++ b/packages/shared/src/__tests__/run840_workflow_warning_contract.test.ts
@@ -17,7 +17,7 @@ function getSchema(name: string): ParseableSchema {
   return schema as ParseableSchema;
 }
 
-describe("RUN-840 workflow warning contract", () => {
+describe("RUN-840/842 warning contracts", () => {
   const warningPayload = {
     message: "Tool definition warning",
     source: "tool_definitions",
@@ -86,9 +86,51 @@ describe("RUN-840 workflow warning contract", () => {
     ).toBe(false);
   });
 
-  it("RunResponseSchema stays free of workflow warning fields", () => {
+  it("RunResponseSchema declares warnings and parses warning payloads", () => {
     const runSchema = getSchema("RunResponseSchema");
 
-    expect(runSchema.shape).not.toHaveProperty("warnings");
+    expect(runSchema.shape).toHaveProperty("warnings");
+
+    const parsed = runSchema.parse({
+      id: "run_1",
+      workflow_id: "wf_1",
+      workflow_name: "Workflow",
+      status: "pending",
+      started_at: null,
+      completed_at: null,
+      duration_seconds: null,
+      total_cost_usd: 0,
+      total_tokens: 0,
+      created_at: 123.0,
+      warnings: [warningPayload],
+    });
+
+    expect(parsed).toHaveProperty("warnings");
+    expect((parsed as { warnings: unknown[] }).warnings).toHaveLength(1);
+    expect((parsed as { warnings: unknown[] }).warnings[0]).toEqual(
+      expect.objectContaining(warningPayload),
+    );
+
+    expect(
+      runSchema.safeParse({
+        id: "run_1",
+        workflow_id: "wf_1",
+        workflow_name: "Workflow",
+        status: "pending",
+        started_at: null,
+        completed_at: null,
+        duration_seconds: null,
+        total_cost_usd: 0,
+        total_tokens: 0,
+        created_at: 123.0,
+        warnings: [
+          {
+            message: "Tool definition warning",
+            source: "tool_definitions",
+            context: { tool_id: "lookup_profile" },
+          },
+        ],
+      }).success,
+    ).toBe(false);
   });
 });

--- a/packages/shared/src/__tests__/run840_workflow_warning_contract.test.ts
+++ b/packages/shared/src/__tests__/run840_workflow_warning_contract.test.ts
@@ -42,6 +42,10 @@ describe("RUN-840/842 warning contracts", () => {
         severity: "warning",
       }).success,
     ).toBe(false);
+    expect(
+      "RunWarningItemSchema" in (sharedZod as Record<string, unknown>),
+      "Duplicate warning schema exports are not allowed",
+    ).toBe(false);
   });
 
   it("WorkflowResponseSchema declares warnings and parses warning payloads", () => {

--- a/packages/shared/src/__tests__/run840_workflow_warning_contract.test.ts
+++ b/packages/shared/src/__tests__/run840_workflow_warning_contract.test.ts
@@ -1,0 +1,54 @@
+import * as sharedZod from "@runsight/shared/zod";
+import { describe, expect, it } from "vitest";
+
+type ParseableSchema = {
+  parse: (input: unknown) => unknown;
+  shape: Record<string, unknown>;
+};
+
+function getSchema(name: string): ParseableSchema {
+  const schema = (sharedZod as Record<string, unknown>)[name];
+
+  expect(
+    schema && typeof (schema as { parse?: unknown }).parse === "function",
+    `Expected ${name} to be exported from @runsight/shared/zod`,
+  ).toBe(true);
+
+  return schema as ParseableSchema;
+}
+
+describe("RUN-840 workflow warning contract", () => {
+  const warningPayload = {
+    message: "Tool definition warning",
+    source: "tool_definitions",
+    context: "lookup_profile",
+  };
+
+  it("exports WarningItemSchema with canonical warning payload fields", () => {
+    const warningSchema = getSchema("WarningItemSchema");
+
+    expect(Object.keys(warningSchema.shape)).toEqual(
+      expect.arrayContaining(["message", "source", "context"]),
+    );
+    expect(warningSchema.parse(warningPayload)).toEqual(
+      expect.objectContaining(warningPayload),
+    );
+  });
+
+  it("WorkflowResponseSchema declares warnings and parses warning payloads", () => {
+    const workflowSchema = getSchema("WorkflowResponseSchema");
+
+    expect(workflowSchema.shape).toHaveProperty("warnings");
+
+    const parsed = workflowSchema.parse({
+      id: "wf_1",
+      warnings: [warningPayload],
+    });
+
+    expect(parsed).toHaveProperty("warnings");
+    expect((parsed as { warnings: unknown[] }).warnings).toHaveLength(1);
+    expect((parsed as { warnings: unknown[] }).warnings[0]).toEqual(
+      expect.objectContaining(warningPayload),
+    );
+  });
+});

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -1597,6 +1597,15 @@ export interface components {
             /** Context */
             ctx?: Record<string, never>;
         };
+        /** WarningItem */
+        WarningItem: {
+            /** Message */
+            message: string;
+            /** Source */
+            source?: string | null;
+            /** Context */
+            context?: string | null;
+        };
         /** WorkflowCanvasState */
         WorkflowCanvasState: {
             /** Nodes */
@@ -1712,6 +1721,11 @@ export interface components {
             valid: boolean;
             /** Validation Error */
             validation_error?: string | null;
+            /**
+             * Warnings
+             * @default []
+             */
+            warnings: components["schemas"]["WarningItem"][];
             /**
              * Block Count
              * @default 0

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -1223,6 +1223,11 @@ export interface components {
             regression_count: number | null;
             /** Regression Types */
             regression_types?: string[];
+            /**
+             * Warnings
+             * @default []
+             */
+            warnings: components["schemas"]["WarningItem"][];
             node_summary?: components["schemas"]["NodeSummary"] | null;
             /** Parent Run Id */
             parent_run_id?: string | null;

--- a/packages/shared/src/zod.ts
+++ b/packages/shared/src/zod.ts
@@ -190,7 +190,7 @@ export type ProviderTestIn = z.infer<typeof ProviderTestInSchema>;
 export const ProviderTestOutSchema = z.object({
   success: z.boolean(),
   message: z.string(),
-  models: z.array(z.string()).optional(),
+  models: z.array(z.string()).optional().default([]),
   model_count: z.number().optional().default(0),
   latency_ms: z.number().optional().default(0.0),
 });
@@ -318,7 +318,7 @@ export const SettingsProviderResponseSchema = z.object({
   api_key_env: z.string().nullable().optional(),
   api_key_preview: z.string().nullable().optional(),
   base_url: z.string().nullable().optional(),
-  models: z.array(z.string()).optional(),
+  models: z.array(z.string()).optional().default([]),
   model_count: z.number().optional().default(0),
   created_at: z.string().nullable().optional(),
   updated_at: z.string().nullable().optional(),
@@ -504,6 +504,13 @@ export const ToolListItemResponseSchema = z.object({
 });
 export type ToolListItemResponse = z.infer<typeof ToolListItemResponseSchema>;
 
+export const WarningItemSchema = z.object({
+  message: z.string(),
+  source: z.string().nullable().optional(),
+  context: z.string().nullable().optional(),
+}).strict();
+export type WarningItem = z.infer<typeof WarningItemSchema>;
+
 export const WorkflowCanvasStateSchema = z.object({
   nodes: z.array(z.record(z.string(), z.unknown())).optional(),
   edges: z.array(z.record(z.string(), z.unknown())).optional(),
@@ -566,6 +573,7 @@ export const WorkflowResponseSchema = z.object({
   canvas_state: WorkflowCanvasStateSchema.nullable().optional(),
   valid: z.boolean().optional().default(true),
   validation_error: z.string().nullable().optional(),
+  warnings: z.array(WarningItemSchema).optional().default([]),
   block_count: z.number().optional().default(0),
   modified_at: z.number().nullable().optional(),
   enabled: z.boolean().optional().default(false),

--- a/packages/shared/src/zod.ts
+++ b/packages/shared/src/zod.ts
@@ -220,6 +220,13 @@ export const RunEvalResponseSchema = z.object({
 });
 export type RunEvalResponse = z.infer<typeof RunEvalResponseSchema>;
 
+export const WarningItemSchema = z.object({
+  message: z.string(),
+  source: z.string().nullable().optional(),
+  context: z.string().nullable().optional(),
+}).strict();
+export type WarningItem = z.infer<typeof WarningItemSchema>;
+
 export const RunResponseSchema = z.object({
   id: z.string(),
   workflow_id: z.string(),
@@ -240,6 +247,7 @@ export const RunResponseSchema = z.object({
   eval_score_avg: z.number().nullable().optional(),
   regression_count: z.number().nullable().optional().default(0),
   regression_types: z.array(z.string()).optional(),
+  warnings: z.array(WarningItemSchema).optional().default([]),
   node_summary: NodeSummarySchema.nullable().optional(),
   parent_run_id: z.string().nullable().optional(),
   root_run_id: z.string().nullable().optional(),
@@ -503,13 +511,6 @@ export const ToolListItemResponseSchema = z.object({
   executor: z.string(),
 });
 export type ToolListItemResponse = z.infer<typeof ToolListItemResponseSchema>;
-
-export const WarningItemSchema = z.object({
-  message: z.string(),
-  source: z.string().nullable().optional(),
-  context: z.string().nullable().optional(),
-}).strict();
-export type WarningItem = z.infer<typeof WarningItemSchema>;
 
 export const WorkflowCanvasStateSchema = z.object({
   nodes: z.array(z.record(z.string(), z.unknown())).optional(),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runsight-workspace"
-version = "0.2.3"
+version = "0.2.4"
 requires-python = ">=3.11"
 dependencies = []
 

--- a/testing/gui-e2e/tests/parser-warnings.spec.ts
+++ b/testing/gui-e2e/tests/parser-warnings.spec.ts
@@ -1,0 +1,295 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import {
+  API,
+  apiGet,
+  apiPost,
+  gotoShellRoute,
+  setupShellReadyWorkspace,
+} from "./helpers/shellReady";
+
+test.describe.configure({ mode: "serial" });
+setupShellReadyWorkspace(test);
+
+type WarningItem = {
+  message: string;
+  source?: string | null;
+  context?: string | null;
+};
+
+type RunNodeSummary = {
+  total: number;
+  completed: number;
+  running: number;
+  pending: number;
+  failed: number;
+};
+
+type RunListItem = {
+  id: string;
+  workflow_id: string;
+  workflow_name: string;
+  status: string;
+  total_cost_usd: number;
+  total_tokens: number;
+  created_at: number;
+  branch: string;
+  source: string;
+  commit_sha?: string | null;
+  run_number?: number | null;
+  eval_pass_pct?: number | null;
+  eval_score_avg?: number | null;
+  regression_count?: number | null;
+  warnings: WarningItem[];
+  node_summary?: RunNodeSummary | null;
+  [key: string]: unknown;
+};
+
+type RunListResponse = {
+  items: RunListItem[];
+  total: number;
+  offset: number;
+  limit: number;
+};
+
+type WorkflowResponse = {
+  id: string;
+  name?: string | null;
+};
+
+const CANVAS_STATE = {
+  nodes: [],
+  edges: [],
+  viewport: { x: 0, y: 0, zoom: 1 },
+  selected_node_id: null,
+  canvas_mode: "dag" as const,
+};
+
+let warningSoulId = "";
+let warningWorkflowId = "";
+let warningWorkflowName = "";
+let warningRunId = "";
+let warningRunListItem: RunListItem | null = null;
+
+function warningWorkflowYaml(soulId: string, workflowName: string) {
+  return `version: "1.0"
+config:
+  model_name: gpt-4o
+blocks:
+  analyze:
+    type: linear
+    soul_ref: ${soulId}
+workflow:
+  name: ${workflowName}
+  entry: analyze
+  transitions:
+    - from: analyze
+      to: null
+`;
+}
+
+async function safeDelete(apiPath: string) {
+  await fetch(`${API}${apiPath}`, { method: "DELETE" });
+}
+
+function rowForWorkflow(page: Page, workflowName: string) {
+  return page.locator("tbody tr").filter({ hasText: workflowName }).first();
+}
+
+test.describe("RUN-845 parser warnings browser flows", () => {
+  test.beforeAll(async () => {
+    const suffix = Date.now().toString(36);
+    warningSoulId = `run845-warning-soul-${suffix}`;
+    warningWorkflowName = `RUN-845 warning flow ${suffix}`;
+
+    await apiPost("/souls", {
+      id: warningSoulId,
+      role: "RUN-845 Warning Soul",
+      system_prompt: "Parser warning soul for e2e coverage.",
+      tools: ["http"],
+      provider: "openai",
+      model_name: "gpt-4.1-mini",
+    });
+
+    const workflow = await apiPost<WorkflowResponse>("/workflows", {
+      name: warningWorkflowName,
+      yaml: warningWorkflowYaml(warningSoulId, warningWorkflowName),
+      canvas_state: CANVAS_STATE,
+      commit: false,
+    });
+    warningWorkflowId = workflow.id;
+
+    const createdRun = await apiPost<{ id: string; warnings: WarningItem[] }>("/runs", {
+      workflow_id: warningWorkflowId,
+      task_data: {},
+    });
+    warningRunId = createdRun.id;
+
+    await expect
+      .poll(async () => {
+        const runs = await apiGet<RunListResponse>("/runs");
+        const item = runs.items.find((run) => run.id === warningRunId);
+        return item?.warnings?.length ?? 0;
+      })
+      .toBeGreaterThan(0);
+
+    const runs = await apiGet<RunListResponse>("/runs");
+    warningRunListItem = runs.items.find((run) => run.id === warningRunId) ?? null;
+  });
+
+  test.afterAll(async () => {
+    if (warningWorkflowId) {
+      await safeDelete(`/workflows/${warningWorkflowId}?force=true`);
+    }
+    if (warningSoulId) {
+      await safeDelete(`/souls/${warningSoulId}`);
+    }
+  });
+
+  test("runs page shows warning badge/tooltip, warnings column, and warning-only runs in Needs attention", async ({
+    page,
+  }) => {
+    await gotoShellRoute(page, "/runs");
+
+    await expect(page.getByRole("columnheader", { name: "Warnings" })).toBeVisible();
+
+    const warningRow = rowForWorkflow(page, warningWorkflowName);
+    await expect(warningRow).toBeVisible();
+
+    const warningBadge = warningRow.getByRole("status", { name: /warning/i });
+    await expect(warningBadge).toBeVisible();
+
+    await warningBadge.hover();
+    await expect(page.getByText("1 warning")).toBeVisible();
+    await expect(page.getByText(/undeclared tool/i)).toBeVisible();
+
+    await page.getByRole("button", { name: "Needs attention" }).click();
+    await expect(page).toHaveURL(/attention=only/);
+    await expect(warningRow).toBeVisible();
+    await expect(warningBadge).toBeVisible();
+
+    await expect(warningRow.locator("td").first()).not.toHaveClass(/before:bg-warning-9/);
+  });
+
+  test("run warning/regression badges keep regression-only behavior and render both badges together", async ({
+    page,
+  }) => {
+    const runs = await apiGet<RunListResponse>("/runs");
+    const template = warningRunListItem ?? runs.items[0];
+    if (!template) {
+      throw new Error("RUN-845 setup failed: no run template available");
+    }
+
+    const warningOnlyRun: RunListItem = {
+      ...template,
+      id: "run845-warning-only",
+      workflow_id: "wf_run845_warning_only",
+      workflow_name: "RUN-845 warning-only",
+      regression_count: 0,
+      warnings: warningRunListItem?.warnings?.length
+        ? warningRunListItem.warnings
+        : [
+            {
+              message: "Injected warning-only row",
+              source: "tool_governance",
+              context: "warning_only",
+            },
+          ],
+      run_number: 8451,
+    };
+
+    const regressionOnlyRun: RunListItem = {
+      ...template,
+      id: "run845-regression-only",
+      workflow_id: "wf_run845_regression_only",
+      workflow_name: "RUN-845 regression-only",
+      regression_count: 4,
+      warnings: [],
+      run_number: 8452,
+    };
+
+    const bothBadgesRun: RunListItem = {
+      ...template,
+      id: "run845-both-badges",
+      workflow_id: "wf_run845_both_badges",
+      workflow_name: "RUN-845 both-badges",
+      regression_count: 2,
+      warnings: [
+        {
+          message: "Injected warning for both-badges row",
+          source: "tool_definitions",
+          context: "lookup_profile",
+        },
+      ],
+      run_number: 8453,
+    };
+
+    await page.route("**/api/runs*", async (route) => {
+      const url = new URL(route.request().url());
+      if (url.pathname !== "/api/runs") {
+        await route.continue();
+        return;
+      }
+
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          items: [warningOnlyRun, regressionOnlyRun, bothBadgesRun],
+          total: 3,
+          offset: 0,
+          limit: 20,
+        }),
+      });
+    });
+
+    await page.route("**/api/runs/run845-regression-only/regressions", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ count: 4, issues: [{ type: "assertion_regression" }] }),
+      });
+    });
+
+    await page.route("**/api/runs/run845-both-badges/regressions", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ count: 2, issues: [{ type: "cost_spike" }] }),
+      });
+    });
+
+    await gotoShellRoute(page, "/runs");
+
+    const warningOnlyRow = rowForWorkflow(page, "RUN-845 warning-only");
+    await expect(warningOnlyRow).toBeVisible();
+    await expect(warningOnlyRow.getByRole("status", { name: /warning/i })).toBeVisible();
+    await expect(warningOnlyRow.locator("td").first()).not.toHaveClass(/before:bg-warning-9/);
+
+    const regressionOnlyRow = rowForWorkflow(page, "RUN-845 regression-only");
+    await expect(regressionOnlyRow).toBeVisible();
+    await expect(regressionOnlyRow.getByRole("status", { name: /warning/i })).toHaveCount(0);
+    await expect(regressionOnlyRow.locator('span[style*="--warning-11"]')).toBeVisible();
+    await expect(regressionOnlyRow.locator("td").first()).toHaveClass(/before:bg-warning-9/);
+
+    const bothBadgesRow = rowForWorkflow(page, "RUN-845 both-badges");
+    await expect(bothBadgesRow).toBeVisible();
+    await expect(bothBadgesRow.getByRole("status", { name: /warning/i })).toBeVisible();
+    await expect(bothBadgesRow.locator('span[style*="--warning-11"]')).toBeVisible();
+    await expect(bothBadgesRow.locator("td").first()).toHaveClass(/before:bg-warning-9/);
+  });
+
+  test("flows page WorkflowRow shows warning badge from live workflow warnings", async ({ page }) => {
+    await gotoShellRoute(page, "/flows");
+
+    const workflowRow = page.getByTestId(`workflow-row-${warningWorkflowId}`);
+    await expect(workflowRow).toBeVisible();
+
+    const warningBadge = workflowRow.getByRole("status", { name: /warning/i });
+    await expect(warningBadge).toBeVisible();
+
+    await warningBadge.hover();
+    await expect(page.getByText("1 warning")).toBeVisible();
+    await expect(page.getByText(/undeclared tool/i)).toBeVisible();
+  });
+});

--- a/tools/generate-zod-schemas.py
+++ b/tools/generate-zod-schemas.py
@@ -56,17 +56,16 @@ def generate_object_schema(schema: dict, schemas: dict) -> str:
             zod_type = f"{zod_type}.optional()"
         if "default" in prop:
             default_val = prop["default"]
-            if isinstance(default_val, bool):
-                zod_type = f"{zod_type}.default({str(default_val).lower()})"
-            elif isinstance(default_val, (int, float)):
-                zod_type = f"{zod_type}.default({default_val})"
-            elif isinstance(default_val, str):
-                zod_type = f'{zod_type}.default("{default_val}")'
-            elif default_val is None:
+            if default_val is None:
                 pass  # nullable already handled
+            else:
+                zod_type = f"{zod_type}.default({json.dumps(default_val)})"
         fields.append(f"  {name}: {zod_type},")
     body = "\n".join(fields)
-    return f"z.object({{\n{body}\n}})"
+    zod_expr = f"z.object({{\n{body}\n}})"
+    if schema.get("additionalProperties") is False:
+        zod_expr += ".strict()"
+    return zod_expr
 
 
 def schema_forbids_unknown_fields(schema: dict) -> bool:

--- a/tools/generate-zod-schemas.py
+++ b/tools/generate-zod-schemas.py
@@ -56,21 +56,20 @@ def generate_object_schema(schema: dict, schemas: dict) -> str:
             zod_type = f"{zod_type}.optional()"
         if "default" in prop:
             default_val = prop["default"]
-            if default_val is None:
-                pass  # nullable already handled
-            else:
+            if isinstance(default_val, bool):
+                zod_type = f"{zod_type}.default({str(default_val).lower()})"
+            elif isinstance(default_val, (int, float)):
+                zod_type = f"{zod_type}.default({default_val})"
+            elif isinstance(default_val, str):
                 zod_type = f"{zod_type}.default({json.dumps(default_val)})"
+            elif default_val is None:
+                pass  # nullable already handled
         fields.append(f"  {name}: {zod_type},")
     body = "\n".join(fields)
     zod_expr = f"z.object({{\n{body}\n}})"
     if schema.get("additionalProperties") is False:
         zod_expr += ".strict()"
     return zod_expr
-
-
-def schema_forbids_unknown_fields(schema: dict) -> bool:
-    """Return whether an OpenAPI object schema rejects additional properties."""
-    return schema.get("additionalProperties") is False
 
 
 def generate_zod_file(openapi_path: str, output_path: str) -> None:
@@ -115,8 +114,6 @@ def generate_zod_file(openapi_path: str, output_path: str) -> None:
     for name in sorted_names:
         schema = schemas[name]
         zod_expr = generate_object_schema(schema, schemas)
-        if schema_forbids_unknown_fields(schema):
-            zod_expr = f"{zod_expr}.strict()"
         lines.append(f"export const {name}Schema = {zod_expr};")
         lines.append(f"export type {name} = z.infer<typeof {name}Schema>;")
         lines.append("")

--- a/uv.lock
+++ b/uv.lock
@@ -2092,7 +2092,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "runsight-workspace"
-version = "0.2.3"
+version = "0.2.4"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- Implements RUN-759 parser warning flow across core, API, persistence, generated contracts, and GUI warning badges.
- Merges origin/main and preserves fail-closed run creation behavior while keeping warning snapshots wired.
- Bumps root workspace version to 0.2.4.

## Validation
- uv run --frozen ruff check apps/api/src/runsight_api/transport/routers/runs.py apps/api/src/runsight_api/transport/schemas/runs.py apps/api/src/runsight_api/main.py apps/api/tests/transport/test_runs_router.py apps/api/tests/transport/test_run772_fail_closed_run_creation.py apps/api/tests/logic/test_run772_stale_run_recovery.py apps/api/tests/test_run845_parser_warnings_e2e.py packages/core/src/runsight_core/yaml/parser.py
- uv run --frozen pytest packages/core/tests/test_run838_validation_result.py packages/core/tests/unit/test_run839_tool_governance_validation_result.py packages/core/tests/unit/test_parser_tool_validation.py packages/core/tests/test_run789_tool_scanner_callers.py packages/core/tests/test_run572_library_soul_tool_governance.py packages/core/tests/test_tool_integration.py apps/api/tests/domain/test_entity_extra_config.py apps/api/tests/unit/data/filesystem/test_run490_workflow_repo_tool_governance.py apps/api/tests/transport/test_run478_workflow_health_router.py apps/api/tests/transport/test_workflows_router.py apps/api/tests/test_run134_openapi_codegen.py packages/core/tests/test_run788_workflow_repo_soul_scanner.py apps/api/tests/domain/test_run379_data_model.py apps/api/tests/domain/test_run663_entity_fields.py apps/api/tests/logic/test_run607_nested_run_lifecycle.py apps/api/tests/transport/test_runs_router.py apps/api/tests/transport/test_run612_child_run_queries.py apps/api/tests/test_run845_parser_warnings_e2e.py apps/api/tests/transport/test_run772_fail_closed_run_creation.py apps/api/tests/logic/test_run772_stale_run_recovery.py apps/api/tests/test_stale_run_recovery.py (291 passed, 0 xfailed)
- pnpm --filter @runsight/shared exec vitest run src/__tests__/codegen.test.ts (47 passed)
- pnpm --filter runsight-gui exec vitest run --config vitest.unit.config.ts src/features/runs/__tests__/run843WarningBadges.test.tsx src/features/surface/__tests__/run844SurfaceWarningBadges.test.tsx src/features/workflows/__tests__/warningBadge.test.tsx src/features/flows/__tests__/workflowWarningBadgeContract.test.tsx (17 passed)
- pnpm exec eslint packages/shared/src/__tests__/codegen.test.ts apps/gui/vitest.setup.ts apps/gui/vitest.unit.config.ts apps/gui/src/features/runs/__tests__/run843WarningBadges.test.tsx apps/gui/src/features/surface/__tests__/run844SurfaceWarningBadges.test.tsx apps/gui/src/features/workflows/__tests__/warningBadge.test.tsx apps/gui/src/features/flows/__tests__/workflowWarningBadgeContract.test.tsx
- Blue Team: APPROVE
- Yellow Team: ALIGNED / APPROVE
