### PR TITLE
fix(RUN-867): forward loop step inputs to inner blocks

### DIFF
--- a/packages/core/src/runsight_core/blocks/loop.py
+++ b/packages/core/src/runsight_core/blocks/loop.py
@@ -198,13 +198,9 @@ class LoopBlock(BaseBlock):
                         f"not found in blocks dict. "
                         f"Available blocks: {sorted(blocks.keys())}"
                     )
-                # Use module-level execute_block so tests can patch it.
-                # Pass parent_inputs as extra_inputs only when there's no
-                # BlockExecutionContext — in that case workflow.execute_block handles
-                # the full dispatch and extra_inputs is not needed.
-                from runsight_core.workflow import BlockExecutionContext as _BEC
-
-                if not isinstance(ctx, _BEC) and parent_inputs:
+                # Use module-level execute_block so tests can patch it, and keep
+                # outer loop inputs visible to inner blocks on every dispatch path.
+                if parent_inputs:
                     state = await execute_block(inner_block, state, ctx, extra_inputs=parent_inputs)
                 else:
                     state = await execute_block(inner_block, state, ctx)
@@ -312,7 +308,7 @@ async def execute_block(
     from runsight_core.workflow import execute_block as workflow_execute_block
 
     if isinstance(ctx, BlockExecutionContext):
-        return await workflow_execute_block(block, state, ctx)
+        return await workflow_execute_block(block, state, ctx, extra_inputs=extra_inputs)
 
     # ctx is None: build a BlockContext and dispatch directly
     block_ctx = build_block_context(block, state)

--- a/packages/core/src/runsight_core/primitives.py
+++ b/packages/core/src/runsight_core/primitives.py
@@ -139,6 +139,9 @@ class Step:
         # is passed. No side-effects on shared_memory from Step.execute.
 
         ctx = build_block_context(self.block, state, step=self)
+        extra_inputs = kwargs.get("extra_inputs")
+        if extra_inputs:
+            ctx = ctx.model_copy(update={"inputs": {**extra_inputs, **ctx.inputs}})
         execution_context = kwargs.get("execution_context")
         if execution_context is not None:
             from runsight_core.blocks.loop import LoopBlock

--- a/packages/core/src/runsight_core/workflow.py
+++ b/packages/core/src/runsight_core/workflow.py
@@ -101,6 +101,7 @@ async def execute_block(
     block: BaseBlock,
     state: WorkflowState,
     ctx: BlockExecutionContext,
+    extra_inputs: Optional[Dict[str, Any]] = None,
 ) -> WorkflowState:
     """Execute a workflow block with observer notifications and retry behavior."""
     from runsight_core.blocks.loop import LoopBlock
@@ -130,12 +131,17 @@ async def execute_block(
 
         # Step wrapper: delegates to Step.execute which handles hooks + block dispatch
         if isinstance(blk, StepType):
-            return await blk.execute(current_state, execution_context=ctx)
+            return await blk.execute(
+                current_state,
+                execution_context=ctx,
+                extra_inputs=extra_inputs,
+            )
         if isinstance(blk, WorkflowBlock):
             wf_block_ctx = build_block_context(blk, current_state)
             wf_block_ctx = wf_block_ctx.model_copy(
                 update={
                     "inputs": {
+                        **(extra_inputs or {}),
                         "call_stack": ctx.call_stack + [ctx.workflow_name],
                         "workflow_registry": ctx.workflow_registry,
                         "observer": observer,
@@ -149,6 +155,8 @@ async def execute_block(
             loop_ctx = loop_ctx.model_copy(
                 update={
                     "inputs": {
+                        **(extra_inputs or {}),
+                        **loop_ctx.inputs,
                         "blocks": ctx.blocks,
                         "ctx": ctx,
                     }
@@ -159,6 +167,10 @@ async def execute_block(
         # All other blocks: build BlockContext and dispatch via new signature
 
         block_ctx = build_block_context(blk, current_state, step=None)
+        if extra_inputs:
+            block_ctx = block_ctx.model_copy(
+                update={"inputs": {**extra_inputs, **block_ctx.inputs}}
+            )
         output = await blk.execute(block_ctx)
         return apply_block_output(current_state, blk.block_id, output)
 

--- a/packages/core/tests/test_loop_block.py
+++ b/packages/core/tests/test_loop_block.py
@@ -763,7 +763,23 @@ class TestLoopBlockWorkflowIntegration:
                 self.received_inputs = dict(ctx.inputs)
                 return await super().execute(ctx)
 
-        inner = TrackingBlock("inner_block")
+        class CapturingInnerBlock(BaseBlock):
+            def __init__(self):
+                super().__init__(block_id="inner_block")
+                self.received_inputs = None
+
+            async def execute(self, ctx):
+                from runsight_core.block_io import BlockOutput
+
+                self.received_inputs = dict(ctx.inputs)
+                calls = list(ctx.state_snapshot.shared_memory.get("inner_block_calls", []))
+                calls.append(len(calls) + 1)
+                return BlockOutput(
+                    output="inner",
+                    shared_memory_updates={"inner_block_calls": calls},
+                )
+
+        inner = CapturingInnerBlock()
         loop = CapturingLoopBlock()
         step = Step(block=loop, declared_inputs={"data": "source"})
 
@@ -780,6 +796,8 @@ class TestLoopBlockWorkflowIntegration:
         assert loop.received_inputs["data"] == "declared value"
         assert "blocks" in loop.received_inputs
         assert "ctx" in loop.received_inputs
+        assert inner.received_inputs is not None
+        assert inner.received_inputs["data"] == "declared value"
         calls = result_state.shared_memory.get("inner_block_calls", [])
         assert len(calls) == 1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runsight-workspace"
-version = "0.4.2"
+version = "0.4.3"
 requires-python = ">=3.11"
 dependencies = []
 

--- a/uv.lock
+++ b/uv.lock
@@ -2088,7 +2088,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "runsight-workspace"
-version = "0.4.2"
+version = "0.4.3"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- forward outer loop Step inputs through workflow dispatch into inner blocks
- preserve declared-input precedence over inherited loop inputs
- prove the Step-wrapped LoopBlock path gives both the loop and inner block the declared input
- bump root workspace version to 0.4.3

## Validation
- uv run pytest packages/core/tests/test_loop_block.py::TestLoopBlockWorkflowIntegration::test_step_wrapped_loop_receives_workflow_infra_and_declared_inputs -q
- uv run pytest packages/core/tests/test_loop_block.py packages/core/tests/test_loopblock_kwargs_forwarding.py packages/core/tests/test_parser_inputs_outputs.py packages/core/tests/test_run892_step_consolidation.py packages/core/tests/test_run884_build_block_context.py packages/core/tests/test_cross_feature_integration.py -q
- uv run ruff check packages/core/src/runsight_core/blocks/loop.py packages/core/src/runsight_core/primitives.py packages/core/src/runsight_core/workflow.py packages/core/tests/test_loop_block.py
- git diff --check