### PR TITLE
RUN-966: scope CodeBlock copy to the local component instance

### DIFF
--- a/packages/ui/src/components/ui/__tests__/codeBlockCopy.test.tsx
+++ b/packages/ui/src/components/ui/__tests__/codeBlockCopy.test.tsx
@@ -1,0 +1,171 @@
+// @vitest-environment jsdom
+
+import * as React from "react"
+import { act } from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { CodeBlock, SyntaxKey, SyntaxString, SyntaxValue } from "../code-block"
+
+let container: HTMLDivElement
+let root: Root | null = null
+
+;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true
+
+function setClipboard(writeText?: (text: string) => Promise<void>) {
+  Object.defineProperty(window.navigator, "clipboard", {
+    configurable: true,
+    value: writeText ? { writeText } : undefined,
+  })
+}
+
+function render(element: React.ReactElement) {
+  root = createRoot(container)
+
+  act(() => {
+    root?.render(element)
+  })
+}
+
+function getCopyButtons() {
+  return Array.from(container.querySelectorAll('button[aria-label="Copy"]')) as HTMLButtonElement[]
+}
+
+async function click(button: HTMLButtonElement) {
+  await act(async () => {
+    button.dispatchEvent(new MouseEvent("click", { bubbles: true }))
+  })
+}
+
+beforeEach(() => {
+  container = document.createElement("div")
+  document.body.appendChild(container)
+})
+
+afterEach(() => {
+  act(() => {
+    root?.unmount()
+  })
+
+  root = null
+  container.remove()
+  vi.restoreAllMocks()
+  vi.useRealTimers()
+})
+
+describe("CodeBlock copy behavior (RUN-966)", () => {
+  it("copies the clicked block's tokenized code content", async () => {
+    const writeText = vi.fn<(_: string) => Promise<void>>().mockResolvedValue(undefined)
+    setClipboard(writeText)
+
+    render(
+      <div>
+        <CodeBlock language="yaml">
+          <SyntaxKey>name</SyntaxKey>{": "}
+          <SyntaxString>alpha</SyntaxString>{"\n"}
+          <SyntaxKey>model</SyntaxKey>{": "}
+          <SyntaxValue>gpt-4.1</SyntaxValue>
+        </CodeBlock>
+        <CodeBlock language="yaml">
+          <SyntaxKey>name</SyntaxKey>{": "}
+          <SyntaxString>beta</SyntaxString>{"\n"}
+          <SyntaxKey>model</SyntaxKey>{": "}
+          <SyntaxValue>gpt-5.4</SyntaxValue>
+        </CodeBlock>
+      </div>
+    )
+
+    const [, secondButton] = getCopyButtons()
+    await click(secondButton)
+
+    expect(writeText).toHaveBeenCalledTimes(1)
+    expect(writeText).toHaveBeenLastCalledWith("name: beta\nmodel: gpt-5.4")
+  })
+
+  it("copies numbered string content without visual line numbers", async () => {
+    const writeText = vi.fn<(_: string) => Promise<void>>().mockResolvedValue(undefined)
+    setClipboard(writeText)
+
+    render(
+      <CodeBlock language="yaml" numbered>
+        {"first: one\nsecond: two"}
+      </CodeBlock>
+    )
+
+    const [button] = getCopyButtons()
+    await click(button)
+
+    expect(writeText).toHaveBeenCalledWith("first: one\nsecond: two")
+  })
+
+  it("does not enter copied state when clipboard is unavailable", async () => {
+    setClipboard()
+
+    render(
+      <CodeBlock language="yaml">
+        {"name: unavailable"}
+      </CodeBlock>
+    )
+
+    const [button] = getCopyButtons()
+    expect(button.textContent).toBe("⧉")
+
+    await click(button)
+
+    expect(button.textContent).toBe("⧉")
+  })
+
+  it("does not enter copied state when clipboard write rejects", async () => {
+    const writeText = vi.fn<(_: string) => Promise<void>>().mockRejectedValue(new Error("denied"))
+    setClipboard(writeText)
+
+    render(
+      <CodeBlock language="yaml">
+        {"name: rejected"}
+      </CodeBlock>
+    )
+
+    const [button] = getCopyButtons()
+    await click(button)
+
+    expect(writeText).toHaveBeenCalledWith("name: rejected")
+    expect(button.textContent).toBe("⧉")
+  })
+
+  it("refreshes the copied-state timer on repeated successful clicks", async () => {
+    vi.useFakeTimers()
+
+    const writeText = vi.fn<(_: string) => Promise<void>>().mockResolvedValue(undefined)
+    setClipboard(writeText)
+
+    render(
+      <CodeBlock language="yaml">
+        {"name: repeated"}
+      </CodeBlock>
+    )
+
+    const [button] = getCopyButtons()
+
+    await click(button)
+    expect(button.textContent).toBe("✓")
+
+    await act(async () => {
+      vi.advanceTimersByTime(1500)
+    })
+
+    await click(button)
+
+    await act(async () => {
+      vi.advanceTimersByTime(600)
+    })
+
+    expect(button.textContent).toBe("✓")
+
+    await act(async () => {
+      vi.advanceTimersByTime(1400)
+    })
+
+    expect(button.textContent).toBe("⧉")
+  })
+})

