### PR TITLE
feat(site): public site discoverability baseline

### DIFF
--- a/apps/site/astro.config.mjs
+++ b/apps/site/astro.config.mjs
@@ -2,22 +2,32 @@
 import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
 import starlightLlmsTxt from 'starlight-llms-txt';
+import { siteIdentity, withSiteUrl } from './src/config/site.mjs';
 
 // https://astro.build/config
 export default defineConfig({
-	site: 'https://runsight.ai',
+	site: siteIdentity.siteUrl,
 	integrations: [
 		starlight({
-			title: 'Runsight',
+			title: siteIdentity.name,
 			logo: {
 				src: './src/assets/logo.svg',
 			},
-			description: 'YAML-first workflow engine for AI agents.',
+			description: siteIdentity.docsDescription,
 			social: [
 				{
 					icon: 'github',
 					label: 'GitHub',
-					href: 'https://github.com/runsight-ai/runsight',
+					href: siteIdentity.links.github,
+				},
+			],
+			head: [
+				{
+					tag: 'link',
+					attrs: {
+						rel: 'sitemap',
+						href: '/sitemap.xml',
+					},
 				},
 			],
 			editLink: {
@@ -120,7 +130,33 @@ export default defineConfig({
 			],
 			customCss: ['./src/styles/custom.css'],
 			plugins: [
-				starlightLlmsTxt(),
+				starlightLlmsTxt({
+					projectName: siteIdentity.name,
+					description: siteIdentity.llms.summary,
+					details: siteIdentity.llms.details,
+					optionalLinks: [
+						{
+							label: 'Homepage',
+							url: withSiteUrl(siteIdentity.links.homepage),
+							description: 'Product overview and positioning',
+						},
+						{
+							label: 'Documentation',
+							url: withSiteUrl(siteIdentity.links.docs),
+							description: 'Complete product documentation',
+						},
+						{
+							label: 'Quickstart',
+							url: withSiteUrl(siteIdentity.links.quickstart),
+							description: 'Fastest path to install and run Runsight',
+						},
+						{
+							label: 'GitHub',
+							url: siteIdentity.links.github,
+							description: 'Source code, issues, and contribution context',
+						},
+					],
+				}),
 			],
 		}),
 	],

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -5,7 +5,9 @@
   "private": true,
   "scripts": {
     "dev": "astro dev",
-    "build": "astro build",
+    "build": "astro build && node ../../tools/site/postbuild-discoverability.mjs && node ../../tools/site/check-discoverability.mjs dist",
+    "check:discoverability:dist": "node ../../tools/site/check-discoverability.mjs dist",
+    "check:discoverability:live": "node ../../tools/site/check-discoverability.mjs live https://runsight.ai",
     "preview": "astro preview"
   },
   "dependencies": {

--- a/apps/site/public/robots.txt
+++ b/apps/site/public/robots.txt
@@ -1,0 +1,10 @@
+User-agent: *
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: GPTBot
+Disallow: /
+
+Sitemap: https://runsight.ai/sitemap.xml

--- a/apps/site/public/social/runsight-preview.svg
+++ b/apps/site/public/social/runsight-preview.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+  <title id="title">Runsight social preview</title>
+  <desc id="desc">Runsight is a YAML-first workflow engine for AI agents.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#111827" />
+      <stop offset="100%" stop-color="#0F172A" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <rect x="48" y="48" width="1104" height="534" rx="32" fill="#0B1220" stroke="#334155" stroke-width="2" />
+  <rect x="84" y="84" width="132" height="132" rx="28" fill="#F59E0B" />
+  <circle cx="150" cy="118" r="16" fill="#FFFFFF" />
+  <circle cx="116" cy="184" r="16" fill="#FFFFFF" opacity="0.8" />
+  <circle cx="184" cy="184" r="16" fill="#FFFFFF" opacity="0.8" />
+  <circle cx="150" cy="158" r="10" fill="#FFFFFF" opacity="0.6" />
+  <line x1="150" y1="134" x2="150" y2="148" stroke="#FFFFFF" stroke-width="8" stroke-linecap="round" />
+  <line x1="141" y1="168" x2="123" y2="175" stroke="#FFFFFF" stroke-width="8" stroke-linecap="round" opacity="0.7" />
+  <line x1="159" y1="168" x2="177" y2="175" stroke="#FFFFFF" stroke-width="8" stroke-linecap="round" opacity="0.7" />
+  <text x="84" y="310" fill="#F8FAFC" font-family="Satoshi, Inter, Arial, sans-serif" font-size="76" font-weight="700">Runsight</text>
+  <text x="84" y="386" fill="#F8FAFC" font-family="Satoshi, Inter, Arial, sans-serif" font-size="36" font-weight="500">YAML-first workflow engine for AI agents</text>
+  <text x="84" y="452" fill="#CBD5E1" font-family="Satoshi, Inter, Arial, sans-serif" font-size="28" font-weight="400">Git-native workflows • local-first control • built-in evals</text>
+  <rect x="84" y="498" width="312" height="52" rx="26" fill="#172033" stroke="#334155" />
+  <text x="112" y="532" fill="#F59E0B" font-family="JetBrains Mono, Menlo, monospace" font-size="24" font-weight="700">uvx runsight</text>
+  <text x="882" y="536" fill="#94A3B8" font-family="JetBrains Mono, Menlo, monospace" font-size="20" text-anchor="end">runsight.ai/docs</text>
+</svg>

--- a/apps/site/src/config/site.mjs
+++ b/apps/site/src/config/site.mjs
@@ -1,0 +1,35 @@
+export const siteIdentity = {
+	name: 'Runsight',
+	siteUrl: 'https://runsight.ai',
+	locale: 'en_US',
+	tagline: 'YAML-first workflow engine for AI agents',
+	homepageTitle: 'Runsight — YAML-first workflow engine for AI agents',
+	homepageDescription:
+		'Design agent workflows in YAML. Commit to Git. Track cost per run. Evaluate with built-in assertions. Open source, self-hosted.',
+	docsDescription: 'YAML-first workflow engine for AI agents.',
+	socialImagePath: '/social/runsight-preview.svg',
+	socialImageAlt:
+		'Runsight social preview card with the tagline YAML-first workflow engine for AI agents.',
+	links: {
+		homepage: '/',
+		docs: '/docs/',
+		quickstart: '/docs/getting-started/quickstart/',
+		github: 'https://github.com/runsight-ai/runsight',
+	},
+	llms: {
+		summary:
+			'Runsight is an open source, Git-native workflow engine for AI agents. It helps engineers design workflows in YAML, commit them to Git, track cost per run, and evaluate behavior with built-in assertions.',
+		details: `Runsight is for engineers who want readable workflow files, local-first control, and a practical way to design, run, and observe AI workflows.
+
+Start here:
+- [Homepage](https://runsight.ai/): product overview, positioning, and high-level capabilities.
+- [Documentation](https://runsight.ai/docs/): complete product docs.
+- [Quickstart](https://runsight.ai/docs/getting-started/quickstart/): fastest path to install and run Runsight.
+
+Use the documentation sets below when an implementation task needs more detail than the homepage summary.`,
+	},
+};
+
+export function withSiteUrl(pathname = '/') {
+	return new URL(pathname, siteIdentity.siteUrl).toString();
+}

--- a/apps/site/src/pages/index.astro
+++ b/apps/site/src/pages/index.astro
@@ -1,6 +1,42 @@
 ---
 // Landing page — outside Starlight, standalone layout
 // Design tokens from /observatory/marketing-design-system/
+import { siteIdentity, withSiteUrl } from "../config/site.mjs";
+
+const canonicalUrl = withSiteUrl(siteIdentity.links.homepage);
+const socialImageUrl = withSiteUrl(siteIdentity.socialImagePath);
+const structuredData = JSON.stringify([
+  {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    name: siteIdentity.name,
+    url: siteIdentity.siteUrl,
+    logo: withSiteUrl("/favicon.svg"),
+    sameAs: [siteIdentity.links.github],
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    name: siteIdentity.name,
+    url: siteIdentity.siteUrl,
+    description: siteIdentity.homepageDescription,
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    name: siteIdentity.name,
+    applicationCategory: "DeveloperApplication",
+    operatingSystem: "macOS, Linux, Windows",
+    url: siteIdentity.siteUrl,
+    description: siteIdentity.homepageDescription,
+    image: socialImageUrl,
+    sourceOrganization: {
+      "@type": "Organization",
+      name: siteIdentity.name,
+      url: siteIdentity.siteUrl,
+    },
+  },
+]);
 ---
 
 <!DOCTYPE html>
@@ -8,10 +44,27 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Runsight — YAML-first workflow engine for AI agents</title>
-  <meta name="description" content="Design agent workflows in YAML. Commit to Git. Track cost per run. Evaluate with built-in assertions. Open source, self-hosted.">
+  <title>{siteIdentity.homepageTitle}</title>
+  <meta name="description" content={siteIdentity.homepageDescription}>
+  <meta name="robots" content="index,follow,max-image-preview:large">
+  <link rel="canonical" href={canonicalUrl}>
+  <link rel="sitemap" href="/sitemap.xml">
+  <meta property="og:title" content={siteIdentity.homepageTitle}>
+  <meta property="og:description" content={siteIdentity.homepageDescription}>
+  <meta property="og:type" content="website">
+  <meta property="og:url" content={canonicalUrl}>
+  <meta property="og:site_name" content={siteIdentity.name}>
+  <meta property="og:locale" content={siteIdentity.locale}>
+  <meta property="og:image" content={socialImageUrl}>
+  <meta property="og:image:alt" content={siteIdentity.socialImageAlt}>
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content={siteIdentity.homepageTitle}>
+  <meta name="twitter:description" content={siteIdentity.homepageDescription}>
+  <meta name="twitter:image" content={socialImageUrl}>
+  <meta name="twitter:image:alt" content={siteIdentity.socialImageAlt}>
 
   <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+  <script type="application/ld+json" set:html={structuredData}></script>
 
   <!-- Fonts: Satoshi (marketing) + JetBrains Mono (code) -->
   <link rel="preconnect" href="https://api.fontshare.com" crossorigin>

--- a/tools/site/check-discoverability.mjs
+++ b/tools/site/check-discoverability.mjs
@@ -1,0 +1,121 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+
+const [mode, target] = process.argv.slice(2);
+
+function assert(condition, message) {
+	if (!condition) {
+		throw new Error(message);
+	}
+}
+
+function expectIncludes(haystack, needle, label) {
+	assert(haystack.includes(needle), `${label} is missing "${needle}"`);
+}
+
+function expectContentType(contentType, expected, label) {
+	assert(contentType?.includes(expected), `${label} should have content type including "${expected}"`);
+}
+
+async function readDistFile(relativePath) {
+	const distDir = path.join(process.cwd(), "dist");
+	return readFile(path.join(distDir, relativePath), "utf8");
+}
+
+async function fetchText(baseUrl, relativePath) {
+	const response = await fetch(new URL(relativePath, baseUrl));
+	const text = await response.text();
+	return { response, text };
+}
+
+async function checkRenderedOutput() {
+	const robots = await readDistFile("robots.txt");
+	const sitemap = await readDistFile("sitemap.xml");
+	const sitemapShard = await readDistFile("sitemap-0.xml");
+	const llms = await readDistFile("llms.txt");
+	const llmsSmall = await readDistFile("llms-small.txt");
+	const llmsFull = await readDistFile("llms-full.txt");
+	const home = await readDistFile("index.html");
+	const docsHome = await readDistFile("docs/index.html");
+
+	expectIncludes(robots, "User-agent: OAI-SearchBot", "robots.txt");
+	expectIncludes(robots, "User-agent: GPTBot", "robots.txt");
+	expectIncludes(robots, "Sitemap: https://runsight.ai/sitemap.xml", "robots.txt");
+
+	expectIncludes(sitemap, "https://runsight.ai/sitemap-0.xml", "sitemap.xml");
+	expectIncludes(sitemapShard, "https://runsight.ai/", "sitemap-0.xml");
+	expectIncludes(sitemapShard, "https://runsight.ai/docs/", "sitemap-0.xml");
+
+	expectIncludes(llms, "[Homepage](https://runsight.ai/)", "llms.txt");
+	expectIncludes(llms, "[Documentation](https://runsight.ai/docs/)", "llms.txt");
+	expectIncludes(llms, "https://runsight.ai/llms-small.txt", "llms.txt");
+	expectIncludes(llms, "https://runsight.ai/llms-full.txt", "llms.txt");
+	expectIncludes(llmsSmall, "<SYSTEM>This is the abridged developer documentation for Runsight</SYSTEM>", "llms-small.txt");
+	expectIncludes(llmsFull, "<SYSTEM>This is the full developer documentation for Runsight</SYSTEM>", "llms-full.txt");
+
+	expectIncludes(home, 'rel="canonical" href="https://runsight.ai/"', "index.html");
+	expectIncludes(home, 'rel="sitemap" href="/sitemap.xml"', "index.html");
+	expectIncludes(home, 'property="og:title"', "index.html");
+	expectIncludes(home, 'name="twitter:card"', "index.html");
+	expectIncludes(home, 'type="application/ld+json"', "index.html");
+	expectIncludes(home, "https://runsight.ai/social/runsight-preview.svg", "index.html");
+	expectIncludes(docsHome, 'rel="sitemap" href="/sitemap.xml"', "docs/index.html");
+
+	console.log("Rendered discoverability checks passed.");
+}
+
+async function checkLiveSite(baseUrl) {
+	assert(baseUrl, 'Live checks require a base URL, e.g. "https://runsight.ai".');
+
+	const robots = await fetchText(baseUrl, "/robots.txt");
+	assert(robots.response.ok, `/robots.txt should return 200, got ${robots.response.status}`);
+	expectContentType(robots.response.headers.get("content-type"), "text/plain", "/robots.txt");
+	expectIncludes(robots.text, "Sitemap: https://runsight.ai/sitemap.xml", "/robots.txt");
+
+	const sitemap = await fetchText(baseUrl, "/sitemap.xml");
+	assert(sitemap.response.ok, `/sitemap.xml should return 200, got ${sitemap.response.status}`);
+	expectContentType(sitemap.response.headers.get("content-type"), "xml", "/sitemap.xml");
+	expectIncludes(sitemap.text, "https://runsight.ai/sitemap-0.xml", "/sitemap.xml");
+
+	const sitemapShard = await fetchText(baseUrl, "/sitemap-0.xml");
+	assert(sitemapShard.response.ok, `/sitemap-0.xml should return 200, got ${sitemapShard.response.status}`);
+	expectContentType(sitemapShard.response.headers.get("content-type"), "xml", "/sitemap-0.xml");
+	expectIncludes(sitemapShard.text, "https://runsight.ai/", "/sitemap-0.xml");
+	expectIncludes(sitemapShard.text, "https://runsight.ai/docs/", "/sitemap-0.xml");
+
+	const llms = await fetchText(baseUrl, "/llms.txt");
+	assert(llms.response.ok, `/llms.txt should return 200, got ${llms.response.status}`);
+	expectContentType(llms.response.headers.get("content-type"), "text/plain", "/llms.txt");
+	expectIncludes(llms.text, "[Homepage](https://runsight.ai/)", "/llms.txt");
+	expectIncludes(llms.text, "https://runsight.ai/llms-small.txt", "/llms.txt");
+	expectIncludes(llms.text, "https://runsight.ai/llms-full.txt", "/llms.txt");
+
+	for (const [pathname, marker] of [
+		["/llms-small.txt", "<SYSTEM>This is the abridged developer documentation for Runsight</SYSTEM>"],
+		["/llms-full.txt", "<SYSTEM>This is the full developer documentation for Runsight</SYSTEM>"],
+	]) {
+		const result = await fetchText(baseUrl, pathname);
+		assert(result.response.ok, `${pathname} should return 200, got ${result.response.status}`);
+		expectContentType(result.response.headers.get("content-type"), "text/plain", pathname);
+		expectIncludes(result.text, marker, pathname);
+	}
+
+	const homepage = await fetchText(baseUrl, "/");
+	assert(homepage.response.ok, `/ should return 200, got ${homepage.response.status}`);
+	expectContentType(homepage.response.headers.get("content-type"), "text/html", "/");
+	expectIncludes(homepage.text, 'rel="canonical" href="https://runsight.ai/"', "/");
+	expectIncludes(homepage.text, 'property="og:title"', "/");
+	expectIncludes(homepage.text, 'name="twitter:card"', "/");
+	expectIncludes(homepage.text, 'type="application/ld+json"', "/");
+
+	console.log(`Live discoverability checks passed for ${baseUrl}`);
+}
+
+if (mode === "dist") {
+	await checkRenderedOutput();
+} else if (mode === "live") {
+	await checkLiveSite(target);
+} else {
+	throw new Error('Usage: node tools/site/check-discoverability.mjs <dist|live> [base-url]');
+}

--- a/tools/site/postbuild-discoverability.mjs
+++ b/tools/site/postbuild-discoverability.mjs
@@ -1,0 +1,15 @@
+import { copyFile } from "node:fs/promises";
+import path from "node:path";
+
+const siteDir = process.cwd();
+const distDir = path.join(siteDir, "dist");
+const sitemapIndexPath = path.join(distDir, "sitemap-index.xml");
+const sitemapAliasPath = path.join(distDir, "sitemap.xml");
+
+try {
+	await copyFile(sitemapIndexPath, sitemapAliasPath);
+	console.log(`Synced ${path.relative(siteDir, sitemapAliasPath)} from sitemap-index.xml`);
+} catch (error) {
+	const message = error instanceof Error ? error.message : String(error);
+	throw new Error(`Failed to create sitemap.xml alias from sitemap-index.xml: ${message}`);
+}


### PR DESCRIPTION
## Summary
- add a public discoverability baseline for the Runsight site and docs
- define explicit crawler policy with a stable  and  contract
- improve homepage metadata, social tags, structured data, and generated  site manifest
- add build-time discoverability checks for rendered output

## Linear
- RUN-946
- RUN-947
- RUN-948
- RUN-949

## Verification
- 
> @runsight/site@0.0.1 build /Users/nataly/Documents/github/runsight/apps/site
> astro build && node ../../tools/site/postbuild-discoverability.mjs && node ../../tools/site/check-discoverability.mjs dist

11:37:01 [content] Syncing content
11:37:01 [content] Synced content
11:37:01 [types] Generated 277ms
11:37:01 [build] output: "static"
11:37:01 [build] mode: "static"
11:37:01 [build] directory: /Users/nataly/Documents/github/runsight/apps/site/dist/
11:37:01 [build] Collecting build info...
11:37:01 [build] ✓ Completed in 357ms.
11:37:01 [build] Building static entrypoints...
11:37:04 [vite] ✓ built in 3.06s
11:37:04 [vite] ✓ built in 86ms
11:37:05 [build] Rearranging server assets...

 generating static routes 
11:37:05   ├─ /404.html (+13ms) 
11:37:05   ├─ /llms-full.txt (+1.19s) 
11:37:06   ├─ /llms-small.txt (+793ms) 
11:37:07   ├─ /llms.txt (+1ms) 
11:37:07   ├─ /index.html (+1ms) 
11:37:07   ├─ /docs/index.html (+2ms) 
11:37:07   ├─ /docs/configuration/fallback/index.html (+3ms) 
11:37:07   ├─ /docs/configuration/first-time-setup/index.html (+4ms) 
11:37:07   ├─ /docs/configuration/providers/index.html (+4ms) 
11:37:07   ├─ /docs/configuration/settings/index.html (+2ms) 
11:37:07   ├─ /docs/evaluation/assertions/index.html (+2ms) 
11:37:07   ├─ /docs/evaluation/custom-assertions/index.html (+32ms) 
11:37:07   ├─ /docs/evaluation/eval-test-harness/index.html (+4ms) 
11:37:07   ├─ /docs/evaluation/regressions/index.html (+2ms) 
11:37:07   ├─ /docs/evaluation/transform-hooks/index.html (+1ms) 
11:37:07   ├─ /docs/execution/budget-and-limits/index.html (+2ms) 
11:37:07   ├─ /docs/execution/error-handling/index.html (+2ms) 
11:37:07   ├─ /docs/execution/fork-recovery/index.html (+2ms) 
11:37:07   ├─ /docs/execution/git-integration/index.html (+1ms) 
11:37:07   ├─ /docs/execution/process-isolation/index.html (+1ms) 
11:37:07   ├─ /docs/execution/running-workflows/index.html (+1ms) 
11:37:07   ├─ /docs/getting-started/installation/index.html (+1ms) 
11:37:07   ├─ /docs/getting-started/key-concepts/index.html (+1ms) 
11:37:07   ├─ /docs/getting-started/quickstart/index.html (+8ms) 
11:37:07   ├─ /docs/reference/assertion-reference/index.html (+2ms) 
11:37:07   ├─ /docs/reference/block-type-reference/index.html (+1ms) 
11:37:07   ├─ /docs/reference/cli-reference/index.html (+1ms) 
11:37:07   ├─ /docs/reference/unified-entity-identity/index.html (+1ms) 
11:37:07   ├─ /docs/reference/unified-entity-identity-adr/index.html (+1ms) 
11:37:07   ├─ /docs/reference/yaml-schema-reference/index.html (+1ms) 
11:37:07   ├─ /docs/souls/inline-souls/index.html (+3ms) 
11:37:07   ├─ /docs/souls/overview/index.html (+1ms) 
11:37:07   ├─ /docs/souls/soul-files/index.html (+2ms) 
11:37:07   ├─ /docs/souls/soul-library/index.html (+2ms) 
11:37:07   ├─ /docs/tools/built-in-tools/index.html (+1ms) 
11:37:07   ├─ /docs/tools/custom-tools/index.html (+1ms) 
11:37:07   ├─ /docs/tools/dispatch-and-delegate/index.html (+1ms) 
11:37:07   ├─ /docs/tools/overview/index.html (+1ms) 
11:37:07   ├─ /docs/visual-builder/canvas-modes/index.html (+1ms) 
11:37:07   ├─ /docs/visual-builder/canvas-overview/index.html (+1ms) 
11:37:07   ├─ /docs/visual-builder/run-detail-view/index.html (+1ms) 
11:37:07   ├─ /docs/visual-builder/yaml-editor/index.html (+1ms) 
11:37:07   ├─ /docs/workflows/block-types/index.html (+1ms) 
11:37:07   ├─ /docs/workflows/context-governance/index.html (+1ms) 
11:37:07   ├─ /docs/workflows/loops/index.html (+3ms) 
11:37:07   ├─ /docs/workflows/sub-workflows/index.html (+1ms) 
11:37:07   ├─ /docs/workflows/transitions-and-routing/index.html (+1ms) 
11:37:07   ├─ /docs/workflows/yaml-dx-shortcuts/index.html (+1ms) 
11:37:07   ├─ /docs/workflows/yaml-schema/index.html (+1ms) 
11:37:07 ✓ Completed in 2.18s.

11:37:07 [build] ✓ Completed in 5.37s.
11:37:07 [starlight:pagefind] Building search index with Pagefind...
11:37:07 [starlight:pagefind] Found 46 HTML files.
11:37:07 [starlight:pagefind] Finished building search index in 120ms.
11:37:07 [@astrojs/sitemap] `sitemap-index.xml` created at `dist`
11:37:07 [build] 46 page(s) built in 5.86s
11:37:07 [build] Complete!
Synced dist/sitemap.xml from sitemap-index.xml
Rendered discoverability checks passed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a discoverability baseline for the public site and docs: explicit crawler policy, richer homepage metadata/structured data, `llms.txt` generation, a sitemap alias, and build-time checks. This improves SEO, social previews, and LLM ingestion, and adds CI-friendly verification (RUN-946 to RUN-949).

- **New Features**
  - Crawler policy in `robots.txt` with sitemap pointer; allow `OAI-SearchBot`, block `GPTBot` (RUN-946).
  - Homepage SEO: canonical URL, Open Graph/Twitter tags, JSON‑LD for Organization/WebSite/SoftwareApplication, and a new social preview image (RUN-947).
  - Centralized site identity config used in `astro.config.mjs` and homepage for consistent metadata.
  - `llms.txt` with small/full variants and key links via `starlight-llms-txt` (RUN-948).
  - Post-build sitemap alias (`sitemap-index.xml` → `sitemap.xml`) and discoverability checks for dist and live sites; build script runs them by default with `check:discoverability:dist` and `check:discoverability:live` scripts (RUN-949).

- **Migration**
  - Ensure CI uses the `build` script for post-build aliasing and checks.
  - Optionally run `pnpm --filter @runsight/site check:discoverability:live https://runsight.ai` after deploys.

<sup>Written for commit 5f1c158ce1fef1c8a14910a1f28c7efa2fe5faee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

