### PR TITLE
docs: add cubic attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![python](https://img.shields.io/badge/python-3.11+-blue)](https://www.python.org)
 [![docs](https://img.shields.io/badge/docs-runsight.ai-orange)](https://runsight.ai/docs)
 [![GitHub stars](https://img.shields.io/github/stars/runsight-ai/runsight)](https://github.com/runsight-ai/runsight)
+[![Powered by cubic.dev](https://img.shields.io/badge/powered%20by-cubic.dev-111111)](https://www.cubic.dev/)
 
 <p align="center">
   <img src="assets/demo.gif" alt="Runsight — visual workflow builder for AI agents" width="640">

--- a/apps/site/public/brands/cubic-mark.svg
+++ b/apps/site/public/brands/cubic-mark.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 80 80" fill="none">
+  <rect width="80" height="80" fill="#060707" rx="20"/>
+  <rect width="49.021" height="49.021" x="15.969" y="15.729" fill="#fff" rx="8.17"/>
+</svg>

--- a/apps/site/src/pages/index.astro
+++ b/apps/site/src/pages/index.astro
@@ -79,6 +79,10 @@
               <a href="#get-started" class="btn-install btn-lg"><span class="prompt">$</span> uvx runsight</a>
               <a href="https://github.com/runsight-ai/runsight" class="btn-ghost">View on GitHub</a>
             </div>
+            <a href="https://www.cubic.dev/" class="hero__powered" rel="noopener noreferrer">
+              <img src="/brands/cubic-mark.svg" alt="" width="16" height="16" loading="lazy">
+              <span>Powered by <strong>cubic.dev</strong></span>
+            </a>
           </div>
 
           <!-- Hero visual: Canvas ↔ YAML duality -->
@@ -459,6 +463,7 @@
       </div>
       <div class="footer__bottom">
         <span>&copy; 2026 Runsight. Apache 2.0 License.</span>
+        <a href="https://www.cubic.dev/" class="footer__powered" rel="noopener noreferrer">Powered by cubic.dev</a>
       </div>
     </div>
   </footer>
@@ -771,6 +776,24 @@
   }
   .hero__headline em { font-style: normal; color: var(--color-accent-text); }
   .hero__sub { font-size: var(--text-lg); color: var(--color-text-body); line-height: 1.6; max-width: 480px; }
+  .hero__powered {
+    display: inline-flex; align-items: center; gap: var(--space-2);
+    margin-top: var(--space-4);
+    font-size: var(--text-xs); font-weight: 500; line-height: 1;
+    color: var(--color-text-muted);
+    transition: color var(--duration-fast) var(--ease-out);
+  }
+  .hero__powered img {
+    width: 16px; height: 16px; border-radius: 4px;
+    border: 1px solid var(--color-border);
+    opacity: 0.9;
+  }
+  .hero__powered strong {
+    color: var(--color-text-body); font-weight: 600;
+    transition: color var(--duration-fast) var(--ease-out);
+  }
+  .hero__powered:hover,
+  .hero__powered:hover strong { color: var(--color-text-heading); }
   .hero__actions { display: flex; align-items: center; gap: var(--space-3); margin-top: var(--space-6); flex-wrap: wrap; }
   .hero__visual { position: relative; }
   .hero__scroll-cue {
@@ -940,6 +963,11 @@
     border-top: 1px solid var(--color-border-subtle);
     font-size: var(--text-xs); color: var(--color-text-muted);
   }
+  .footer__powered {
+    color: var(--color-text-muted);
+    transition: color var(--duration-fast) var(--ease-out);
+  }
+  .footer__powered:hover { color: var(--color-text-heading); }
 
   /* ═══ SCROLL REVEALS ═══ */
   [data-reveal], [data-reveal-stagger] { opacity: 0; transform: translateY(16px); transition: opacity var(--duration-reveal) var(--ease-out), transform var(--duration-reveal) var(--ease-out); will-change: opacity, transform; }
@@ -1053,6 +1081,7 @@
   @media (max-width: 64em) {
     .hero__grid { grid-template-columns: 1fr; gap: var(--space-8); }
     .hero__text { text-align: center; }
+    .hero__powered { justify-content: center; }
     .hero__sub { margin-left: auto; margin-right: auto; }
     .hero__actions { justify-content: center; }
     .hero { min-height: auto; padding-top: calc(var(--nav-height) + var(--space-10)); }


### PR DESCRIPTION
## Summary
- add a cubic.dev badge to the README badge row
- add Powered by cubic.dev attribution to the landing page hero and footer
- vendor the small cubic mark for the site attribution

## Checks
- git merge main: already up to date
- pnpm --filter @runsight/site build
- git show --check --stat --oneline HEAD
- blue review: passed
- yellow review: passed

Version not bumped per request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add cubic.dev attribution across the README and site. Adds a README badge, a “Powered by cubic.dev” link in the hero, a footer link, and vendors the `cubic-mark.svg` asset.

<sup>Written for commit 1079a5f93614134a30e4f64b5bf231c7c1d9315e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