--- a/packages/ui/src/components/ui/code-block.tsx
+++ b/packages/ui/src/components/ui/code-block.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { cva, type VariantProps } from "class-variance-authority"
 
 import { cn } from "../../utils/helpers"
@@ -54,16 +54,59 @@ export function CodeBlock({
   ...props
 }: CodeBlockProps) {
   const [copied, setCopied] = useState(false)
+  const codeContentRef = useRef<HTMLElement | null>(null)
+  const copiedResetTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-  function handleCopy() {
+  useEffect(() => {
+    return () => {
+      if (copiedResetTimeoutRef.current !== null) {
+        clearTimeout(copiedResetTimeoutRef.current)
+      }
+    }
+  }, [])
+
+  function clearCopiedState() {
+    if (copiedResetTimeoutRef.current !== null) {
+      clearTimeout(copiedResetTimeoutRef.current)
+      copiedResetTimeoutRef.current = null
+    }
+
+    setCopied(false)
+  }
+
+  function scheduleCopiedReset() {
+    if (copiedResetTimeoutRef.current !== null) {
+      clearTimeout(copiedResetTimeoutRef.current)
+    }
+
+    copiedResetTimeoutRef.current = setTimeout(() => {
+      copiedResetTimeoutRef.current = null
+      setCopied(false)
+    }, 2000)
+  }
+
+  async function handleCopy() {
     const text =
       typeof children === "string"
         ? children
-        : (document.querySelector("[data-slot='code-block-content']")?.textContent ?? "")
-    navigator.clipboard.writeText(text).then(() => {
+        : (codeContentRef.current?.textContent ?? "")
+
+    const writeText =
+      typeof navigator === "undefined" ? undefined : navigator.clipboard?.writeText?.bind(navigator.clipboard)
+
+    if (!writeText) {
+      clearCopiedState()
+      return
+    }
+
+    try {
+      await writeText(text)
       setCopied(true)
-      setTimeout(() => setCopied(false), 2000)
-    })
+      scheduleCopiedReset()
+    } catch {
+      // Clipboard access can be unavailable in unsupported or denied contexts.
+      clearCopiedState()
+    }
   }
 
   return (
@@ -111,7 +154,7 @@ export function CodeBlock({
         data-slot="code-block-content"
         className="overflow-x-auto"
       >
-        <code>
+        <code ref={codeContentRef}>
           {numbered && typeof children === "string"
             ? children.split("\n").map((line, i) => (
                 <span

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runsight-workspace"
-version = "0.4.12"
+version = "0.4.13"
 requires-python = ">=3.11"
 dependencies = []
 


### PR DESCRIPTION
## Summary
- scope `CodeBlock` copy actions to the clicked component instance instead of using a document-global selector
- fail silently when clipboard access is unavailable or rejected, and refresh copied-state timing on repeated successful clicks
- add a focused `packages/ui` regression test for local-instance copy behavior and bump the root version to `0.4.13`

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm -C packages/ui run test:unit -- src/components/ui/__tests__/codeBlockCopy.test.tsx`
- `pnpm exec eslint packages/ui/src/components/ui/code-block.tsx packages/ui/src/components/ui/__tests__/codeBlockCopy.test.tsx`

## Follow-up
- `RUN-977` tracks the broader rendered component test baseline for `packages/ui`.

## Links
- Closes #59

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CodeBlock copy so it only copies from the clicked block and handles clipboard failures without toggling the copied state. Addresses RUN-966 and keeps the copied-state timing accurate.

- **Bug Fixes**
  - Scoped copy to the component instance via a local ref; no document-global selector.
  - Silent fallback when `navigator.clipboard` is missing or write rejects; copied state not set.
  - Copied-state timer refreshes on repeat clicks and clears on unmount; added a focused `packages/ui` regression test.

<sup>Written for commit cf82765707e4d140a2c7727ef588a72b36591721. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->
