### PR TITLE
fix(RUN-867): preserve step-wrapped loop context

### DIFF
--- a/packages/core/src/runsight_core/block_io.py
+++ b/packages/core/src/runsight_core/block_io.py
@@ -258,11 +258,15 @@ def build_block_context(
     # LoopBlock strategy: detect inner_block_refs attribute
     inner_block_refs = getattr(block, "inner_block_refs", None)
     if inner_block_refs is not None:
+        loop_inputs = _resolve_declared_inputs(step, state)
+        resolved_inputs = state.shared_memory.get("_resolved_inputs", {})
+        if not loop_inputs and resolved_inputs:
+            loop_inputs = dict(resolved_inputs)
         return BlockContext(
             block_id=block.block_id,
             instruction="loop",
             context=None,
-            inputs={},
+            inputs=loop_inputs,
             conversation_history=[],
             soul=None,
             model_name=None,

--- a/packages/core/src/runsight_core/primitives.py
+++ b/packages/core/src/runsight_core/primitives.py
@@ -139,6 +139,35 @@ class Step:
         # is passed. No side-effects on shared_memory from Step.execute.
 
         ctx = build_block_context(self.block, state, step=self)
+        execution_context = kwargs.get("execution_context")
+        if execution_context is not None:
+            from runsight_core.blocks.loop import LoopBlock
+            from runsight_core.blocks.workflow_block import WorkflowBlock
+            from runsight_core.workflow import BlockExecutionContext
+
+            if isinstance(execution_context, BlockExecutionContext):
+                if isinstance(self.block, LoopBlock):
+                    ctx = ctx.model_copy(
+                        update={
+                            "inputs": {
+                                **ctx.inputs,
+                                "blocks": execution_context.blocks,
+                                "ctx": execution_context,
+                            }
+                        }
+                    )
+                elif isinstance(self.block, WorkflowBlock):
+                    ctx = ctx.model_copy(
+                        update={
+                            "inputs": {
+                                **ctx.inputs,
+                                "call_stack": execution_context.call_stack
+                                + [execution_context.workflow_name],
+                                "workflow_registry": execution_context.workflow_registry,
+                                "observer": execution_context.observer,
+                            }
+                        }
+                    )
         output = await self.block.execute(ctx)
         state = apply_block_output(state, self.block.block_id, output)
 

--- a/packages/core/src/runsight_core/workflow.py
+++ b/packages/core/src/runsight_core/workflow.py
@@ -130,7 +130,7 @@ async def execute_block(
 
         # Step wrapper: delegates to Step.execute which handles hooks + block dispatch
         if isinstance(blk, StepType):
-            return await blk.execute(current_state)
+            return await blk.execute(current_state, execution_context=ctx)
         if isinstance(blk, WorkflowBlock):
             wf_block_ctx = build_block_context(blk, current_state)
             wf_block_ctx = wf_block_ctx.model_copy(

--- a/packages/core/tests/conftest.py
+++ b/packages/core/tests/conftest.py
@@ -34,15 +34,12 @@ async def execute_block_for_test(block, state, *, inputs=None, step=None):
     adapter in tests lets production code stay on execute(ctx) -> BlockOutput.
     """
     from runsight_core.block_io import BlockOutput, apply_block_output, build_block_context
-    from runsight_core.state import WorkflowState
 
     ctx = build_block_context(block, state, step=step)
     if inputs:
         ctx = ctx.model_copy(update={"inputs": {**ctx.inputs, **inputs}})
 
     output = await block.execute(ctx)
-    if isinstance(output, WorkflowState):
-        return output
     if not isinstance(output, BlockOutput):
         raise TypeError(
             f"{type(block).__name__}.execute returned {type(output).__name__}; expected BlockOutput"

--- a/packages/core/tests/test_loop_block.py
+++ b/packages/core/tests/test_loop_block.py
@@ -743,6 +743,46 @@ class TestLoopBlockWorkflowIntegration:
         result_state = await wf.run(state)
         assert "inner_block" in result_state.results
 
+    @pytest.mark.asyncio
+    async def test_step_wrapped_loop_receives_workflow_infra_and_declared_inputs(self):
+        """A Step-wrapped LoopBlock must keep declared inputs and workflow runtime infra."""
+        from runsight_core import LoopBlock
+        from runsight_core.primitives import Step
+        from runsight_core.state import BlockResult
+
+        class CapturingLoopBlock(LoopBlock):
+            def __init__(self):
+                super().__init__(
+                    block_id="loop_block",
+                    inner_block_refs=["inner_block"],
+                    max_rounds=1,
+                )
+                self.received_inputs = None
+
+            async def execute(self, ctx):
+                self.received_inputs = dict(ctx.inputs)
+                return await super().execute(ctx)
+
+        inner = TrackingBlock("inner_block")
+        loop = CapturingLoopBlock()
+        step = Step(block=loop, declared_inputs={"data": "source"})
+
+        wf = Workflow(name="step_wrapped_loop_wf")
+        wf.add_block(inner)
+        wf.add_block(step)
+        wf.add_transition("loop_block", None)
+        wf.set_entry("loop_block")
+
+        state = WorkflowState(results={"source": BlockResult(output="declared value")})
+        result_state = await wf.run(state)
+
+        assert loop.received_inputs is not None
+        assert loop.received_inputs["data"] == "declared value"
+        assert "blocks" in loop.received_inputs
+        assert "ctx" in loop.received_inputs
+        calls = result_state.shared_memory.get("inner_block_calls", [])
+        assert len(calls) == 1
+
 
 # ===========================================================================
 # 5. Integration tests — writer + critic pattern

--- a/packages/core/tests/test_run884_build_block_context.py
+++ b/packages/core/tests/test_run884_build_block_context.py
@@ -462,7 +462,7 @@ class TestFitToBudgetIntegration:
         call_args = mock_fit.call_args
         request = call_args[0][0]
         # No workflow result in state, so context defaults to ""
-        assert request.context == "" or request.context is None
+        assert request.context == ""
 
     def test_fit_to_budget_receives_conversation_history(self):
         """fit_to_budget is called with conversation history keyed by block_id_soul_id."""
@@ -620,4 +620,4 @@ class TestEdgeCases:
         call_args = mock_fit.call_args
         request = call_args[0][0]
         # Should be "" not None — mirrors LinearBlock.execute behaviour
-        assert request.context == "" or request.context is None
+        assert request.context == ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runsight-workspace"
-version = "0.4.1"
+version = "0.4.2"
 requires-python = ">=3.11"
 dependencies = []
 

--- a/uv.lock
+++ b/uv.lock
@@ -2088,7 +2088,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "runsight-workspace"
-version = "0.4.1"
+version = "0.4.2"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- preserve declared inputs and workflow runtime infra when a Step wraps a LoopBlock
- reject legacy WorkflowState returns in the shared test helper
- tighten budget context assertions to require empty-string normalization
- bump root workspace version to 0.4.2

## Validation
- uv run pytest packages/core/tests/test_loop_block.py::TestLoopBlockWorkflowIntegration::test_step_wrapped_loop_receives_workflow_infra_and_declared_inputs packages/core/tests/test_run884_build_block_context.py::TestFitToBudgetIntegration::test_fit_to_budget_receives_correct_context packages/core/tests/test_run884_build_block_context.py::TestEdgeCases::test_task_context_none_passes_empty_string_to_budget -q
- uv run pytest apps/api/tests/test_run706_api_e2e.py packages/core/tests/test_budget_migration_remaining.py packages/core/tests/test_budget_wiring.py packages/core/tests/test_carry_context_blockresult.py packages/core/tests/test_code_block.py packages/core/tests/test_codeblock_sandbox_hardening.py packages/core/tests/test_dispatch_synthesize_integration.py packages/core/tests/test_dispatch_v2.py packages/core/tests/test_gate_file_writer_blocks.py packages/core/tests/test_integration_blocks_workflow.py packages/core/tests/test_integration_merge_validation.py packages/core/tests/test_integration_workflow_block.py packages/core/tests/test_integration_workflow_block_backward_compat.py packages/core/tests/test_integration_workflow_block_with_other_blocks.py packages/core/tests/test_loop_block.py packages/core/tests/test_loopblock_kwargs_forwarding.py packages/core/tests/test_remove_placeholder_block.py packages/core/tests/test_run137_async_subprocess.py packages/core/tests/test_run170_complex_read_sites.py packages/core/tests/test_run604_interface_execution.py packages/core/tests/test_run606_runtime_depth_parity.py packages/core/tests/test_run614_integration_subworkflow.py packages/core/tests/test_run663_child_observer_wrapper.py packages/core/tests/test_run670_error_route_runtime.py packages/core/tests/test_run676_execute_block_extraction.py packages/core/tests/test_run681_linearblock_exit_conditions.py packages/core/tests/test_run682_workflowblock_loopblock_e2e.py packages/core/tests/test_run701_state_isolation_verification.py packages/core/tests/test_run872_gate_execute.py packages/core/tests/test_run873_synthesize_execute.py packages/core/tests/test_run874_dispatch_execute.py packages/core/tests/test_run876_loop_no_current_task.py packages/core/tests/test_run884_build_block_context.py packages/core/tests/test_run892_step_consolidation.py packages/core/tests/test_workflow_defensive_observer.py packages/core/tests/test_workflow_output_conditions.py packages/core/tests/unit/test_exit_ports_integration.py packages/core/tests/unit/test_gate_exit_handle.py packages/core/tests/unit/test_loop_exit_handle.py packages/core/tests/unit/test_resolve_next_exit_handle.py -q
- uv run pytest packages/core/tests/test_cross_feature_integration.py -q
- uv run ruff check packages/core/src/runsight_core/block_io.py packages/core/src/runsight_core/primitives.py packages/core/src/runsight_core/workflow.py packages/core/tests/conftest.py packages/core/tests/test_run884_build_block_context.py packages/core/tests/test_loop_block.py
- git diff --check