### PR TITLE
RUN-976: complete child stream ownership and dashboard follow-ups

### DIFF
--- a/apps/api/src/runsight_api/logic/observers/eval_observer.py
+++ b/apps/api/src/runsight_api/logic/observers/eval_observer.py
@@ -1,7 +1,8 @@
 """EvalObserver: runs assertion configs on block completion, persists eval results."""
 
+import asyncio
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from runsight_core.assertions.base import AssertionContext
 from runsight_core.assertions.registry import run_assertions_sync
@@ -33,18 +34,25 @@ class EvalObserver:
         run_id: str,
         sse_queue: Any,
         assertion_configs: Dict[str, List[Dict[str, Any]]] | None = None,
+        child_sse_queue_factory: Callable[[str], Any] | None = None,
     ) -> None:
         self.engine = engine
         self.run_id = run_id
         self.sse_queue = sse_queue
         self.assertion_configs = assertion_configs
+        self._child_sse_queue_factory = child_sse_queue_factory
 
     def clone_for_child_run(self, *, child_run_id: str) -> "EvalObserver":
         return EvalObserver(
             engine=self.engine,
             run_id=child_run_id,
-            sse_queue=self.sse_queue,
+            sse_queue=(
+                self._child_sse_queue_factory(child_run_id)
+                if self._child_sse_queue_factory is not None
+                else asyncio.Queue()
+            ),
             assertion_configs=self.assertion_configs,
+            child_sse_queue_factory=self._child_sse_queue_factory,
         )
 
     # ------------------------------------------------------------------

--- a/apps/api/src/runsight_api/logic/observers/eval_observer.py
+++ b/apps/api/src/runsight_api/logic/observers/eval_observer.py
@@ -55,6 +55,15 @@ class EvalObserver:
             child_sse_queue_factory=self._child_sse_queue_factory,
         )
 
+    def bind_sse_queue(
+        self,
+        *,
+        sse_queue: Any,
+        child_sse_queue_factory: Callable[[str], Any] | None = None,
+    ) -> None:
+        self.sse_queue = sse_queue
+        self._child_sse_queue_factory = child_sse_queue_factory
+
     # ------------------------------------------------------------------
     # No-op protocol methods
     # ------------------------------------------------------------------

--- a/apps/api/src/runsight_api/logic/observers/eval_observer.py
+++ b/apps/api/src/runsight_api/logic/observers/eval_observer.py
@@ -16,6 +16,7 @@ from runsight_api.data.repositories.run_read_model import RunReadModel
 from runsight_api.domain.entities.run import RunNode
 
 logger = logging.getLogger(__name__)
+_USE_PARENT_ASSERTION_CONFIGS = object()
 
 
 class EvalObserver:
@@ -42,7 +43,17 @@ class EvalObserver:
         self.assertion_configs = assertion_configs
         self._child_sse_queue_factory = child_sse_queue_factory
 
-    def clone_for_child_run(self, *, child_run_id: str) -> "EvalObserver":
+    def clone_for_child_run(
+        self,
+        *,
+        child_run_id: str,
+        assertion_configs: Dict[str, List[Dict[str, Any]]] | None | object = (
+            _USE_PARENT_ASSERTION_CONFIGS
+        ),
+    ) -> "EvalObserver":
+        child_assertion_configs = self.assertion_configs
+        if assertion_configs is not _USE_PARENT_ASSERTION_CONFIGS:
+            child_assertion_configs = assertion_configs
         return EvalObserver(
             engine=self.engine,
             run_id=child_run_id,
@@ -51,7 +62,7 @@ class EvalObserver:
                 if self._child_sse_queue_factory is not None
                 else asyncio.Queue()
             ),
-            assertion_configs=self.assertion_configs,
+            assertion_configs=child_assertion_configs,
             child_sse_queue_factory=self._child_sse_queue_factory,
         )
 

--- a/apps/api/src/runsight_api/logic/observers/streaming_observer.py
+++ b/apps/api/src/runsight_api/logic/observers/streaming_observer.py
@@ -39,6 +39,7 @@ class StreamingObserver:
         parent_summary_queue: asyncio.Queue[Dict[str, Any]] | None = None,
         register_stream: Callable[[str, "StreamingObserver"], None] | None = None,
         unregister_stream: Callable[[str], None] | None = None,
+        release_child_queue: Callable[[str], None] | None = None,
         child_owns_terminal_stream: bool = False,
     ):
         self.run_id = run_id
@@ -47,6 +48,7 @@ class StreamingObserver:
         self.parent_summary_queue = parent_summary_queue
         self._register_stream = register_stream
         self._unregister_stream = unregister_stream
+        self._release_child_queue = release_child_queue
         self._child_owns_terminal_stream = child_owns_terminal_stream
         self._child_queues: dict[str, asyncio.Queue[Dict[str, Any]]] = {}
         self.is_done: bool = False
@@ -66,11 +68,15 @@ class StreamingObserver:
             parent_summary_queue=self.queue,
             register_stream=self._register_stream,
             unregister_stream=self._unregister_stream,
+            release_child_queue=self._drop_child_queue,
             child_owns_terminal_stream=True,
         )
         if self._register_stream is not None:
             self._register_stream(child_run_id, child)
         return child
+
+    def _drop_child_queue(self, child_run_id: str) -> None:
+        self._child_queues.pop(child_run_id, None)
 
     def on_workflow_start(self, workflow_name: str, state: WorkflowState) -> None:
         self.queue.put_nowait({"event": SSE_RUN_STARTED, "data": {"run_id": self.run_id}})
@@ -169,6 +175,8 @@ class StreamingObserver:
                 )
             if self._unregister_stream is not None:
                 self._unregister_stream(self.run_id)
+            if self._release_child_queue is not None:
+                self._release_child_queue(self.run_id)
         elif self.parent_run_id is not None:
             # Compatibility path for manually-constructed child observers.
             self.queue.put_nowait(
@@ -240,6 +248,8 @@ class StreamingObserver:
         if self.parent_run_id is not None and self._child_owns_terminal_stream:
             if self._unregister_stream is not None:
                 self._unregister_stream(self.run_id)
+            if self._release_child_queue is not None:
+                self._release_child_queue(self.run_id)
 
     def on_context_resolution(self, event: ContextAuditEventV1) -> None:
         event = redact_context_audit_event_preview(event)

--- a/apps/api/src/runsight_api/logic/observers/streaming_observer.py
+++ b/apps/api/src/runsight_api/logic/observers/streaming_observer.py
@@ -2,7 +2,7 @@
 
 import asyncio
 from datetime import datetime
-from typing import Any, Dict, Optional
+from typing import Any, Callable, Dict, Optional
 
 from runsight_core.context_governance import (
     ContextAuditEventV1,
@@ -30,15 +30,46 @@ class StreamingObserver:
     The GUI SSE endpoint drains this queue to stream real-time execution events.
     """
 
-    def __init__(self, *, run_id: str, parent_run_id: Optional[str] = None):
+    def __init__(
+        self,
+        *,
+        run_id: str,
+        parent_run_id: Optional[str] = None,
+        queue: asyncio.Queue[Dict[str, Any]] | None = None,
+        parent_summary_queue: asyncio.Queue[Dict[str, Any]] | None = None,
+        register_stream: Callable[[str, "StreamingObserver"], None] | None = None,
+        unregister_stream: Callable[[str], None] | None = None,
+        child_owns_terminal_stream: bool = False,
+    ):
         self.run_id = run_id
         self.parent_run_id = parent_run_id
-        self.queue: asyncio.Queue[Dict[str, Any]] = asyncio.Queue()
+        self.queue: asyncio.Queue[Dict[str, Any]] = queue or asyncio.Queue()
+        self.parent_summary_queue = parent_summary_queue
+        self._register_stream = register_stream
+        self._unregister_stream = unregister_stream
+        self._child_owns_terminal_stream = child_owns_terminal_stream
+        self._child_queues: dict[str, asyncio.Queue[Dict[str, Any]]] = {}
         self.is_done: bool = False
 
+    def child_queue_for_run(self, child_run_id: str) -> asyncio.Queue[Dict[str, Any]]:
+        queue = self._child_queues.get(child_run_id)
+        if queue is None:
+            queue = asyncio.Queue()
+            self._child_queues[child_run_id] = queue
+        return queue
+
     def clone_for_child_run(self, *, child_run_id: str) -> "StreamingObserver":
-        child = StreamingObserver(run_id=child_run_id, parent_run_id=self.run_id)
-        child.queue = self.queue
+        child = StreamingObserver(
+            run_id=child_run_id,
+            parent_run_id=self.run_id,
+            queue=self.child_queue_for_run(child_run_id),
+            parent_summary_queue=self.queue,
+            register_stream=self._register_stream,
+            unregister_stream=self._unregister_stream,
+            child_owns_terminal_stream=True,
+        )
+        if self._register_stream is not None:
+            self._register_stream(child_run_id, child)
         return child
 
     def on_workflow_start(self, workflow_name: str, state: WorkflowState) -> None:
@@ -109,8 +140,37 @@ class StreamingObserver:
     def on_workflow_complete(
         self, workflow_name: str, state: WorkflowState, duration_s: float
     ) -> None:
-        if self.parent_run_id is not None:
-            # Child run: emit non-terminal event, do NOT mark stream as done
+        if self.parent_run_id is not None and self._child_owns_terminal_stream:
+            self.queue.put_nowait(
+                {
+                    "event": SSE_RUN_COMPLETED,
+                    "data": {
+                        "run_id": self.run_id,
+                        "duration_s": duration_s,
+                        "total_cost_usd": state.total_cost_usd,
+                        "total_tokens": state.total_tokens,
+                    },
+                }
+            )
+            self.is_done = True
+            if self.parent_summary_queue is not None:
+                self.parent_summary_queue.put_nowait(
+                    {
+                        "event": SSE_CHILD_RUN_COMPLETED,
+                        "data": {
+                            "run_id": self.run_id,
+                            "parent_run_id": self.parent_run_id,
+                            "child_run_id": self.run_id,
+                            "duration_s": duration_s,
+                            "total_cost_usd": state.total_cost_usd,
+                            "total_tokens": state.total_tokens,
+                        },
+                    }
+                )
+            if self._unregister_stream is not None:
+                self._unregister_stream(self.run_id)
+        elif self.parent_run_id is not None:
+            # Compatibility path for manually-constructed child observers.
             self.queue.put_nowait(
                 {
                     "event": SSE_CHILD_RUN_COMPLETED,
@@ -177,6 +237,9 @@ class StreamingObserver:
             }
         )
         self.is_done = True
+        if self.parent_run_id is not None and self._child_owns_terminal_stream:
+            if self._unregister_stream is not None:
+                self._unregister_stream(self.run_id)
 
     def on_context_resolution(self, event: ContextAuditEventV1) -> None:
         event = redact_context_audit_event_preview(event)

--- a/apps/api/src/runsight_api/logic/services/execution_preparation.py
+++ b/apps/api/src/runsight_api/logic/services/execution_preparation.py
@@ -33,6 +33,17 @@ def _provider_ref(provider_id: str) -> str:
     return str(EntityRef(EntityKind.PROVIDER, provider_id))
 
 
+def _snapshot_failure_reason(error: Exception) -> str:
+    if isinstance(error, subprocess.CalledProcessError):
+        stderr = (error.stderr or "").strip()
+        stdout = (error.stdout or "").strip()
+        if stderr:
+            return stderr
+        if stdout:
+            return stdout
+    return str(error)
+
+
 def has_workflow_blocks(workflow_definition: Dict[str, Any]) -> bool:
     blocks = workflow_definition.get("blocks", {})
     if not isinstance(blocks, dict):
@@ -110,12 +121,17 @@ class ExecutionPreparationService:
             try:
                 yaml_content = self.git_service.read_file(workflow_path, explicit_branch)
                 commit_sha = self.git_service.get_sha(explicit_branch, workflow_path)
-            except Exception:
-                raise
+            except Exception as exc:
+                raise ValueError(
+                    f"Requested snapshot could not be loaded for workflow "
+                    f"{_workflow_ref(workflow_id)} on ref {explicit_branch!r}: "
+                    f"{_snapshot_failure_reason(exc)}"
+                ) from exc
             if commit_sha is None:
                 raise ValueError(
-                    f"Requested snapshot sha could not be resolved for workflow "
-                    f"{_workflow_ref(workflow_id)} on ref {explicit_branch!r}"
+                    f"Requested snapshot could not be loaded for workflow "
+                    f"{_workflow_ref(workflow_id)} on ref {explicit_branch!r}: "
+                    "requested snapshot sha could not be resolved"
                 )
         else:
             if wf_entity is None:
@@ -124,30 +140,41 @@ class ExecutionPreparationService:
             commit_sha = get_workflow_commit_sha(workflow_path)
 
         api_keys = self.resolve_api_keys()
-        workflow_definition, runner = prepare_runtime_workflow(
-            yaml_content=yaml_content,
-            api_keys=api_keys,
-        )
-
-        workflow_registry = None
-        if has_workflow_blocks(workflow_definition):
-            registry_builder = self.workflow_registry_builder
-            if registry_builder is None:
-                registry_builder = self.workflow_repo.build_runnable_workflow_registry
-            workflow_registry = registry_builder(
-                workflow_id,
-                yaml_content,
-                git_ref=registry_git_ref,
-                git_service=registry_git_service,
+        try:
+            workflow_definition, runner = prepare_runtime_workflow(
+                yaml_content=yaml_content,
+                api_keys=api_keys,
             )
 
-        workflow = parser(
-            yaml_content,
-            workflow_registry=workflow_registry,
-            api_keys=api_keys,
-            runner=runner,
-            _base_dir=str(getattr(self.workflow_repo, "base_path", ".")),
-        )
+            workflow_registry = None
+            if has_workflow_blocks(workflow_definition):
+                registry_builder = self.workflow_registry_builder
+                if registry_builder is None:
+                    registry_builder = self.workflow_repo.build_runnable_workflow_registry
+                workflow_registry = registry_builder(
+                    workflow_id,
+                    yaml_content,
+                    git_ref=registry_git_ref,
+                    git_service=registry_git_service,
+                )
+
+            workflow = parser(
+                yaml_content,
+                workflow_registry=workflow_registry,
+                api_keys=api_keys,
+                runner=runner,
+                _base_dir=str(getattr(self.workflow_repo, "base_path", ".")),
+                _discovery_git_ref=registry_git_ref,
+                _discovery_git_service=registry_git_service,
+            )
+        except Exception as exc:
+            if explicit_branch is not None:
+                raise ValueError(
+                    f"Requested snapshot could not be loaded for workflow "
+                    f"{_workflow_ref(workflow_id)} on ref {explicit_branch!r}: "
+                    f"{_snapshot_failure_reason(exc)}"
+                ) from exc
+            raise
         return PreparedWorkflow(workflow=workflow, commit_sha=commit_sha)
 
     def resolve_api_keys(self) -> Dict[str, str]:

--- a/apps/api/src/runsight_api/logic/services/execution_runtime.py
+++ b/apps/api/src/runsight_api/logic/services/execution_runtime.py
@@ -64,7 +64,11 @@ class ExecutionRuntimeCoordinator:
         """Execute a prepared workflow under concurrency and stream coordination."""
         from runsight_core.state import WorkflowState
 
-        streaming_obs = StreamingObserver(run_id=run_id)
+        streaming_obs = StreamingObserver(
+            run_id=run_id,
+            register_stream=self.streams.register,
+            unregister_stream=self.streams.unregister,
+        )
         self.streams.register(run_id, streaming_obs)
 
         try:
@@ -88,6 +92,7 @@ class ExecutionRuntimeCoordinator:
                                 run_id=run_id,
                                 sse_queue=streaming_obs.queue,
                                 assertion_configs=build_assertion_configs(wf),
+                                child_sse_queue_factory=streaming_obs.child_queue_for_run,
                             )
                         )
                     observer = CompositeObserver(*observers)

--- a/apps/api/src/runsight_api/logic/services/execution_runtime.py
+++ b/apps/api/src/runsight_api/logic/services/execution_runtime.py
@@ -27,6 +27,9 @@ def _split_runtime_inputs(inputs: Any) -> tuple[dict[str, Any], Any | None]:
 
 def build_assertion_configs(wf: Any) -> Optional[Dict[str, list]]:
     """Extract block-owned assertion configs from runtime blocks."""
+    getter = getattr(wf, "assertion_configs", None)
+    if callable(getter):
+        return getter()
     blocks = getattr(wf, "_blocks", None)
     if not blocks or not isinstance(blocks, dict):
         return None

--- a/apps/api/src/runsight_api/logic/services/execution_service.py
+++ b/apps/api/src/runsight_api/logic/services/execution_service.py
@@ -455,7 +455,13 @@ class ExecutionService:
                 )
                 return
         except Exception as e:
-            logger.exception("Failed to prepare workflow for run %s", run_id)
+            logger.exception(
+                "Failed to prepare workflow for run %s (workflow=%s, requested_ref=%r): %s",
+                run_id,
+                workflow_id,
+                explicit_branch,
+                e,
+            )
             self._fail_run_on_prepare_error(run_id, e)
             return
 

--- a/apps/api/src/runsight_api/logic/services/execution_stream_registry.py
+++ b/apps/api/src/runsight_api/logic/services/execution_stream_registry.py
@@ -18,7 +18,7 @@ class ExecutionStreamRegistry:
     def __init__(self):
         self._observers: Dict[str, StreamingObserver] = {}
         self._observer_events: Dict[str, asyncio.Event] = {}
-        self._completed_streams: "OrderedDict[str, None]" = OrderedDict()
+        self._completed_streams: "OrderedDict[str, StreamingObserver]" = OrderedDict()
 
     def register(self, run_id: str, observer: StreamingObserver) -> None:
         self._observers[run_id] = observer
@@ -33,7 +33,7 @@ class ExecutionStreamRegistry:
         observer = self._observers.pop(run_id, None)
         ready_event = self._observer_events.pop(run_id, None)
         if observer is not None and observer.is_done:
-            self._mark_completed(run_id)
+            self._mark_completed(run_id, observer)
             if ready_event is not None:
                 ready_event.set()
             return
@@ -53,10 +53,8 @@ class ExecutionStreamRegistry:
         )
 
     async def subscribe(self, run_id: str) -> AsyncGenerator[Dict[str, Any], None]:
-        observer = self._observers.get(run_id)
+        observer = self._observers.get(run_id) or self._completed_streams.get(run_id)
         if observer is None:
-            if run_id in self._completed_streams:
-                return
             created_ready_event = run_id not in self._observer_events
             ready_event = self._observer_events.setdefault(run_id, asyncio.Event())
             try:
@@ -72,18 +70,20 @@ class ExecutionStreamRegistry:
                 ):
                     self._observer_events.pop(run_id, None)
                 return
-            observer = self._observers.get(run_id)
+            observer = self._observers.get(run_id) or self._completed_streams.get(run_id)
             if observer is None:
-                if run_id in self._completed_streams:
-                    return
                 if created_ready_event:
                     self._observer_events.pop(run_id, None)
                 return
 
         while True:
+            if observer.is_done and observer.queue.empty():
+                break
             try:
                 event = await asyncio.wait_for(observer.queue.get(), timeout=30.0)
             except asyncio.TimeoutError:
+                if observer.is_done and observer.queue.empty():
+                    break
                 continue
 
             if event["event"] == self.STREAM_CLOSED_EVENT:
@@ -94,8 +94,8 @@ class ExecutionStreamRegistry:
             if event["event"] in SSE_TERMINAL_EVENTS:
                 break
 
-    def _mark_completed(self, run_id: str) -> None:
+    def _mark_completed(self, run_id: str, observer: StreamingObserver) -> None:
         self._completed_streams.pop(run_id, None)
-        self._completed_streams[run_id] = None
+        self._completed_streams[run_id] = observer
         while len(self._completed_streams) > self.COMPLETED_STREAM_CACHE_SIZE:
             self._completed_streams.popitem(last=False)

--- a/apps/api/src/runsight_api/logic/services/git_service.py
+++ b/apps/api/src/runsight_api/logic/services/git_service.py
@@ -94,6 +94,13 @@ class GitService:
         result = self._run("show", f"{ref}:{repo_path}")
         return result.stdout
 
+    def list_files(self, ref: str, path_prefix: str) -> list[str]:
+        repo_path = self._normalize_repo_path(path_prefix)
+        result = self._run("ls-tree", "-r", "--name-only", ref, "--", repo_path, check=False)
+        if result.returncode != 0:
+            return []
+        return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
     def get_sha(self, branch: str, path: str) -> Optional[str]:
         repo_path = self._normalize_repo_path(path)
         result = self._run("log", "-1", "--format=%H", branch, "--", repo_path, check=False)

--- a/apps/api/src/runsight_api/logic/services/git_service.py
+++ b/apps/api/src/runsight_api/logic/services/git_service.py
@@ -99,7 +99,7 @@ class GitService:
         result = self._run("ls-tree", "-r", "--name-only", ref, "--", repo_path, check=False)
         if result.returncode != 0:
             return []
-        return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+        return [line for line in result.stdout.splitlines() if line != ""]
 
     def get_sha(self, branch: str, path: str) -> Optional[str]:
         repo_path = self._normalize_repo_path(path)

--- a/apps/api/src/runsight_api/main.py
+++ b/apps/api/src/runsight_api/main.py
@@ -12,6 +12,8 @@ from sqlalchemy import text
 from starlette.responses import FileResponse
 from sqlmodel import Session
 
+from runsight_core.paths import is_path_within_base
+
 from .core.config import ensure_project_dirs
 from .core.config import settings as app_settings
 from .core.di import engine
@@ -190,13 +192,14 @@ def create_app() -> FastAPI:
 
     # Serve built frontend static files (bundled in wheel or overridden via env)
     _pkg_static = Path(__file__).parent / "static"
-    static_dir = Path(os.environ.get("RUNSIGHT_STATIC_DIR", str(_pkg_static)))
+    static_dir = Path(os.environ.get("RUNSIGHT_STATIC_DIR", str(_pkg_static))).resolve()
     if static_dir.is_dir():
         assets_dir = static_dir / "assets"
         if assets_dir.is_dir():
             app.mount("/assets", StaticFiles(directory=str(assets_dir)), name="assets")
 
         index_html = static_dir / "index.html"
+        resolved_index_html = index_html.resolve(strict=False)
 
         @app.get("/runsight.svg", include_in_schema=False)
         async def _favicon():
@@ -204,11 +207,14 @@ def create_app() -> FastAPI:
 
         @app.get("/{full_path:path}", include_in_schema=False)
         async def _spa_catch_all(full_path: str):
-            # Serve static file if it exists, otherwise index.html for SPA routing
-            candidate = static_dir / full_path
-            if candidate.is_file():
-                return FileResponse(candidate)
-            return FileResponse(index_html)
+            resolved_candidate = (static_dir / full_path).resolve(strict=False)
+            if not is_path_within_base(static_dir, resolved_candidate):
+                raise RunsightError("Not found", error_code="NOT_FOUND", status_code=404)
+            if resolved_candidate.is_file():
+                return FileResponse(resolved_candidate)
+            if not is_path_within_base(static_dir, resolved_index_html):
+                raise RunsightError("Not found", error_code="NOT_FOUND", status_code=404)
+            return FileResponse(resolved_index_html)
 
     return app
 

--- a/apps/api/src/runsight_api/transport/routers/git.py
+++ b/apps/api/src/runsight_api/transport/routers/git.py
@@ -7,6 +7,7 @@ from typing import List
 from urllib.parse import unquote
 
 from fastapi import APIRouter
+from runsight_core.paths import is_path_within_base
 
 from ...core.config import settings
 from ...domain.errors import GitError, InputValidationError
@@ -90,22 +91,16 @@ def _validate_file_path(file_path: str) -> None:
         raise InputValidationError("Invalid path: path traversal not allowed")
 
     base = Path(settings.base_path).resolve()
-    if decoded.startswith("/"):
-        resolved = Path(decoded).resolve()
-        if not str(resolved).startswith(str(base)):
+    candidate_path = Path(decoded)
+    if candidate_path.is_absolute():
+        resolved = candidate_path.resolve()
+        if not is_path_within_base(base, resolved):
             raise InputValidationError("Invalid path: absolute path outside project root")
+        return
 
     resolved = (base / decoded).resolve()
-    if not str(resolved).startswith(str(base)):
+    if not is_path_within_base(base, resolved):
         raise InputValidationError("Invalid path: path escapes project root")
-
-    candidate = base / decoded
-    if candidate.is_symlink():
-        real = candidate.resolve()
-        if not str(real).startswith(str(base)):
-            raise InputValidationError(
-                "Invalid path: symlink target outside project root",
-            )
 
 
 def _validate_git_ref(ref: str) -> None:

--- a/apps/api/tests/logic/test_eval_observer.py
+++ b/apps/api/tests/logic/test_eval_observer.py
@@ -1026,3 +1026,71 @@ class TestEvalObserverChildStreamIsolation:
         event = child.sse_queue.get_nowait()
         assert event["event"] == "node_eval_complete"
         assert event["data"]["node_id"] == "block_a"
+
+    @pytest.mark.asyncio
+    async def test_sibling_child_eval_events_do_not_bleed_across_child_queues(
+        self,
+        db_engine,
+        sse_queue,
+        sample_state,
+        sample_soul,
+        contains_assertion_configs,
+    ):
+        parent_run_id = "run_973_eval_parent_siblings"
+        child_a_run_id = "run_973_eval_child_a"
+        child_b_run_id = "run_973_eval_child_b"
+
+        with Session(db_engine) as session:
+            for run_id, workflow_id in [
+                (parent_run_id, "wf_parent"),
+                (child_a_run_id, "wf_child_a"),
+                (child_b_run_id, "wf_child_b"),
+            ]:
+                session.add(
+                    Run(
+                        id=run_id,
+                        workflow_id=workflow_id,
+                        workflow_name=workflow_id,
+                        status=RunStatus.running,
+                        task_json="{}",
+                        branch="main",
+                    )
+                )
+            for run_id in [child_a_run_id, child_b_run_id]:
+                session.add(
+                    RunNode(
+                        id=f"{run_id}:block_a",
+                        run_id=run_id,
+                        node_id="block_a",
+                        block_type="LinearBlock",
+                        status="completed",
+                        cost_usd=0.05,
+                        tokens={"total": 1500},
+                        output="Some output containing Sources information.",
+                    )
+                )
+            session.commit()
+
+        EvalObserver = _import_eval_observer()
+        parent = EvalObserver(
+            engine=db_engine,
+            run_id=parent_run_id,
+            sse_queue=sse_queue,
+            assertion_configs=contains_assertion_configs,
+        )
+        child_a = parent.clone_for_child_run(child_run_id=child_a_run_id)
+        child_b = parent.clone_for_child_run(child_run_id=child_b_run_id)
+
+        child_a.on_block_complete(
+            "wf_child_a", "block_a", "LinearBlock", 2.5, sample_state, soul=sample_soul
+        )
+
+        assert sse_queue.empty(), (
+            "Sibling child eval events must not bleed back into the parent queue."
+        )
+        assert child_b.sse_queue.empty(), (
+            "An eval event emitted for child A must not appear on child B's queue."
+        )
+        event = child_a.sse_queue.get_nowait()
+        assert event["event"] == "node_eval_complete"
+        assert event["data"]["node_id"] == "block_a"

--- a/apps/api/tests/logic/test_eval_observer.py
+++ b/apps/api/tests/logic/test_eval_observer.py
@@ -938,3 +938,91 @@ class TestEvalObserverProtocol:
         state = WorkflowState()
         # Should not raise
         obs.on_workflow_start("wf", state)
+
+
+class TestEvalObserverChildStreamIsolation:
+    def test_clone_for_child_run_uses_a_distinct_sse_queue(self, seed_run, sse_queue):
+        engine, run_id = seed_run
+        EvalObserver = _import_eval_observer()
+        parent = EvalObserver(
+            engine=engine,
+            run_id=run_id,
+            sse_queue=sse_queue,
+            assertion_configs={"block_a": [{"type": "contains", "value": "x"}]},
+        )
+
+        child = parent.clone_for_child_run(child_run_id="run_973_child")
+
+        assert child.run_id == "run_973_child"
+        assert child.sse_queue is not parent.sse_queue, (
+            "Child eval observers must own a dedicated SSE queue so child eval traffic "
+            "cannot bleed into the parent's live stream."
+        )
+
+    @pytest.mark.asyncio
+    async def test_child_eval_events_stay_off_the_parent_queue(
+        self,
+        db_engine,
+        sse_queue,
+        sample_state,
+        sample_soul,
+        contains_assertion_configs,
+    ):
+        parent_run_id = "run_973_eval_parent"
+        child_run_id = "run_973_eval_child"
+
+        with Session(db_engine) as session:
+            session.add(
+                Run(
+                    id=parent_run_id,
+                    workflow_id="wf_parent",
+                    workflow_name="parent",
+                    status=RunStatus.running,
+                    task_json="{}",
+                    branch="main",
+                )
+            )
+            session.add(
+                Run(
+                    id=child_run_id,
+                    workflow_id="wf_child",
+                    workflow_name="child",
+                    status=RunStatus.running,
+                    task_json="{}",
+                    branch="main",
+                )
+            )
+            session.add(
+                RunNode(
+                    id=f"{child_run_id}:block_a",
+                    run_id=child_run_id,
+                    node_id="block_a",
+                    block_type="LinearBlock",
+                    status="completed",
+                    cost_usd=0.05,
+                    tokens={"total": 1500},
+                    output="Some output containing Sources information.",
+                )
+            )
+            session.commit()
+
+        EvalObserver = _import_eval_observer()
+        parent = EvalObserver(
+            engine=db_engine,
+            run_id=parent_run_id,
+            sse_queue=sse_queue,
+            assertion_configs=contains_assertion_configs,
+        )
+        child = parent.clone_for_child_run(child_run_id=child_run_id)
+
+        child.on_block_complete(
+            "wf_child", "block_a", "LinearBlock", 2.5, sample_state, soul=sample_soul
+        )
+
+        assert sse_queue.empty(), (
+            "A child run's node_eval_complete event must not be enqueued onto the parent's "
+            "live stream queue."
+        )
+        event = child.sse_queue.get_nowait()
+        assert event["event"] == "node_eval_complete"
+        assert event["data"]["node_id"] == "block_a"

--- a/apps/api/tests/logic/test_eval_observer.py
+++ b/apps/api/tests/logic/test_eval_observer.py
@@ -1199,7 +1199,3 @@ class TestEvalObserverChildAssertionOwnership:
             "Rebinding a child observer to the child workflow's assertion configs must not "
             "erase or replace the parent observer's root-workflow assertions."
         )
-        assert child.assertion_configs is not parent.assertion_configs, (
-            "Child eval observers must own an assertion config surface that can be rebound "
-            "to the child workflow without mutating the parent's root workflow configs."
-        )

--- a/apps/api/tests/logic/test_eval_observer.py
+++ b/apps/api/tests/logic/test_eval_observer.py
@@ -19,11 +19,18 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
+from runsight_core.block_io import BlockOutput
+from runsight_core.blocks.base import BaseBlock
+from runsight_core.blocks.workflow_block import WorkflowBlock
+from runsight_core.observer import CompositeObserver
 from runsight_core.primitives import Soul
 from runsight_core.state import BlockResult, WorkflowState
+from runsight_core.workflow import Workflow
 from sqlmodel import Session, SQLModel, create_engine, select
 
 from runsight_api.domain.entities.run import Run, RunNode, RunStatus
+from runsight_api.logic.observers.execution_observer import ExecutionObserver
+from runsight_api.logic.services.execution_runtime import build_assertion_configs
 
 # ---------------------------------------------------------------------------
 # Deferred import — EvalObserver does not exist yet
@@ -1097,105 +1104,100 @@ class TestEvalObserverChildStreamIsolation:
 
 
 class TestEvalObserverChildAssertionOwnership:
-    def test_child_assertion_config_rebinding_does_not_mutate_parent_surface(
+    @pytest.mark.asyncio
+    async def test_nested_child_workflow_uses_its_own_assertions_without_mutating_parent_surface(
         self,
         db_engine,
         sse_queue,
     ):
         parent_run_id = "run_973_eval_parent_config"
-        child_run_id = "run_973_eval_child_config"
+
+        class AssertionEchoBlock(BaseBlock):
+            def __init__(self, block_id: str, output: str, assertions: list[dict[str, object]]):
+                super().__init__(block_id)
+                self.output = output
+                self.assertions = assertions
+
+            async def execute(self, ctx):
+                return BlockOutput(
+                    output=self.output,
+                    cost_usd=0.0,
+                    total_tokens=0,
+                )
 
         with Session(db_engine) as session:
-            for run_id, workflow_id in [
-                (parent_run_id, "wf_parent"),
-                (child_run_id, "wf_child"),
-            ]:
-                session.add(
-                    Run(
-                        id=run_id,
-                        workflow_id=workflow_id,
-                        workflow_name=workflow_id,
-                        status=RunStatus.running,
-                        task_json="{}",
-                        branch="main",
-                    )
-                )
             session.add(
-                RunNode(
-                    id=f"{parent_run_id}:root_block",
-                    run_id=parent_run_id,
-                    node_id="root_block",
-                    block_type="LinearBlock",
-                    status="completed",
-                    cost_usd=0.05,
-                    tokens={"total": 1200},
-                    output="ROOT signal",
-                )
-            )
-            session.add(
-                RunNode(
-                    id=f"{child_run_id}:child_block",
-                    run_id=child_run_id,
-                    node_id="child_block",
-                    block_type="LinearBlock",
-                    status="completed",
-                    cost_usd=0.03,
-                    tokens={"total": 800},
-                    output="CHILD signal",
+                Run(
+                    id=parent_run_id,
+                    workflow_id="wf_parent",
+                    workflow_name="wf_parent",
+                    status=RunStatus.running,
+                    task_json="{}",
+                    branch="main",
                 )
             )
             session.commit()
 
+        child_wf = Workflow(name="wf_child")
+        child_wf.add_block(
+            AssertionEchoBlock(
+                "child_block",
+                "CHILD signal",
+                [{"type": "contains", "value": "CHILD", "weight": 1.0}],
+            )
+        )
+        child_wf.set_entry("child_block")
+        child_wf.add_transition("child_block", None)
+
+        parent_wf = Workflow(name="wf_parent")
+        parent_wf.add_block(
+            AssertionEchoBlock(
+                "root_block",
+                "ROOT signal",
+                [{"type": "contains", "value": "ROOT", "weight": 1.0}],
+            )
+        )
+        parent_wf.add_block(
+            WorkflowBlock(
+                block_id="invoke_child",
+                child_workflow=child_wf,
+                inputs={},
+                outputs={},
+                workflow_ref="wf_child",
+            )
+        )
+        parent_wf.set_entry("root_block")
+        parent_wf.add_transition("root_block", "invoke_child")
+        parent_wf.add_transition("invoke_child", None)
+
         EvalObserver = _import_eval_observer()
-        parent = EvalObserver(
-            engine=db_engine,
-            run_id=parent_run_id,
-            sse_queue=sse_queue,
-            assertion_configs={
-                "root_block": [{"type": "contains", "value": "ROOT", "weight": 1.0}]
-            },
-        )
-        child = parent.clone_for_child_run(child_run_id=child_run_id)
-
-        child.assertion_configs.clear()
-        child.assertion_configs.update(
-            {"child_block": [{"type": "contains", "value": "CHILD", "weight": 1.0}]}
-        )
-
-        child.on_block_complete(
-            "wf_child",
-            "child_block",
-            "LinearBlock",
-            0.25,
-            WorkflowState(
-                total_cost_usd=0.03,
-                total_tokens=800,
-                results={"child_block": BlockResult(output="CHILD signal")},
+        observer = CompositeObserver(
+            ExecutionObserver(engine=db_engine, run_id=parent_run_id),
+            EvalObserver(
+                engine=db_engine,
+                run_id=parent_run_id,
+                sse_queue=sse_queue,
+                assertion_configs=build_assertion_configs(parent_wf),
             ),
         )
-        assert parent.assertion_configs.get("root_block"), (
-            "Child eval rebinding must not erase the parent's root assertion config surface."
-        )
-        parent.on_block_complete(
-            "wf_parent",
-            "root_block",
-            "LinearBlock",
-            0.25,
-            WorkflowState(
-                total_cost_usd=0.05,
-                total_tokens=1200,
-                results={"root_block": BlockResult(output="ROOT signal")},
-            ),
-        )
+
+        await parent_wf.run(WorkflowState(), observer=observer)
 
         with Session(db_engine) as session:
-            child_node = session.get(RunNode, f"{child_run_id}:child_block")
             parent_node = session.get(RunNode, f"{parent_run_id}:root_block")
+            invoke_child_node = session.get(RunNode, f"{parent_run_id}:invoke_child")
+
+            assert invoke_child_node is not None
+            assert invoke_child_node.child_run_id is not None
+            child_node = session.get(RunNode, f"{invoke_child_node.child_run_id}:child_block")
 
         assert child_node is not None
-        assert child_node.eval_passed is True
         assert parent_node is not None
         assert parent_node.eval_passed is True, (
-            "Rebinding a child observer to the child workflow's assertion configs must not "
-            "erase or replace the parent observer's root-workflow assertions."
+            "The parent/root assertion surface must still evaluate the root block on the "
+            "real nested workflow path."
+        )
+        assert child_node.eval_passed is True, (
+            "Nested child workflows must evaluate using the child workflow's own assertion "
+            "configs on the real WorkflowBlock + CompositeObserver path."
         )

--- a/apps/api/tests/logic/test_eval_observer.py
+++ b/apps/api/tests/logic/test_eval_observer.py
@@ -1094,3 +1094,109 @@ class TestEvalObserverChildStreamIsolation:
         event = child_a.sse_queue.get_nowait()
         assert event["event"] == "node_eval_complete"
         assert event["data"]["node_id"] == "block_a"
+
+
+class TestEvalObserverChildAssertionOwnership:
+    def test_child_assertion_config_rebinding_does_not_mutate_parent_surface(
+        self,
+        db_engine,
+        sse_queue,
+    ):
+        parent_run_id = "run_973_eval_parent_config"
+        child_run_id = "run_973_eval_child_config"
+
+        with Session(db_engine) as session:
+            for run_id, workflow_id in [
+                (parent_run_id, "wf_parent"),
+                (child_run_id, "wf_child"),
+            ]:
+                session.add(
+                    Run(
+                        id=run_id,
+                        workflow_id=workflow_id,
+                        workflow_name=workflow_id,
+                        status=RunStatus.running,
+                        task_json="{}",
+                        branch="main",
+                    )
+                )
+            session.add(
+                RunNode(
+                    id=f"{parent_run_id}:root_block",
+                    run_id=parent_run_id,
+                    node_id="root_block",
+                    block_type="LinearBlock",
+                    status="completed",
+                    cost_usd=0.05,
+                    tokens={"total": 1200},
+                    output="ROOT signal",
+                )
+            )
+            session.add(
+                RunNode(
+                    id=f"{child_run_id}:child_block",
+                    run_id=child_run_id,
+                    node_id="child_block",
+                    block_type="LinearBlock",
+                    status="completed",
+                    cost_usd=0.03,
+                    tokens={"total": 800},
+                    output="CHILD signal",
+                )
+            )
+            session.commit()
+
+        EvalObserver = _import_eval_observer()
+        parent = EvalObserver(
+            engine=db_engine,
+            run_id=parent_run_id,
+            sse_queue=sse_queue,
+            assertion_configs={
+                "root_block": [{"type": "contains", "value": "ROOT", "weight": 1.0}]
+            },
+        )
+        child = parent.clone_for_child_run(child_run_id=child_run_id)
+
+        child.assertion_configs.clear()
+        child.assertion_configs.update(
+            {"child_block": [{"type": "contains", "value": "CHILD", "weight": 1.0}]}
+        )
+
+        child.on_block_complete(
+            "wf_child",
+            "child_block",
+            "LinearBlock",
+            0.25,
+            WorkflowState(
+                total_cost_usd=0.03,
+                total_tokens=800,
+                results={"child_block": BlockResult(output="CHILD signal")},
+            ),
+        )
+        parent.on_block_complete(
+            "wf_parent",
+            "root_block",
+            "LinearBlock",
+            0.25,
+            WorkflowState(
+                total_cost_usd=0.05,
+                total_tokens=1200,
+                results={"root_block": BlockResult(output="ROOT signal")},
+            ),
+        )
+
+        with Session(db_engine) as session:
+            child_node = session.get(RunNode, f"{child_run_id}:child_block")
+            parent_node = session.get(RunNode, f"{parent_run_id}:root_block")
+
+        assert child_node is not None
+        assert child_node.eval_passed is True
+        assert parent_node is not None
+        assert parent_node.eval_passed is True, (
+            "Rebinding a child observer to the child workflow's assertion configs must not "
+            "erase or replace the parent observer's root-workflow assertions."
+        )
+        assert child.assertion_configs is not parent.assertion_configs, (
+            "Child eval observers must own an assertion config surface that can be rebound "
+            "to the child workflow without mutating the parent's root workflow configs."
+        )

--- a/apps/api/tests/logic/test_eval_observer.py
+++ b/apps/api/tests/logic/test_eval_observer.py
@@ -1173,6 +1173,9 @@ class TestEvalObserverChildAssertionOwnership:
                 results={"child_block": BlockResult(output="CHILD signal")},
             ),
         )
+        assert parent.assertion_configs.get("root_block"), (
+            "Child eval rebinding must not erase the parent's root assertion config surface."
+        )
         parent.on_block_complete(
             "wf_parent",
             "root_block",

--- a/apps/api/tests/logic/test_eval_observer.py
+++ b/apps/api/tests/logic/test_eval_observer.py
@@ -1111,6 +1111,7 @@ class TestEvalObserverChildAssertionOwnership:
         sse_queue,
     ):
         parent_run_id = "run_973_eval_parent_config"
+        block_id = "asserted_block"
 
         class AssertionEchoBlock(BaseBlock):
             def __init__(self, block_id: str, output: str, assertions: list[dict[str, object]]):
@@ -1141,18 +1142,18 @@ class TestEvalObserverChildAssertionOwnership:
         child_wf = Workflow(name="wf_child")
         child_wf.add_block(
             AssertionEchoBlock(
-                "child_block",
+                block_id,
                 "CHILD signal",
                 [{"type": "contains", "value": "CHILD", "weight": 1.0}],
             )
         )
-        child_wf.set_entry("child_block")
-        child_wf.add_transition("child_block", None)
+        child_wf.set_entry(block_id)
+        child_wf.add_transition(block_id, None)
 
         parent_wf = Workflow(name="wf_parent")
         parent_wf.add_block(
             AssertionEchoBlock(
-                "root_block",
+                block_id,
                 "ROOT signal",
                 [{"type": "contains", "value": "ROOT", "weight": 1.0}],
             )
@@ -1166,8 +1167,8 @@ class TestEvalObserverChildAssertionOwnership:
                 workflow_ref="wf_child",
             )
         )
-        parent_wf.set_entry("root_block")
-        parent_wf.add_transition("root_block", "invoke_child")
+        parent_wf.set_entry(block_id)
+        parent_wf.add_transition(block_id, "invoke_child")
         parent_wf.add_transition("invoke_child", None)
 
         EvalObserver = _import_eval_observer()
@@ -1184,12 +1185,12 @@ class TestEvalObserverChildAssertionOwnership:
         await parent_wf.run(WorkflowState(), observer=observer)
 
         with Session(db_engine) as session:
-            parent_node = session.get(RunNode, f"{parent_run_id}:root_block")
+            parent_node = session.get(RunNode, f"{parent_run_id}:{block_id}")
             invoke_child_node = session.get(RunNode, f"{parent_run_id}:invoke_child")
 
             assert invoke_child_node is not None
             assert invoke_child_node.child_run_id is not None
-            child_node = session.get(RunNode, f"{invoke_child_node.child_run_id}:child_block")
+            child_node = session.get(RunNode, f"{invoke_child_node.child_run_id}:{block_id}")
 
         assert child_node is not None
         assert parent_node is not None

--- a/apps/api/tests/logic/test_execution_stream_registry_cleanup.py
+++ b/apps/api/tests/logic/test_execution_stream_registry_cleanup.py
@@ -43,7 +43,7 @@ async def _drain_completed_subscription(registry: ExecutionStreamRegistry, run_i
     return observed
 
 
-def test_completed_stream_marker_still_allows_immediate_terminal_shutdown() -> None:
+def test_completed_stream_marker_allows_one_late_terminal_drain() -> None:
     registry = ExecutionStreamRegistry()
     run_id = "run_completed_late_subscriber"
     observer = StreamingObserver(run_id=run_id)
@@ -54,8 +54,10 @@ def test_completed_stream_marker_still_allows_immediate_terminal_shutdown() -> N
     registry.unregister(run_id)
 
     observed = asyncio.run(_drain_completed_subscription(registry, run_id))
+    observed_again = asyncio.run(_drain_completed_subscription(registry, run_id))
 
-    assert observed == []
+    assert observed == [{"event": "run_completed", "data": {"run_id": run_id}}]
+    assert observed_again == []
 
 
 def test_subscribe_timeout_cleans_placeholder_ready_event() -> None:

--- a/apps/api/tests/logic/test_run207_streaming_observer.py
+++ b/apps/api/tests/logic/test_run207_streaming_observer.py
@@ -712,3 +712,31 @@ class TestEndToEndEventPipeline:
 
         assert collected == []
         assert svc._streams.get(run_id) is None
+
+
+class TestChildStreamingObserverIsolation:
+    """Child stream observers must own separate queue state from the parent."""
+
+    def test_clone_for_child_run_creates_a_distinct_queue(self) -> None:
+        parent = StreamingObserver(run_id="run_973_parent")
+
+        child = parent.clone_for_child_run(child_run_id="run_973_child")
+
+        assert child.run_id == "run_973_child"
+        assert child.parent_run_id == "run_973_parent"
+        assert child.queue is not parent.queue, (
+            "Child StreamingObserver must own its own SSE queue so /stream subscribers "
+            "for the child do not drain parent-owned events."
+        )
+
+    def test_sibling_child_observers_do_not_share_each_others_live_events(self) -> None:
+        parent = StreamingObserver(run_id="run_973_parent")
+        first_child = parent.clone_for_child_run(child_run_id="run_973_child_a")
+        second_child = parent.clone_for_child_run(child_run_id="run_973_child_b")
+
+        first_child.on_block_start("child_wf", "child_step", "workflow")
+
+        assert second_child.queue.empty(), (
+            "A live event emitted for one child run must not appear on a sibling child's "
+            "queue; each child stream should belong to exactly one run id."
+        )

--- a/apps/api/tests/logic/test_run207_streaming_observer.py
+++ b/apps/api/tests/logic/test_run207_streaming_observer.py
@@ -740,3 +740,33 @@ class TestChildStreamingObserverIsolation:
             "A live event emitted for one child run must not appear on a sibling child's "
             "queue; each child stream should belong to exactly one run id."
         )
+
+    def test_child_queue_is_removed_after_child_completion(self) -> None:
+        parent = StreamingObserver(run_id="run_973_parent")
+        child = parent.clone_for_child_run(child_run_id="run_973_child_done")
+
+        assert "run_973_child_done" in parent._child_queues
+
+        child.on_workflow_complete(
+            "child_wf",
+            WorkflowState(total_cost_usd=0.01, total_tokens=42),
+            0.25,
+        )
+
+        assert "run_973_child_done" not in parent._child_queues, (
+            "Parent StreamingObserver must release a child queue after that child stream "
+            "reaches terminal completion."
+        )
+
+    def test_child_queue_is_removed_after_child_failure(self) -> None:
+        parent = StreamingObserver(run_id="run_973_parent")
+        child = parent.clone_for_child_run(child_run_id="run_973_child_failed")
+
+        assert "run_973_child_failed" in parent._child_queues
+
+        child.on_workflow_error("child_wf", RuntimeError("boom"), 0.25)
+
+        assert "run_973_child_failed" not in parent._child_queues, (
+            "Parent StreamingObserver must release a child queue after that child stream "
+            "reaches terminal failure."
+        )

--- a/apps/api/tests/logic/test_run207_streaming_observer.py
+++ b/apps/api/tests/logic/test_run207_streaming_observer.py
@@ -752,6 +752,7 @@ class TestChildStreamingObserverIsolation:
             WorkflowState(total_cost_usd=0.01, total_tokens=42),
             0.25,
         )
+        assert child.is_done is True
 
         assert "run_973_child_done" not in parent._child_queues, (
             "Parent StreamingObserver must release a child queue after that child stream "
@@ -765,6 +766,7 @@ class TestChildStreamingObserverIsolation:
         assert "run_973_child_failed" in parent._child_queues
 
         child.on_workflow_error("child_wf", RuntimeError("boom"), 0.25)
+        assert child.is_done is True
 
         assert "run_973_child_failed" not in parent._child_queues, (
             "Parent StreamingObserver must release a child queue after that child stream "

--- a/apps/api/tests/logic/test_run374_git_service.py
+++ b/apps/api/tests/logic/test_run374_git_service.py
@@ -261,7 +261,30 @@ class TestReadFile:
 
 
 # ---------------------------------------------------------------------------
-# 6. get_sha(branch, path)
+# 6. list_files(ref, path_prefix)
+# ---------------------------------------------------------------------------
+
+
+class TestListFiles:
+    def test_preserves_leading_and_trailing_spaces_in_filenames(self, tmp_path: Path):
+        from runsight_api.logic.services.git_service import GitService
+
+        repo = _init_repo(tmp_path)
+        workflows_dir = repo / "custom" / "workflows"
+        workflows_dir.mkdir(parents=True, exist_ok=True)
+        spaced_name = " leading workflow .yaml "
+        (workflows_dir / spaced_name).write_text("version: '1.0'\n", encoding="utf-8")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-m", "add spaced workflow name")
+
+        svc = GitService(repo_path=str(repo))
+        files = svc.list_files(svc.current_branch(), "custom/workflows")
+
+        assert f"custom/workflows/{spaced_name}" in files
+
+
+# ---------------------------------------------------------------------------
+# 7. get_sha(branch, path)
 # ---------------------------------------------------------------------------
 
 
@@ -302,7 +325,7 @@ class TestGetSha:
 
 
 # ---------------------------------------------------------------------------
-# 7. commit_to_branch(branch, files, message)
+# 8. commit_to_branch(branch, files, message)
 # ---------------------------------------------------------------------------
 
 

--- a/apps/api/tests/logic/test_run606_execution_service_snapshot_resolution.py
+++ b/apps/api/tests/logic/test_run606_execution_service_snapshot_resolution.py
@@ -87,8 +87,11 @@ class _SnapshotGitService:
         self._snapshot_files = dict(snapshot_files)
         self.read_calls: list[tuple[str, str]] = []
 
-    def list_snapshot_files(self) -> list[str]:
-        return sorted(self._snapshot_files)
+    def list_files(self, ref: str, path_prefix: str) -> list[str]:
+        del ref
+        return sorted(
+            path for path in self._snapshot_files if path.startswith(path_prefix.rstrip("/") + "/")
+        )
 
     def read_file(self, path: str, ref: str) -> str:
         self.read_calls.append((path, ref))
@@ -159,7 +162,7 @@ async def test_launch_execution_resolves_child_workflow_from_snapshot_files_with
         snapshot_root=tmp_path,
         snapshot_files=snapshot_files,
     )
-    assert git_service.list_snapshot_files() == [
+    assert git_service.list_files("main", "custom/workflows/") == [
         "custom/workflows/child.yaml",
         "custom/workflows/parent.yaml",
     ]

--- a/apps/api/tests/logic/test_run606_execution_service_snapshot_resolution.py
+++ b/apps/api/tests/logic/test_run606_execution_service_snapshot_resolution.py
@@ -81,13 +81,32 @@ def _run_record():
     )
 
 
+class _SnapshotGitService:
+    def __init__(self, *, snapshot_root: Path, snapshot_files: dict[str, str]) -> None:
+        self.snapshot_root = snapshot_root
+        self._snapshot_files = dict(snapshot_files)
+        self.read_calls: list[tuple[str, str]] = []
+
+    def list_snapshot_files(self) -> list[str]:
+        return sorted(self._snapshot_files)
+
+    def read_file(self, path: str, ref: str) -> str:
+        self.read_calls.append((path, ref))
+        candidate = Path(path)
+        if candidate.is_absolute():
+            candidate = candidate.relative_to(self.snapshot_root)
+        return self._snapshot_files[candidate.as_posix()]
+
+    def get_sha(self, branch: str, path: str) -> str:
+        return "8" * 40
+
+
 @pytest.mark.asyncio
-async def test_launch_execution_resolves_child_workflow_from_requested_branch_snapshot(
+async def test_launch_execution_resolves_child_workflow_from_snapshot_files_without_repo_path(
     tmp_path: Path,
 ) -> None:
     from runsight_api.data.filesystem.workflow_repo import WorkflowRepository
     from runsight_api.logic.services.execution_service import ExecutionService
-    from runsight_api.logic.services.git_service import GitService
 
     parent_yaml = """
     version: "1.0"
@@ -131,38 +150,19 @@ async def test_launch_execution_resolves_child_workflow_from_requested_branch_sn
         - from: finish
           to: null
     """
-    dirty_child_yaml = """
-    version: "1.0"
-    inputs:
-      detail:
-        type: string
-        required: true
-    blocks:
-      finish:
-        type: code
-        inputs:
-          detail:
-            from: workflow.detail
-        code: |
-          def main(data):
-              return {"detail": data["detail"]}
-    workflow:
-      name: Dirty Child Workflow
-      entry: finish
-      transitions:
-        - from: finish
-          to: null
-    """
 
-    repo = _init_git_repo_with_nested_workflows(
-        tmp_path,
-        parent_yaml=parent_yaml,
-        child_yaml=child_yaml,
+    snapshot_files = {
+        "custom/workflows/parent.yaml": _with_workflow_identity("parent", parent_yaml),
+        "custom/workflows/child.yaml": _with_workflow_identity("child", child_yaml),
+    }
+    git_service = _SnapshotGitService(
+        snapshot_root=tmp_path,
+        snapshot_files=snapshot_files,
     )
-    (repo / "custom" / "workflows" / "child.yaml").write_text(
-        _with_workflow_identity("child", dirty_child_yaml),
-        encoding="utf-8",
-    )
+    assert git_service.list_snapshot_files() == [
+        "custom/workflows/child.yaml",
+        "custom/workflows/parent.yaml",
+    ]
 
     run_repo = Mock()
     run_repo.get_run.return_value = _run_record()
@@ -171,8 +171,7 @@ async def test_launch_execution_resolves_child_workflow_from_requested_branch_sn
     provider_repo.list_all.return_value = [
         Mock(id="openai", type="openai", is_active=True, models=["gpt-4o"], api_key=None)
     ]
-    workflow_repo = WorkflowRepository(base_path=str(repo))
-    git_service = GitService(repo_path=repo)
+    workflow_repo = WorkflowRepository(base_path=str(tmp_path))
     svc = ExecutionService(
         run_repo=run_repo,
         workflow_repo=workflow_repo,

--- a/apps/api/tests/logic/test_run607_nested_run_lifecycle.py
+++ b/apps/api/tests/logic/test_run607_nested_run_lifecycle.py
@@ -21,6 +21,7 @@ from sqlmodel import Session, SQLModel, create_engine, select
 
 from runsight_api.domain.entities.run import Run, RunNode, RunStatus
 from runsight_api.logic.observers.execution_observer import ExecutionObserver
+from runsight_api.logic.observers.streaming_observer import StreamingObserver
 
 
 # ---------------------------------------------------------------------------
@@ -437,6 +438,45 @@ class TestParentNodeStoresChildRunId:
             assert child_run is not None, (
                 f"child_run_id '{node.child_run_id}' should reference an existing Run"
             )
+
+    def test_parent_node_started_event_includes_allocated_child_run_id(self, db_engine):
+        """The live parent node_started event should expose the child run created downstream."""
+        with Session(db_engine) as session:
+            _create_run(
+                session,
+                run_id="parent_live_stream",
+                workflow_id="wf_parent",
+                workflow_name="Parent",
+                status=RunStatus.running,
+                depth=0,
+            )
+
+        streaming_observer = StreamingObserver(run_id="parent_live_stream")
+        parent_observer = CompositeObserver(
+            streaming_observer,
+            ExecutionObserver(engine=db_engine, run_id="parent_live_stream"),
+        )
+
+        parent_observer.on_block_start(
+            "Parent",
+            "call_child",
+            "WorkflowBlock",
+            child_workflow_id="wf_real_child",
+            child_workflow_name="Child Workflow",
+        )
+
+        event = streaming_observer.queue.get_nowait()
+
+        with Session(db_engine) as session:
+            node = session.get(RunNode, "parent_live_stream:call_child")
+
+        assert node is not None
+        assert node.child_run_id is not None
+        assert event["event"] == "node_started"
+        assert event["data"]["child_run_id"] == node.child_run_id, (
+            "The parent live node_started event must include the child_run_id allocated by "
+            "the runtime observer path, not only when a test injects child_run_id manually."
+        )
 
     def test_child_observer_persists_child_nodes_on_child_run(self, db_engine):
         """Child workflow events must be persisted on the child run, not the parent run."""

--- a/apps/api/tests/logic/test_run607_nested_run_lifecycle.py
+++ b/apps/api/tests/logic/test_run607_nested_run_lifecycle.py
@@ -473,7 +473,7 @@ class TestParentNodeStoresChildRunId:
         assert node is not None
         assert node.child_run_id is not None
         assert event["event"] == "node_started"
-        assert event["data"]["child_run_id"] == node.child_run_id, (
+        assert event["data"].get("child_run_id") == node.child_run_id, (
             "The parent live node_started event must include the child_run_id allocated by "
             "the runtime observer path, not only when a test injects child_run_id manually."
         )

--- a/apps/api/tests/logic/test_run800_eval_observer_custom_assertion.py
+++ b/apps/api/tests/logic/test_run800_eval_observer_custom_assertion.py
@@ -184,10 +184,28 @@ def _make_achat_response(content: str, cost_usd: float = 0.001, total_tokens: in
 
 def _git_service_for(base_dir: Path) -> Mock:
     git_service = Mock()
-    git_service.read_file.side_effect = lambda workflow_path, branch: Path(workflow_path).read_text(
-        encoding="utf-8"
-    )
+
+    def _list_files(branch: str, path_prefix: str) -> list[str]:
+        del branch
+        root = base_dir / path_prefix.rstrip("/")
+        if not root.exists():
+            return []
+        return sorted(
+            path.relative_to(base_dir).as_posix()
+            for path in root.rglob("*")
+            if path.is_file() and path.suffix in {".yaml", ".yml"}
+        )
+
+    def _read_file(workflow_path: str, branch: str) -> str:
+        del branch
+        path = Path(workflow_path)
+        if not path.is_absolute():
+            path = base_dir / workflow_path
+        return path.read_text(encoding="utf-8")
+
+    git_service.read_file.side_effect = _read_file
     git_service.get_sha.side_effect = lambda branch, workflow_path: "8" * 40
+    git_service.list_files.side_effect = _list_files
     return git_service
 
 

--- a/apps/api/tests/logic/test_run952_execution_preparation.py
+++ b/apps/api/tests/logic/test_run952_execution_preparation.py
@@ -461,6 +461,14 @@ class TestRequestedSnapshotSourceOfTruth:
             )
             await asyncio.sleep(0)
 
+        with Session(engine) as session:
+            run = session.get(Run, run_id)
+            assert run is not None
+            assert run.status == RunStatus.failed
+            assert run.error is not None
+            assert branch in run.error
+            assert "not a git repository" in run.error.lower()
+
         assert run_workflow.await_count == 0, (
             "launch_execution must fail instead of silently degrading to the working tree "
             "when the requested git snapshot cannot be read."
@@ -500,6 +508,14 @@ class TestRequestedSnapshotSourceOfTruth:
                 branch="main",
             )
             await asyncio.sleep(0)
+
+        with Session(engine) as session:
+            run = session.get(Run, run_id)
+            assert run is not None
+            assert run.status == RunStatus.failed
+            assert run.error is not None
+            assert "main" in run.error
+            assert "git service unavailable" in run.error.lower()
 
         assert run_workflow.await_count == 0, (
             "An explicit branch='main' request must still be treated as a git snapshot request "
@@ -819,6 +835,8 @@ class TestSnapshotDiscoveryFailsClosed:
             assert run is not None
             assert run.status == RunStatus.failed
             assert run.error is not None
+            assert "main" in run.error
+            assert "custom/souls/reviewer.yaml" in run.error
             assert "reviewer" in run.error.lower()
 
         assert run_workflow.await_count == 0, (

--- a/apps/api/tests/logic/test_run952_execution_preparation.py
+++ b/apps/api/tests/logic/test_run952_execution_preparation.py
@@ -1,19 +1,23 @@
-"""Red tests for RUN-952 execution preparation and launch coordination.
+"""Red tests for RUN-952 and RUN-969 execution snapshot preparation.
 
 These tests lock the coordinator split around preparation-time ownership:
 
 - the requested snapshot/ref is the source of truth for launch preparation
 - commit metadata lookup failures stay explicit instead of silently degrading
 - cancellation that lands during prepare prevents execution from being scheduled
+- explicit snapshot parser-time discovery fails closed instead of mixing in
+  dirty working-tree souls, tools, or assertions
 
 All tests in this file should fail on the pre-split implementation.
 """
 
 import asyncio
+import logging
 import subprocess
 import threading
 import tempfile
 from pathlib import Path
+from textwrap import dedent
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -118,6 +122,163 @@ def _cancel_run(engine, run_id: str) -> None:
 
 def _run_repo(engine):
     return RunRepository(Session(engine))
+
+
+def _write_repo_files(repo: Path, files: dict[str, str]) -> None:
+    for relative_path, contents in files.items():
+        target = repo / relative_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(dedent(contents).lstrip(), encoding="utf-8")
+
+
+def _init_git_repo_with_files(tmp_path: Path, *, files: dict[str, str]) -> Path:
+    repo = tmp_path / "repo"
+    _write_repo_files(repo, files)
+
+    subprocess.run(["git", "init", "-b", "main"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@runsight.dev"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Runsight Tests"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "initial snapshot"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+    return repo
+
+
+def _snapshot_missing_external_soul_workflow(workflow_id: str) -> str:
+    return f"""\
+version: "1.0"
+id: {workflow_id}
+kind: workflow
+workflow:
+  name: Snapshot Soul Workflow
+  entry: review
+  transitions:
+    - from: review
+      to: null
+blocks:
+  review:
+    type: linear
+    soul_ref: reviewer
+souls: {{}}
+config: {{}}
+"""
+
+
+def _working_tree_external_soul() -> str:
+    return """\
+id: reviewer
+kind: soul
+name: Reviewer
+role: Reviewer
+system_prompt: Review carefully.
+provider: openai
+model_name: gpt-4o
+"""
+
+
+def _snapshot_missing_tool_workflow(workflow_id: str) -> str:
+    return f"""\
+version: "1.0"
+id: {workflow_id}
+kind: workflow
+tools:
+  - helper_tool
+workflow:
+  name: Snapshot Tool Workflow
+  entry: analyze
+  transitions:
+    - from: analyze
+      to: null
+blocks:
+  analyze:
+    type: linear
+    soul_ref: assistant
+souls:
+  assistant:
+    id: assistant
+    kind: soul
+    name: Assistant
+    role: Assistant
+    system_prompt: Help carefully.
+    provider: openai
+    model_name: gpt-4o
+    tools:
+      - helper_tool
+config: {{}}
+"""
+
+
+def _working_tree_tool_definition() -> str:
+    return """\
+version: "1.0"
+id: helper_tool
+kind: tool
+type: custom
+executor: python
+name: Helper Tool
+description: Helper tool discovered only in the dirty working tree.
+parameters:
+  type: object
+code: |
+  def main(args):
+      return {"ok": True}
+"""
+
+
+def _snapshot_missing_assertion_workflow(workflow_id: str, assertion_id: str) -> str:
+    return f"""\
+version: "1.0"
+id: {workflow_id}
+kind: workflow
+workflow:
+  name: Snapshot Assertion Workflow
+  entry: analyze
+  transitions:
+    - from: analyze
+      to: null
+blocks:
+  analyze:
+    type: code
+    code: |
+      def main(data):
+          return "calm response"
+    assertions:
+      - type: custom:{assertion_id}
+config: {{}}
+"""
+
+
+def _working_tree_assertion_manifest(assertion_id: str) -> str:
+    return f"""\
+version: "1.0"
+id: {assertion_id}
+kind: assertion
+name: Snapshot Guard
+description: Assertion discovered only in the dirty working tree.
+returns: bool
+source: {assertion_id}.py
+"""
+
+
+def _working_tree_assertion_source() -> str:
+    return """\
+def get_assert(output, context):
+    return output == "calm response"
+"""
 
 
 class TestRequestedSnapshotSourceOfTruth:
@@ -609,3 +770,215 @@ async def test_cancelled_run_is_not_resurrected_when_queued_execution_slot_opens
         assert run.status == RunStatus.cancelled
 
     mock_wf.run.assert_not_awaited()
+
+
+class TestSnapshotDiscoveryFailsClosed:
+    @pytest.mark.asyncio
+    async def test_launch_execution_fails_when_requested_snapshot_lacks_external_soul_but_working_tree_has_one(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        from runsight_api.data.filesystem.workflow_repo import WorkflowRepository
+        from runsight_api.logic.services.git_service import GitService
+
+        workflow_id = "wf_snapshot_missing_soul"
+        repo = _init_git_repo_with_files(
+            tmp_path,
+            files={
+                f"custom/workflows/{workflow_id}.yaml": _snapshot_missing_external_soul_workflow(
+                    workflow_id
+                )
+            },
+        )
+        _write_repo_files(repo, {"custom/souls/reviewer.yaml": _working_tree_external_soul()})
+
+        engine = _db_engine()
+        run_id = "run_969_missing_soul_snapshot"
+        _seed_run(engine, run_id, workflow_id=workflow_id)
+
+        service = ExecutionService(
+            run_repo=_run_repo(engine),
+            workflow_repo=WorkflowRepository(base_path=str(repo)),
+            provider_repo=Mock(list_all=Mock(return_value=[])),
+            engine=engine,
+            git_service=GitService(repo_path=repo),
+        )
+
+        run_workflow = AsyncMock()
+        with patch.object(service, "_run_workflow", run_workflow):
+            await service.launch_execution(
+                run_id,
+                workflow_id,
+                _prepared_inputs({"instruction": "must fail closed"}),
+                branch="main",
+            )
+            await asyncio.sleep(0)
+
+        with Session(engine) as session:
+            run = session.get(Run, run_id)
+            assert run is not None
+            assert run.status == RunStatus.failed
+            assert run.error is not None
+            assert "reviewer" in run.error.lower()
+
+        assert run_workflow.await_count == 0, (
+            "Explicit snapshot launches must fail instead of mixing committed "
+            "workflow YAML with a dirty working-tree soul file."
+        )
+
+    @pytest.mark.asyncio
+    async def test_launch_execution_fails_when_requested_snapshot_lacks_custom_tool_but_working_tree_has_one(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        from runsight_api.data.filesystem.workflow_repo import WorkflowRepository
+        from runsight_api.logic.services.git_service import GitService
+
+        workflow_id = "wf_snapshot_missing_tool"
+        repo = _init_git_repo_with_files(
+            tmp_path,
+            files={
+                f"custom/workflows/{workflow_id}.yaml": _snapshot_missing_tool_workflow(workflow_id)
+            },
+        )
+        _write_repo_files(repo, {"custom/tools/helper_tool.yaml": _working_tree_tool_definition()})
+
+        engine = _db_engine()
+        run_id = "run_969_missing_tool_snapshot"
+        _seed_run(engine, run_id, workflow_id=workflow_id)
+
+        provider_repo = Mock()
+        provider_repo.list_all.return_value = [_provider()]
+        service = ExecutionService(
+            run_repo=_run_repo(engine),
+            workflow_repo=WorkflowRepository(base_path=str(repo)),
+            provider_repo=provider_repo,
+            engine=engine,
+            git_service=GitService(repo_path=repo),
+        )
+
+        run_workflow = AsyncMock()
+        with patch.object(service, "_run_workflow", run_workflow):
+            await service.launch_execution(
+                run_id,
+                workflow_id,
+                _prepared_inputs({"instruction": "must fail closed"}),
+                branch="main",
+            )
+            await asyncio.sleep(0)
+
+        with Session(engine) as session:
+            run = session.get(Run, run_id)
+            assert run is not None
+            assert run.status == RunStatus.failed
+            assert run.error is not None
+            assert "helper_tool" in run.error.lower()
+
+        assert run_workflow.await_count == 0, (
+            "Explicit snapshot launches must fail instead of resolving custom "
+            "tool metadata from the dirty working tree."
+        )
+
+    @pytest.mark.asyncio
+    async def test_launch_execution_fails_when_requested_snapshot_lacks_custom_assertion_but_working_tree_has_one(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        from runsight_api.data.filesystem.workflow_repo import WorkflowRepository
+        from runsight_api.logic.services.git_service import GitService
+
+        workflow_id = "wf_snapshot_missing_assertion"
+        assertion_id = "snapshot_guard_969"
+        repo = _init_git_repo_with_files(
+            tmp_path,
+            files={
+                f"custom/workflows/{workflow_id}.yaml": _snapshot_missing_assertion_workflow(
+                    workflow_id,
+                    assertion_id,
+                )
+            },
+        )
+        _write_repo_files(
+            repo,
+            {
+                f"custom/assertions/{assertion_id}.yaml": _working_tree_assertion_manifest(
+                    assertion_id
+                ),
+                f"custom/assertions/{assertion_id}.py": _working_tree_assertion_source(),
+            },
+        )
+
+        engine = _db_engine()
+        run_id = "run_969_missing_assertion_snapshot"
+        _seed_run(engine, run_id, workflow_id=workflow_id)
+
+        service = ExecutionService(
+            run_repo=_run_repo(engine),
+            workflow_repo=WorkflowRepository(base_path=str(repo)),
+            provider_repo=Mock(list_all=Mock(return_value=[])),
+            engine=engine,
+            git_service=GitService(repo_path=repo),
+        )
+
+        run_workflow = AsyncMock()
+        with patch.object(service, "_run_workflow", run_workflow):
+            await service.launch_execution(
+                run_id,
+                workflow_id,
+                _prepared_inputs({"instruction": "must fail closed"}),
+                branch="main",
+            )
+            await asyncio.sleep(0)
+
+        with Session(engine) as session:
+            run = session.get(Run, run_id)
+            assert run is not None
+            assert run.status == RunStatus.failed
+            assert run.error is not None
+            assert assertion_id in run.error
+
+        assert run_workflow.await_count == 0, (
+            "Explicit snapshot launches must fail instead of registering custom "
+            "assertions from the dirty working tree."
+        )
+
+    @pytest.mark.asyncio
+    async def test_launch_execution_logs_requested_ref_when_prepare_fails(self, caplog) -> None:
+        engine = _db_engine()
+        run_id = "run_969_prepare_log_context"
+        workflow_id = "wf_969_log_context"
+        requested_ref = "feature/snapshot-review"
+        _seed_run(engine, run_id, workflow_id=workflow_id)
+
+        workflow_repo = Mock()
+        workflow_repo._get_path.return_value = Path(f"/tmp/custom/workflows/{workflow_id}.yaml")
+        provider_repo = Mock()
+        provider_repo.list_all.return_value = []
+        service = ExecutionService(
+            run_repo=_run_repo(engine),
+            workflow_repo=workflow_repo,
+            provider_repo=provider_repo,
+            engine=engine,
+            git_service=Mock(),
+        )
+
+        with (
+            patch.object(
+                service._preparation,
+                "prepare_for_launch",
+                side_effect=ValueError("Requested snapshot is missing custom/souls/reviewer.yaml"),
+            ),
+            caplog.at_level(
+                logging.ERROR,
+                logger="runsight_api.logic.services.execution_service",
+            ),
+        ):
+            await service.launch_execution(
+                run_id,
+                workflow_id,
+                _prepared_inputs({"instruction": "report requested ref"}),
+                branch=requested_ref,
+            )
+
+        assert requested_ref in caplog.text
+        assert "custom/souls/reviewer.yaml" in caplog.text

--- a/apps/api/tests/logic/test_run952_stream_subscription.py
+++ b/apps/api/tests/logic/test_run952_stream_subscription.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock
 import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
+from runsight_core.context_governance import ContextAuditEventV1, ContextAuditRecordV1
 
 from runsight_api.logic.observers.streaming_observer import StreamingObserver
 from runsight_api.logic.services.execution_service import ExecutionService
@@ -282,6 +283,105 @@ class TestChildRunStreamOwnership:
             "Parent streams may carry an explicit child summary signal, but they must not "
             "receive raw child node lifecycle traffic."
         )
+
+    @pytest.mark.asyncio
+    async def test_child_failure_terminates_only_child_stream(self):
+        service = _make_service()
+        parent = StreamingObserver(run_id="run_973_parent")
+        child = parent.clone_for_child_run(child_run_id="run_973_child")
+        service._streams.register(parent.run_id, parent)
+        service._streams.register(child.run_id, child)
+
+        events: list[dict] = []
+
+        async def consume_parent() -> None:
+            async for event in service.subscribe_stream(parent.run_id):
+                events.append(event)
+
+        consumer = asyncio.create_task(consume_parent())
+        await asyncio.sleep(0)
+
+        child.on_workflow_error("child_workflow", RuntimeError("child boom"), 0.25)
+
+        await asyncio.sleep(0.05)
+        assert not consumer.done(), (
+            "A child failure must terminate only the child stream; the parent subscriber "
+            "should stay attached until the parent emits its own terminal event."
+        )
+
+        child_stream = service.subscribe_stream(child.run_id)
+        event = await asyncio.wait_for(anext(child_stream), timeout=1)
+        await child_stream.aclose()
+
+        assert event["event"] == "run_failed"
+        assert event["data"]["run_id"] == child.run_id
+
+        parent.on_workflow_complete(
+            "parent_workflow", Mock(total_cost_usd=0.02, total_tokens=84), 0.5
+        )
+        await asyncio.wait_for(consumer, timeout=1)
+
+        assert events[-1]["event"] == "run_completed"
+        assert all(parent_event["event"] != "run_failed" for parent_event in events), (
+            "Parent streams must not receive child run_failed traffic."
+        )
+
+    @pytest.mark.asyncio
+    async def test_parent_stream_filters_child_context_resolution_events(self):
+        service = _make_service()
+        parent = StreamingObserver(run_id="run_973_parent")
+        child = parent.clone_for_child_run(child_run_id="run_973_child")
+        service._streams.register(parent.run_id, parent)
+        service._streams.register(child.run_id, child)
+
+        events: list[dict] = []
+
+        async def consume_parent() -> None:
+            async for event in service.subscribe_stream(parent.run_id):
+                events.append(event)
+
+        consumer = asyncio.create_task(consume_parent())
+        await asyncio.sleep(0)
+
+        child.on_context_resolution(
+            ContextAuditEventV1(
+                run_id=child.run_id,
+                workflow_name="child_workflow",
+                node_id="resolve_context",
+                block_type="linear",
+                access="declared",
+                mode="strict",
+                records=[
+                    ContextAuditRecordV1(
+                        input_name="query",
+                        from_ref="results.query",
+                        namespace="results",
+                        source="query",
+                        field_path="query",
+                        status="resolved",
+                        severity="allow",
+                        value_type="str",
+                        preview="bounded preview",
+                        reason=None,
+                    )
+                ],
+                resolved_count=1,
+                denied_count=0,
+                warning_count=0,
+                emitted_at=datetime.now(timezone.utc),
+            )
+        )
+
+        await asyncio.sleep(0.05)
+        assert events == [], "Parent streams must not receive raw child context_resolution traffic."
+        assert not consumer.done(), (
+            "A child context-resolution event must not terminate the parent stream."
+        )
+
+        parent.on_workflow_complete(
+            "parent_workflow", Mock(total_cost_usd=0.02, total_tokens=84), 0.5
+        )
+        await asyncio.wait_for(consumer, timeout=1)
 
 
 @pytest.mark.parametrize(

--- a/apps/api/tests/logic/test_run952_stream_subscription.py
+++ b/apps/api/tests/logic/test_run952_stream_subscription.py
@@ -249,6 +249,8 @@ class TestChildRunStreamOwnership:
         )
         service._streams.register(parent.run_id, parent)
         child = parent.clone_for_child_run(child_run_id="run_973_child_complete")
+        assert service._streams.get(child.run_id) is child
+        assert child.parent_run_id == parent.run_id
 
         child.on_workflow_complete(
             "child_workflow",
@@ -274,6 +276,8 @@ class TestChildRunStreamOwnership:
         )
         service._streams.register(parent.run_id, parent)
         child = parent.clone_for_child_run(child_run_id="run_973_child_failed")
+        assert service._streams.get(child.run_id) is child
+        assert child.parent_run_id == parent.run_id
 
         child.on_workflow_error("child_workflow", RuntimeError("child boom"), 0.25)
 

--- a/apps/api/tests/logic/test_run952_stream_subscription.py
+++ b/apps/api/tests/logic/test_run952_stream_subscription.py
@@ -240,6 +240,52 @@ class TestChildRunStreamOwnership:
         assert event["data"]["run_id"] == child.run_id
 
     @pytest.mark.asyncio
+    async def test_late_child_subscriber_still_receives_completed_terminal_event(self):
+        service = _make_service()
+        parent = StreamingObserver(
+            run_id="run_973_parent",
+            register_stream=service._streams.register,
+            unregister_stream=service._streams.unregister,
+        )
+        service._streams.register(parent.run_id, parent)
+        child = parent.clone_for_child_run(child_run_id="run_973_child_complete")
+
+        child.on_workflow_complete(
+            "child_workflow",
+            Mock(total_cost_usd=0.01, total_tokens=42),
+            0.25,
+        )
+
+        events = [event async for event in service.subscribe_stream(child.run_id)]
+
+        assert [event["event"] for event in events] == ["run_completed"], (
+            "A late child subscriber must still observe the child's live run_completed event "
+            "even after the child stream unregisters itself on terminal completion."
+        )
+        assert events[0]["data"]["run_id"] == child.run_id
+
+    @pytest.mark.asyncio
+    async def test_late_child_subscriber_still_receives_failed_terminal_event(self):
+        service = _make_service()
+        parent = StreamingObserver(
+            run_id="run_973_parent",
+            register_stream=service._streams.register,
+            unregister_stream=service._streams.unregister,
+        )
+        service._streams.register(parent.run_id, parent)
+        child = parent.clone_for_child_run(child_run_id="run_973_child_failed")
+
+        child.on_workflow_error("child_workflow", RuntimeError("child boom"), 0.25)
+
+        events = [event async for event in service.subscribe_stream(child.run_id)]
+
+        assert [event["event"] for event in events] == ["run_failed"], (
+            "A late child subscriber must still observe the child's live run_failed event "
+            "even after the child stream unregisters itself on terminal failure."
+        )
+        assert events[0]["data"]["run_id"] == child.run_id
+
+    @pytest.mark.asyncio
     async def test_parent_stream_stays_open_and_filters_child_raw_events(self):
         service = _make_service()
         parent = StreamingObserver(run_id="run_973_parent")

--- a/apps/api/tests/logic/test_run952_stream_subscription.py
+++ b/apps/api/tests/logic/test_run952_stream_subscription.py
@@ -1,6 +1,7 @@
 """Red tests for RUN-952 stream subscription coordination."""
 
 import asyncio
+from datetime import datetime, timezone
 from unittest.mock import Mock
 
 import pytest
@@ -212,6 +213,74 @@ class TestLateStreamSubscribers:
         assert any("event:run_completed" in chunk for chunk in chunks), (
             "The SSE endpoint should wait for the stream registry to attach and "
             "then deliver the terminal event to an already-connected subscriber."
+        )
+
+
+class TestChildRunStreamOwnership:
+    @pytest.mark.asyncio
+    async def test_child_stream_gets_child_owned_terminal_event(self):
+        service = _make_service()
+        parent = StreamingObserver(run_id="run_973_parent")
+        child = parent.clone_for_child_run(child_run_id="run_973_child")
+        service._streams.register(parent.run_id, parent)
+        service._streams.register(child.run_id, child)
+
+        child_state = Mock(total_cost_usd=0.01, total_tokens=42)
+
+        stream = service.subscribe_stream(child.run_id)
+        child.on_workflow_complete("child_workflow", child_state, 0.25)
+        event = await asyncio.wait_for(anext(stream), timeout=1)
+        await stream.aclose()
+
+        assert event["event"] == "run_completed", (
+            "A child run's own stream must terminate with child-owned terminal traffic, "
+            "not a parent-summary event."
+        )
+        assert event["data"]["run_id"] == child.run_id
+
+    @pytest.mark.asyncio
+    async def test_parent_stream_stays_open_and_filters_child_raw_events(self):
+        service = _make_service()
+        parent = StreamingObserver(run_id="run_973_parent")
+        child = parent.clone_for_child_run(child_run_id="run_973_child")
+        service._streams.register(parent.run_id, parent)
+        service._streams.register(child.run_id, child)
+
+        parent_state = Mock(total_cost_usd=0.02, total_tokens=84)
+        child_state = Mock(total_cost_usd=0.01, total_tokens=42)
+        events: list[dict] = []
+
+        async def consume_parent() -> None:
+            async for event in service.subscribe_stream(parent.run_id):
+                events.append(event)
+
+        consumer = asyncio.create_task(consume_parent())
+        await asyncio.sleep(0)
+
+        child.on_block_start("child_workflow", "child_step", "workflow")
+        child.on_block_heartbeat(
+            "child_workflow",
+            "child_step",
+            "running",
+            "still working",
+            datetime.now(timezone.utc),
+        )
+        child.on_workflow_complete("child_workflow", child_state, 0.25)
+
+        await asyncio.sleep(0.05)
+        assert not consumer.done(), (
+            "A parent stream must remain open after child completion until the parent itself "
+            "enqueues terminal traffic."
+        )
+
+        parent.on_workflow_complete("parent_workflow", parent_state, 0.5)
+        await asyncio.wait_for(consumer, timeout=1)
+
+        event_types = [event["event"] for event in events]
+        assert event_types[-1] == "run_completed"
+        assert set(event_types) <= {"child_run_completed", "run_completed"}, (
+            "Parent streams may carry an explicit child summary signal, but they must not "
+            "receive raw child node lifecycle traffic."
         )
 
 

--- a/apps/api/tests/test_run705_assertions_fire_e2e.py
+++ b/apps/api/tests/test_run705_assertions_fire_e2e.py
@@ -103,10 +103,28 @@ def _write_workflow_file(base_dir: Path, workflow_id: str, content: str) -> None
 
 def _git_service_for(base_dir: Path) -> Mock:
     git_service = Mock()
-    git_service.read_file.side_effect = lambda workflow_path, branch: Path(workflow_path).read_text(
-        encoding="utf-8"
-    )
+
+    def _list_files(branch: str, path_prefix: str) -> list[str]:
+        del branch
+        root = base_dir / path_prefix.rstrip("/")
+        if not root.exists():
+            return []
+        return sorted(
+            path.relative_to(base_dir).as_posix()
+            for path in root.rglob("*")
+            if path.is_file() and path.suffix in {".yaml", ".yml"}
+        )
+
+    def _read_file(workflow_path: str, branch: str) -> str:
+        del branch
+        path = Path(workflow_path)
+        if not path.is_absolute():
+            path = base_dir / workflow_path
+        return path.read_text(encoding="utf-8")
+
+    git_service.read_file.side_effect = _read_file
     git_service.get_sha.side_effect = lambda branch, workflow_path: "7" * 40
+    git_service.list_files.side_effect = _list_files
     return git_service
 
 

--- a/apps/api/tests/test_run706_api_e2e.py
+++ b/apps/api/tests/test_run706_api_e2e.py
@@ -132,10 +132,28 @@ def _write_secrets_file(base_dir: Path) -> None:
 
 def _git_service_for(base_dir: Path) -> Mock:
     git_service = Mock()
-    git_service.read_file.side_effect = lambda workflow_path, branch: Path(workflow_path).read_text(
-        encoding="utf-8"
-    )
+
+    def _list_files(branch: str, path_prefix: str) -> list[str]:
+        del branch
+        root = base_dir / path_prefix.rstrip("/")
+        if not root.exists():
+            return []
+        return sorted(
+            path.relative_to(base_dir).as_posix()
+            for path in root.rglob("*")
+            if path.is_file() and path.suffix in {".yaml", ".yml"}
+        )
+
+    def _read_file(workflow_path: str, branch: str) -> str:
+        del branch
+        path = Path(workflow_path)
+        if not path.is_absolute():
+            path = base_dir / workflow_path
+        return path.read_text(encoding="utf-8")
+
+    git_service.read_file.side_effect = _read_file
     git_service.get_sha.side_effect = lambda branch, workflow_path: "6" * 40
+    git_service.list_files.side_effect = _list_files
     return git_service
 
 

--- a/apps/api/tests/test_run707_sse_streaming_e2e.py
+++ b/apps/api/tests/test_run707_sse_streaming_e2e.py
@@ -483,20 +483,21 @@ class TestSSEStreamProducesBlockEvents:
 
 
 # ===========================================================================
-# AC2 — Child WorkflowBlock -> SSE stream contains child block events
+# AC2 — Child WorkflowBlock -> SSE stream keeps child raw traffic on child stream
 # ===========================================================================
 
 
-class TestSSEStreamContainsChildBlockEvents:
-    """When a parent workflow contains a workflow-call block that spawns a child
-    workflow, the SSE stream must contain events for the child workflow's blocks."""
+class TestSSEStreamContainsChildSummaryOnly:
+    """The parent stream should surface child completion summary only.
+
+    Raw child node lifecycle traffic belongs on the child run stream.
+    """
 
     @pytest.mark.asyncio
     async def test_child_workflow_block_events_appear_in_stream(
         self, execution_service, db_engine, base_dir
     ):
-        """The stream for a parent run must include node events from the child
-        workflow's blocks (e.g. do_work), not just the parent's blocks."""
+        """The parent stream must not expose raw child node lifecycle events."""
         from runsight_core.yaml.parser import parse_workflow_yaml
 
         import yaml
@@ -527,13 +528,17 @@ class TestSSEStreamContainsChildBlockEvents:
             for e in events
             if e["event"] == SSE_NODE_STARTED and "node_id" in e.get("data", {})
         }
+        event_types = [e["event"] for e in events]
 
-        assert "do_work" in started_node_ids, (
-            f"Child workflow's block 'do_work' must appear in the parent's SSE "
-            f"stream. Got node_ids: {started_node_ids}"
+        assert "do_work" not in started_node_ids, (
+            f"Parent stream must not include raw child block events. Got node_ids: "
+            f"{started_node_ids}"
         )
         assert "plan" in started_node_ids, (
             f"Parent block 'plan' must appear in SSE stream. Got: {started_node_ids}"
+        )
+        assert "child_run_completed" in event_types, (
+            f"Parent stream must surface a child summary event. Got: {event_types}"
         )
 
 

--- a/apps/api/tests/test_run707_sse_streaming_e2e.py
+++ b/apps/api/tests/test_run707_sse_streaming_e2e.py
@@ -193,10 +193,28 @@ def _make_achat_response(content: str, cost_usd: float = 0.001, total_tokens: in
 
 def _git_service_for(base_dir: Path) -> Mock:
     git_service = Mock()
-    git_service.read_file.side_effect = lambda workflow_path, branch: Path(workflow_path).read_text(
-        encoding="utf-8"
-    )
+
+    def _list_files(branch: str, path_prefix: str) -> list[str]:
+        del branch
+        root = base_dir / path_prefix.rstrip("/")
+        if not root.exists():
+            return []
+        return sorted(
+            path.relative_to(base_dir).as_posix()
+            for path in root.rglob("*")
+            if path.is_file() and path.suffix in {".yaml", ".yml"}
+        )
+
+    def _read_file(workflow_path: str, branch: str) -> str:
+        del branch
+        path = Path(workflow_path)
+        if not path.is_absolute():
+            path = base_dir / workflow_path
+        return path.read_text(encoding="utf-8")
+
+    git_service.read_file.side_effect = _read_file
     git_service.get_sha.side_effect = lambda branch, workflow_path: "7" * 40
+    git_service.list_files.side_effect = _list_files
     return git_service
 
 

--- a/apps/api/tests/test_run845_parser_warnings_e2e.py
+++ b/apps/api/tests/test_run845_parser_warnings_e2e.py
@@ -74,10 +74,28 @@ def _write_openai_provider(base_dir: Path) -> None:
 
 def _git_service_for(base_dir: Path) -> Mock:
     git_service = Mock()
-    git_service.read_file.side_effect = lambda workflow_path, branch: Path(workflow_path).read_text(
-        encoding="utf-8"
-    )
+
+    def _list_files(branch: str, path_prefix: str) -> list[str]:
+        del branch
+        root = base_dir / path_prefix.rstrip("/")
+        if not root.exists():
+            return []
+        return sorted(
+            path.relative_to(base_dir).as_posix()
+            for path in root.rglob("*")
+            if path.is_file() and path.suffix in {".yaml", ".yml"}
+        )
+
+    def _read_file(workflow_path: str, branch: str) -> str:
+        del branch
+        path = Path(workflow_path)
+        if not path.is_absolute():
+            path = base_dir / workflow_path
+        return path.read_text(encoding="utf-8")
+
+    git_service.read_file.side_effect = _read_file
     git_service.get_sha.side_effect = lambda branch, workflow_path: "8" * 40
+    git_service.list_files.side_effect = _list_files
     return git_service
 
 

--- a/apps/api/tests/test_run929_workflow_input_redaction_integration.py
+++ b/apps/api/tests/test_run929_workflow_input_redaction_integration.py
@@ -351,12 +351,24 @@ def _git_service_for(base_dir: Path) -> Mock:
     git_service = Mock()
     git_service.repo_path = str(base_dir)
 
+    def _list_files(branch: str, path_prefix: str) -> list[str]:
+        del branch
+        root = base_dir / path_prefix.rstrip("/")
+        if not root.exists():
+            return []
+        return sorted(
+            path.relative_to(base_dir).as_posix()
+            for path in root.rglob("*")
+            if path.is_file() and path.suffix in {".yaml", ".yml"}
+        )
+
     def _read_file(workflow_path: str, branch: str) -> str:
         path = Path(workflow_path)
         if not path.is_absolute():
             path = base_dir / workflow_path
         return path.read_text(encoding="utf-8")
 
+    git_service.list_files.side_effect = _list_files
     git_service.read_file.side_effect = _read_file
     git_service.get_sha.side_effect = lambda branch, workflow_path: "9" * 40
     return git_service

--- a/apps/api/tests/test_run971_spa_catch_all.py
+++ b/apps/api/tests/test_run971_spa_catch_all.py
@@ -1,0 +1,103 @@
+"""Red tests for RUN-971: constrain SPA catch-all to the configured static root."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+import pytest
+
+
+@pytest.fixture()
+def spa_client(monkeypatch):
+    """Build a fresh app whose catch-all serves from a test-controlled static root."""
+    from runsight_api import main as main_module
+
+    @asynccontextmanager
+    async def noop_lifespan(app):
+        yield
+
+    def _make(static_dir: Path) -> TestClient:
+        monkeypatch.setenv("RUNSIGHT_STATIC_DIR", str(static_dir))
+        monkeypatch.setattr(main_module, "lifespan", noop_lifespan)
+        return TestClient(main_module.create_app(), raise_server_exceptions=False)
+
+    return _make
+
+
+@pytest.fixture()
+def static_site(tmp_path):
+    """Create a minimal frontend build tree for catch-all route tests."""
+    static_dir = tmp_path / "frontend"
+    static_dir.mkdir()
+    index_bytes = b"<html><body>runsight spa shell</body></html>"
+    (static_dir / "index.html").write_bytes(index_bytes)
+    return static_dir, index_bytes
+
+
+def _assert_rejected(response, *, index_bytes: bytes) -> None:
+    assert response.status_code == 404, (
+        f"Expected SPA catch-all to reject with 404, got {response.status_code} "
+        f"with body {response.content!r}"
+    )
+    assert response.content != index_bytes
+
+
+class TestSpaCatchAllStaticRoot:
+    def test_serves_real_in_root_file_reached_by_catch_all(self, spa_client, static_site):
+        static_dir, _index_bytes = static_site
+        docs_dir = static_dir / "docs"
+        docs_dir.mkdir()
+        file_bytes = b"catch-all served docs"
+        (docs_dir / "guide.txt").write_bytes(file_bytes)
+
+        with spa_client(static_dir) as client:
+            response = client.get("/docs/guide.txt")
+
+        assert response.status_code == 200
+        assert response.content == file_bytes
+
+    def test_serves_index_for_nested_spa_route_without_backing_file(self, spa_client, static_site):
+        static_dir, index_bytes = static_site
+
+        with spa_client(static_dir) as client:
+            response = client.get("/app/settings/profile")
+
+        assert response.status_code == 200
+        assert response.content == index_bytes
+
+    def test_returns_404_for_percent_encoded_traversal(self, spa_client, static_site):
+        static_dir, index_bytes = static_site
+        outside_bytes = b"outside static root"
+        (static_dir.parent / "secret.txt").write_bytes(outside_bytes)
+
+        with spa_client(static_dir) as client:
+            response = client.get("/%2e%2e/secret.txt")
+
+        _assert_rejected(response, index_bytes=index_bytes)
+
+    def test_returns_404_for_sibling_prefix_escape(self, spa_client, static_site):
+        static_dir, index_bytes = static_site
+        sibling = static_dir.parent / f"{static_dir.name}-escape"
+        sibling.mkdir()
+        (sibling / "secret.txt").write_bytes(b"sibling prefix escape")
+
+        with spa_client(static_dir) as client:
+            response = client.get(f"/%2e%2e/{sibling.name}/secret.txt")
+
+        _assert_rejected(response, index_bytes=index_bytes)
+
+    def test_returns_404_for_symlink_escape(self, spa_client, static_site):
+        static_dir, index_bytes = static_site
+        outside_dir = static_dir.parent / "outside"
+        outside_dir.mkdir()
+        (outside_dir / "secret.txt").write_bytes(b"symlink escape")
+
+        link = static_dir / "linked-outside"
+        link.symlink_to(outside_dir, target_is_directory=True)
+
+        with spa_client(static_dir) as client:
+            response = client.get("/linked-outside/secret.txt")
+
+        _assert_rejected(response, index_bytes=index_bytes)

--- a/apps/api/tests/transport/test_git_security.py
+++ b/apps/api/tests/transport/test_git_security.py
@@ -73,6 +73,12 @@ client = TestClient(app)
 _PATH_REJECTION_KEYWORD = "path"
 
 
+def _error_detail(response) -> str:
+    """Return the lowercase error/detail payload for assertion helpers."""
+    body = response.json()
+    return body.get("error", body.get("detail", "")).lower()
+
+
 # ===================================================================
 # Path Traversal Prevention
 # ===================================================================
@@ -160,6 +166,104 @@ class TestPathTraversal:
             },
         )
         assert resp.status_code == 400
+
+
+# ===================================================================
+# Path Ancestry Validation
+# ===================================================================
+
+
+class TestPathAncestryValidation:
+    """Resolved-path ancestry decisions must reject prefix-based escapes."""
+
+    def test_validate_file_path_allows_absolute_path_inside_project_root(self, git_repo):
+        """Absolute paths inside the repo stay allowed by the current API policy."""
+        from runsight_api.transport.routers.git import _validate_file_path
+
+        tracked = git_repo / "README.md"
+
+        _validate_file_path(str(tracked))
+
+    def test_validate_file_path_rejects_absolute_sibling_prefix_path(self, git_repo):
+        """A resolved sibling like repo-escape must not pass ancestry validation."""
+        from runsight_api.domain.errors import InputValidationError
+        from runsight_api.transport.routers.git import _validate_file_path
+
+        sibling = git_repo.parent / f"{git_repo.name}-escape"
+        sibling.mkdir()
+        outside = sibling / "secret.txt"
+        outside.write_text("outside")
+
+        with pytest.raises(InputValidationError, match="path"):
+            _validate_file_path(str(outside))
+
+    def test_validate_file_path_rejects_symlink_to_sibling_prefix_directory(self, git_repo):
+        """A symlinked directory that resolves to repo-escape must be rejected."""
+        from runsight_api.domain.errors import InputValidationError
+        from runsight_api.transport.routers.git import _validate_file_path
+
+        sibling = git_repo.parent / f"{git_repo.name}-escape"
+        sibling.mkdir()
+        outside = sibling / "secret.txt"
+        outside.write_text("outside")
+
+        link = git_repo / "custom" / "workflows" / "escape-link"
+        link.symlink_to(sibling, target_is_directory=True)
+
+        with pytest.raises(InputValidationError, match="path"):
+            _validate_file_path("custom/workflows/escape-link/secret.txt")
+
+    def test_commit_rejects_absolute_sibling_prefix_path(self, git_repo):
+        """POST /api/git/commit must reject sibling-prefix absolute inputs up front."""
+        sibling = git_repo.parent / f"{git_repo.name}-escape"
+        sibling.mkdir()
+        outside = sibling / "secret.txt"
+        outside.write_text("outside")
+
+        resp = client.post(
+            "/api/git/commit",
+            json={
+                "message": "reject sibling prefix",
+                "files": [str(outside)],
+            },
+        )
+
+        assert resp.status_code == 400
+        assert _PATH_REJECTION_KEYWORD in _error_detail(resp)
+
+    def test_file_read_accepts_in_bounds_relative_path(self, git_repo):
+        """GET /api/git/file still reads a normal tracked file within the repo."""
+        resp = client.get(
+            "/api/git/file",
+            params={
+                "ref": "HEAD",
+                "path": "README.md",
+            },
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["content"] == "init"
+
+    def test_file_read_rejects_symlink_to_sibling_prefix_directory(self, git_repo):
+        """GET /api/git/file must reject symlink escapes before touching git."""
+        sibling = git_repo.parent / f"{git_repo.name}-escape"
+        sibling.mkdir()
+        outside = sibling / "secret.txt"
+        outside.write_text("outside")
+
+        link = git_repo / "custom" / "workflows" / "escape-link"
+        link.symlink_to(sibling, target_is_directory=True)
+
+        resp = client.get(
+            "/api/git/file",
+            params={
+                "ref": "HEAD",
+                "path": "custom/workflows/escape-link/secret.txt",
+            },
+        )
+
+        assert resp.status_code == 400
+        assert _PATH_REJECTION_KEYWORD in _error_detail(resp)
 
 
 # ===================================================================

--- a/apps/api/tests/transport/test_sse_stream.py
+++ b/apps/api/tests/transport/test_sse_stream.py
@@ -69,6 +69,38 @@ def _parse_sse_events(raw: str) -> list[dict]:
     return events
 
 
+def _context_audit_message(run_id: str) -> dict:
+    return {
+        "schema_version": "context_audit.v1",
+        "event": "context_resolution",
+        "run_id": run_id,
+        "workflow_name": "child_workflow",
+        "node_id": "resolve_context",
+        "block_type": "linear",
+        "access": "declared",
+        "mode": "strict",
+        "records": [
+            {
+                "input_name": "query",
+                "from_ref": "results.query",
+                "namespace": "results",
+                "source": "query",
+                "field_path": "query",
+                "status": "resolved",
+                "severity": "allow",
+                "value_type": "str",
+                "preview": "bounded preview",
+                "reason": None,
+                "internal": False,
+            }
+        ],
+        "resolved_count": 1,
+        "denied_count": 0,
+        "warning_count": 0,
+        "emitted_at": "2026-04-23T00:00:00+00:00",
+    }
+
+
 # ---------------------------------------------------------------------------
 # 1. SSE endpoint returns text/event-stream content type
 # ---------------------------------------------------------------------------
@@ -368,6 +400,56 @@ class TestLateJoinReplay:
                 "parent queue traffic must not bleed into the child stream."
             )
             assert events[0]["data"]["run_id"] == child_run_id
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_child_context_resolution_replay_does_not_switch_to_live_parent_queue(self):
+        """Child context-audit replay must not be followed by parent live traffic."""
+        from runsight_api.logic.observers.streaming_observer import StreamingObserver
+        from runsight_api.logic.services.execution_service import ExecutionService
+
+        child_run_id = "run_sse_child_context"
+        parent_run_id = "run_sse_parent_context"
+
+        mock_run_service = Mock()
+        mock_run_service.get_run.return_value = _make_mock_run(run_id=child_run_id)
+
+        replay_log = Mock()
+        replay_log.id = 12
+        replay_log.message = json.dumps(_context_audit_message(child_run_id))
+        replay_log.level = "trace"
+        replay_log.timestamp = 1713790803.0
+        mock_run_service.get_run_logs.return_value = [replay_log]
+
+        execution_service = ExecutionService(
+            run_repo=Mock(),
+            workflow_repo=Mock(),
+            provider_repo=Mock(),
+        )
+        parent = StreamingObserver(run_id=parent_run_id)
+        child = parent.clone_for_child_run(child_run_id=child_run_id)
+        execution_service._streams.register(parent_run_id, parent)
+        execution_service._streams.register(child_run_id, child)
+
+        parent.on_block_start("parent_workflow", "delegate", "workflow")
+        execution_service._streams.close_stream(child_run_id, observer=child)
+
+        app.dependency_overrides[get_run_service] = lambda: mock_run_service
+        app.dependency_overrides[get_execution_service] = lambda: execution_service
+
+        try:
+            with client.stream("GET", f"/api/runs/{child_run_id}/stream") as response:
+                body = response.read().decode()
+            events = _parse_sse_events(body)
+
+            assert [event["event"] for event in events] == ["context_resolution"], (
+                "A child context-resolution replay stream must not switch into live parent "
+                "queue traffic."
+            )
+            assert events[0]["data"]["run_id"] == child_run_id
+            assert all(
+                queued["event"] != "context_resolution" for queued in list(parent.queue._queue)
+            ), "Parent live queue must remain silent for child context_resolution traffic."
         finally:
             app.dependency_overrides.clear()
 

--- a/apps/api/tests/transport/test_sse_stream.py
+++ b/apps/api/tests/transport/test_sse_stream.py
@@ -324,6 +324,53 @@ class TestLateJoinReplay:
         finally:
             app.dependency_overrides.clear()
 
+    def test_child_late_join_replay_does_not_switch_to_live_parent_queue(self):
+        """A late child subscriber must stay on replayed child history, not parent live traffic."""
+        from runsight_api.logic.observers.streaming_observer import StreamingObserver
+        from runsight_api.logic.services.execution_service import ExecutionService
+
+        child_run_id = "run_sse_child"
+        parent_run_id = "run_sse_parent"
+
+        mock_run_service = Mock()
+        mock_run_service.get_run.return_value = _make_mock_run(run_id=child_run_id)
+
+        replay_log = Mock()
+        replay_log.id = 11
+        replay_log.message = json.dumps({"event": "workflow_complete", "run_id": child_run_id})
+        replay_log.level = "info"
+        replay_log.timestamp = 1713790802.0
+        mock_run_service.get_run_logs.return_value = [replay_log]
+
+        execution_service = ExecutionService(
+            run_repo=Mock(),
+            workflow_repo=Mock(),
+            provider_repo=Mock(),
+        )
+        parent = StreamingObserver(run_id=parent_run_id)
+        child = parent.clone_for_child_run(child_run_id=child_run_id)
+        execution_service._streams.register(parent_run_id, parent)
+        execution_service._streams.register(child_run_id, child)
+
+        parent.on_block_start("parent_workflow", "delegate", "workflow")
+        execution_service._streams.close_stream(child_run_id, observer=child)
+
+        app.dependency_overrides[get_run_service] = lambda: mock_run_service
+        app.dependency_overrides[get_execution_service] = lambda: execution_service
+
+        try:
+            with client.stream("GET", f"/api/runs/{child_run_id}/stream") as response:
+                body = response.read().decode()
+            events = _parse_sse_events(body)
+
+            assert [event["event"] for event in events] == ["replay"], (
+                "A late child subscriber should receive persisted child replay only; live "
+                "parent queue traffic must not bleed into the child stream."
+            )
+            assert events[0]["data"]["run_id"] == child_run_id
+        finally:
+            app.dependency_overrides.clear()
+
 
 # ---------------------------------------------------------------------------
 # 6. Cleanup after completion

--- a/apps/gui/src/features/dashboard/__tests__/activeRunsSection.test.ts
+++ b/apps/gui/src/features/dashboard/__tests__/activeRunsSection.test.ts
@@ -1,314 +1,395 @@
-/**
- * RED-TEAM tests for RUN-339: A3 — Active Runs section with SSE (end-to-end).
- *
- * These tests verify the structural acceptance criteria by reading source
- * files and asserting observable properties:
- *
- * AC1: Dashboard imports and uses StatusDot component
- * AC2: "ACTIVE RUNS" section label exists in the dashboard
- * AC3: useActiveRuns hook exists and queries with status filter
- * AC4: StatusDot has animate="pulse" for running runs
- * AC5: Click navigates to /runs/:id
- * AC6: Section hidden when no active runs (conditional rendering)
- * AC7: useNavigate used for run click navigation
- * AC9: Run removed from active list when completed/failed via SSE
- *
- * Expected failures (current state):
- *   - DashboardOrOnboarding.tsx is a minimal 30-line shell with no active runs section
- *   - No useActiveRuns hook exists in queries/runs.ts
- *   - No StatusDot import in the dashboard
- *   - No "ACTIVE RUNS" label anywhere
- */
+// @vitest-environment jsdom
 
-import { describe, it, expect } from "vitest";
-import { readFileSync, readdirSync } from "node:fs";
-import { resolve } from "node:path";
+import React from "react";
+import { act, cleanup, screen, waitFor, within } from "@testing-library/react";
+import type { RunListResponse, RunResponse } from "@runsight/shared/zod";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderWithProviders } from "@/test/testUtils";
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
+const harness = vi.hoisted(() => ({
+  listRuns: vi.fn<(params?: unknown) => Promise<RunListResponse>>(),
+}));
 
-const SRC_DIR = resolve(__dirname, "../../..");
-const DASHBOARD_COMPONENTS_DIR = resolve(SRC_DIR, "features/dashboard/components");
+vi.mock("@/api/runs", () => ({
+  runsApi: {
+    listRuns: (...args: unknown[]) => harness.listRuns(...args),
+  },
+}));
 
-function readSource(relativePath: string): string {
-  const main = readFileSync(resolve(SRC_DIR, relativePath), "utf-8");
-  if (relativePath.includes("DashboardOrOnboarding")) {
-    try {
-      const subFiles = readdirSync(DASHBOARD_COMPONENTS_DIR).filter((f) => f.endsWith(".tsx"));
-      const subSource = subFiles.map((f) => readFileSync(resolve(DASHBOARD_COMPONENTS_DIR, f), "utf-8")).join("\n");
-      return main + "\n" + subSource;
-    } catch { /* components dir may not exist in older states */ }
+vi.mock("@/queries/workflows", () => ({
+  useWorkflows: () => ({
+    data: { items: [{ id: "wf_root", name: "Root Flow" }] },
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+vi.mock("@/queries/dashboard", () => ({
+  useDashboardKPIs: () => ({
+    data: {
+      runs_today: 2,
+      cost_today_usd: 9.5,
+      eval_pass_rate: 0.8,
+      regressions: 0,
+      runs_previous_period: 1,
+      cost_previous_period_usd: 4.25,
+      eval_pass_rate_previous_period: 0.7,
+      regressions_previous_period: 0,
+    },
+    isPending: false,
+    isError: false,
+    refetch: vi.fn(),
+  }),
+  useAttentionItems: () => ({ data: { items: [] } }),
+  useRecentRuns: () => ({ data: { items: [] } }),
+}));
+
+vi.mock("../useNewWorkflow", () => ({
+  useNewWorkflow: () => ({
+    handleNewWorkflow: vi.fn(),
+    isPending: false,
+  }),
+}));
+
+vi.mock("@/components/shared/PageHeader", () => ({
+  PageHeader: ({
+    title,
+    subtitle,
+    actions,
+  }: {
+    title: string;
+    subtitle?: string;
+    actions?: React.ReactNode;
+  }) =>
+    React.createElement("header", null, [
+      React.createElement("h1", { key: "title" }, title),
+      subtitle ? React.createElement("p", { key: "subtitle" }, subtitle) : null,
+      React.createElement("div", { key: "actions" }, actions),
+    ]),
+}));
+
+vi.mock("@runsight/ui/empty-state", () => ({
+  EmptyState: ({
+    title,
+    description,
+  }: {
+    title: string;
+    description: string;
+  }) =>
+    React.createElement("section", null, [
+      React.createElement("h2", { key: "title" }, title),
+      React.createElement("p", { key: "description" }, description),
+    ]),
+}));
+
+vi.mock("@runsight/ui/button", () => ({
+  Button: ({
+    children,
+    onClick,
+    disabled,
+    type,
+  }: {
+    children?: React.ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+    type?: "button" | "submit" | "reset";
+  }) =>
+    React.createElement(
+      "button",
+      {
+        type: type ?? "button",
+        onClick,
+        disabled,
+      },
+      children,
+    ),
+}));
+
+vi.mock("@runsight/ui/card", () => ({
+  Card: ({ children }: { children?: React.ReactNode }) => React.createElement("div", null, children),
+}));
+
+vi.mock("@runsight/ui/status-dot", () => ({
+  StatusDot: () => React.createElement("span", null, "status-dot"),
+}));
+
+vi.mock("@runsight/ui/skeleton", () => ({
+  Skeleton: () => React.createElement("div", null, "skeleton"),
+}));
+
+vi.mock("@runsight/ui/table", () => ({
+  Table: ({ children }: { children?: React.ReactNode }) =>
+    React.createElement("table", null, children),
+  TableBody: ({ children }: { children?: React.ReactNode }) =>
+    React.createElement("tbody", null, children),
+  TableCell: ({ children }: { children?: React.ReactNode }) =>
+    React.createElement("td", null, children),
+  TableHead: ({ children }: { children?: React.ReactNode }) =>
+    React.createElement("th", null, children),
+  TableHeader: ({ children }: { children?: React.ReactNode }) =>
+    React.createElement("thead", null, children),
+  TableRow: ({ children, onClick }: { children?: React.ReactNode; onClick?: () => void }) =>
+    React.createElement("tr", { onClick }, children),
+}));
+
+vi.mock("../components/DashboardKPIs", () => ({
+  DashboardKPIs: () => React.createElement("section", null, "dashboard-kpis"),
+}));
+
+vi.mock("../components/AttentionItems", () => ({
+  AttentionItems: () => React.createElement("section", null, "attention-items"),
+}));
+
+vi.mock("lucide-react", () => ({
+  Plus: () => React.createElement("span", { "aria-hidden": "true" }, "+"),
+  Workflow: () => React.createElement("span", { "aria-hidden": "true" }, "wf"),
+  Play: () => React.createElement("span", { "aria-hidden": "true" }, "play"),
+}));
+
+import { Component as DashboardOrOnboarding } from "../DashboardOrOnboarding";
+
+type EventSourceListener = (event: MessageEvent) => void;
+
+const eventSources: MockEventSource[] = [];
+
+class MockEventSource {
+  readonly url: string;
+  readonly close = vi.fn();
+  private readonly listeners = new Map<string, EventSourceListener[]>();
+
+  constructor(url: string) {
+    this.url = url;
+    eventSources.push(this);
   }
-  return main;
+
+  addEventListener(type: string, listener: EventSourceListener) {
+    const existing = this.listeners.get(type) ?? [];
+    this.listeners.set(type, [...existing, listener]);
+  }
+
+  emit(type: string, payload: unknown) {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(new MessageEvent(type, { data: JSON.stringify(payload) }));
+    }
+  }
 }
 
-// ---------------------------------------------------------------------------
-// File paths
-// ---------------------------------------------------------------------------
+function makeRun(overrides: Partial<RunResponse>): RunResponse {
+  return {
+    id: "run_root",
+    workflow_id: "wf_root",
+    workflow_name: "Root Flow",
+    status: "running",
+    error: null,
+    started_at: 1_710_000_000,
+    completed_at: null,
+    duration_seconds: null,
+    total_cost_usd: 1.25,
+    total_tokens: 123,
+    created_at: 1_710_000_100,
+    branch: "main",
+    source: "manual",
+    commit_sha: "sha-root",
+    run_number: 42,
+    eval_pass_pct: null,
+    eval_score_avg: null,
+    regression_count: 0,
+    regression_types: [],
+    warnings: [],
+    node_summary: null,
+    parent_run_id: null,
+    root_run_id: null,
+    depth: 0,
+    workflow_inputs: null,
+    workflow_input_schema: null,
+    ...overrides,
+  };
+}
 
-const DASHBOARD_PATH = "features/dashboard/DashboardOrOnboarding.tsx";
-const RUNS_QUERIES_PATH = "queries/runs.ts";
-// ===========================================================================
-// 1. useActiveRuns hook exists (AC3)
-// ===========================================================================
+function buildRunList(items: RunResponse[]): RunListResponse {
+  return {
+    items,
+    total: items.length,
+    offset: 0,
+    limit: 50,
+  };
+}
 
-describe("useActiveRuns hook (AC3: queries with status filter)", () => {
-  let source: string;
+function rootRun(overrides: Partial<RunResponse> = {}): RunResponse {
+  return makeRun(overrides);
+}
 
-  it("exports a useActiveRuns function from queries/runs.ts", () => {
-    source = readSource(RUNS_QUERIES_PATH);
-    expect(source).toMatch(/export\s+function\s+useActiveRuns/);
+function secondRootRun(overrides: Partial<RunResponse> = {}): RunResponse {
+  return makeRun({
+    id: "run_root_2",
+    workflow_id: "wf_root_2",
+    workflow_name: "Second Root Flow",
+    run_number: 43,
+    total_cost_usd: 2.5,
+    created_at: 1_710_000_150,
+    ...overrides,
+  });
+}
+
+function childRun(overrides: Partial<RunResponse> = {}): RunResponse {
+  return makeRun({
+    id: "run_child",
+    workflow_id: "wf_child",
+    workflow_name: "Child Flow",
+    run_number: 99,
+    total_cost_usd: 0.4,
+    created_at: 1_710_000_200,
+    parent_run_id: "run_root",
+    root_run_id: "run_root",
+    depth: 1,
+    ...overrides,
+  });
+}
+
+function renderDashboard() {
+  return renderWithProviders(React.createElement(DashboardOrOnboarding));
+}
+
+async function waitForInitialActiveRunsLoad(expectedWorkflowNames: string[]) {
+  await waitFor(() => {
+    expect(screen.queryByText("skeleton")).toBeNull();
+    for (const workflowName of expectedWorkflowNames) {
+      expect(screen.getByText(workflowName)).toBeTruthy();
+    }
+  });
+}
+
+function getRunRow(workflowName: string): HTMLTableRowElement {
+  const row = screen.getByText(workflowName).closest("tr");
+  expect(row).not.toBeNull();
+  return row as HTMLTableRowElement;
+}
+
+function expectRunCost(workflowName: string, formattedCost: string) {
+  expect(within(getRunRow(workflowName)).getByText(formattedCost)).toBeTruthy();
+}
+
+function findStream(runId: string): MockEventSource {
+  const source = eventSources.find((candidate) => candidate.url === `/api/runs/${runId}/stream`);
+  expect(source).toBeTruthy();
+  return source as MockEventSource;
+}
+
+describe("RUN-974 active runs dashboard behavior", () => {
+  let activeRunsData: RunResponse[] = [];
+
+  beforeEach(() => {
+    activeRunsData = [];
+    harness.listRuns.mockReset();
+    harness.listRuns.mockImplementation(async () => buildRunList(activeRunsData));
+    eventSources.length = 0;
+    vi.stubGlobal("EventSource", MockEventSource as unknown as typeof EventSource);
   });
 
-  it("useActiveRuns passes status filter params (running, pending)", () => {
-    source = readSource(RUNS_QUERIES_PATH);
-    // Should construct query params with status=running and status=pending
-    expect(source).toMatch(/status/);
-    expect(source).toMatch(/running/);
-    expect(source).toMatch(/pending/);
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
   });
 
-  it("useActiveRuns filters to production sources (manual, webhook, schedule)", () => {
-    source = readSource(RUNS_QUERIES_PATH);
-    expect(source).toMatch(/source/);
-    expect(source).toMatch(/manual/);
-    expect(source).toMatch(/webhook/);
-    expect(source).toMatch(/schedule/);
+  it("shows only eligible root runs and opens one stream per root run", async () => {
+    activeRunsData = [rootRun(), secondRootRun(), childRun()];
+
+    renderDashboard();
+    await waitForInitialActiveRunsLoad(["Root Flow", "Second Root Flow"]);
+
+    expect(screen.queryByText("Child Flow")).toBeNull();
+    expect(eventSources.map((source) => source.url).sort()).toEqual([
+      "/api/runs/run_root/stream",
+      "/api/runs/run_root_2/stream",
+    ]);
   });
 
-  it("useActiveRuns uses a polling interval (refetchInterval)", () => {
-    source = readSource(RUNS_QUERIES_PATH);
-    // The hook should poll at an interval (e.g. 5000ms)
-    // Look for refetchInterval in the context of useActiveRuns
-    const hookMatch = source.match(
-      /function\s+useActiveRuns[\s\S]*?^}/m
-    );
-    expect(hookMatch).not.toBeNull();
-    expect(hookMatch![0]).toMatch(/refetchInterval/);
-  });
-});
+  it.each(["run_completed", "run_failed"] as const)(
+    "removes a root row through the %s refetch path without promoting child runs",
+    async (eventName) => {
+      activeRunsData = [rootRun()];
 
-// ===========================================================================
-// 2. Dashboard imports StatusDot (AC1)
-// ===========================================================================
+      renderDashboard();
+      await waitForInitialActiveRunsLoad(["Root Flow"]);
 
-describe("Dashboard imports StatusDot (AC1)", () => {
-  let source: string;
+      const rootSource = findStream("run_root");
+      activeRunsData = [childRun()];
 
-  it("imports StatusDot from components/ui/status-dot", () => {
-    source = readSource(DASHBOARD_PATH);
-    expect(source).toMatch(/import.*StatusDot.*from/);
-    expect(source).toMatch(/status-dot/);
-  });
+      act(() => {
+        rootSource.emit(eventName, { run_id: "run_root" });
+      });
 
-  it("uses StatusDot in JSX", () => {
-    source = readSource(DASHBOARD_PATH);
-    expect(source).toMatch(/<StatusDot\b/);
-  });
-});
+      await waitFor(() => {
+        expect(harness.listRuns.mock.calls.length).toBeGreaterThanOrEqual(2);
+        expect(screen.queryByText("Root Flow")).toBeNull();
+        expect(rootSource.close).toHaveBeenCalledTimes(1);
+      });
 
-// ===========================================================================
-// 3. "ACTIVE RUNS" section label (AC2)
-// ===========================================================================
+      expect(screen.queryByText("Child Flow")).toBeNull();
+      expect(eventSources.map((source) => source.url)).toEqual(["/api/runs/run_root/stream"]);
+    },
+  );
 
-describe("Active Runs section label (AC2)", () => {
-  let source: string;
+  it("updates rendered cost after a cost-bearing node_completed refetch without surfacing child runs", async () => {
+    activeRunsData = [rootRun({ total_cost_usd: 1.25 })];
 
-  it("contains Active Runs text in the dashboard", () => {
-    source = readSource(DASHBOARD_PATH);
-    expect(source).toMatch(/Active Runs/);
-  });
+    renderDashboard();
+    await waitForInitialActiveRunsLoad(["Root Flow"]);
 
-  it("uses monospace and muted styling for the label", () => {
-    source = readSource(DASHBOARD_PATH);
-    // The label should have mono font and muted text color per spec
-    expect(source).toMatch(/font-mono|mono/);
-    expect(source).toMatch(/text-muted|--text-muted/);
-  });
-});
+    expectRunCost("Root Flow", "$1.25");
 
-// ===========================================================================
-// 4. StatusDot pulses for running runs (AC4)
-// ===========================================================================
+    const rootSource = findStream("run_root");
+    activeRunsData = [rootRun({ total_cost_usd: 1.75 }), childRun({ total_cost_usd: 0.9 })];
 
-describe("StatusDot animate='pulse' for running (AC4)", () => {
-  let source: string;
+    act(() => {
+      rootSource.emit("node_completed", { cost_usd: 0.5 });
+    });
 
-  it("passes animate='pulse' to StatusDot for running status", () => {
-    source = readSource(DASHBOARD_PATH);
-    // Should have animate="pulse" conditional on running status
-    expect(source).toMatch(/animate\s*=\s*["'{].*pulse/);
+    await waitFor(() => {
+      expect(harness.listRuns.mock.calls.length).toBeGreaterThanOrEqual(2);
+      expectRunCost("Root Flow", "$1.75");
+    });
+
+    expect(screen.queryByText("Child Flow")).toBeNull();
+    expect(eventSources.map((source) => source.url)).toEqual(["/api/runs/run_root/stream"]);
   });
 
-  it("does NOT pulse for pending status", () => {
-    source = readSource(DASHBOARD_PATH);
-    // For pending runs, animate should be "none" or absent — not "pulse"
-    // We check that there's a conditional: running → pulse, pending → something else
-    // This means there should be a ternary or condition around pulse
-    const hasPulseConditional =
-      /running.*pulse|status.*===.*["']running["'].*pulse/.test(source);
-    expect(
-      hasPulseConditional,
-      "Expected pulse animation to be conditional on running status"
-    ).toBe(true);
-  });
-});
+  it("ignores replay, context_resolution, node_eval_complete, and child_run_completed when the data does not change", async () => {
+    activeRunsData = [rootRun()];
 
-// ===========================================================================
-// 5. Click navigates to run detail (AC5, AC7)
-// ===========================================================================
+    renderDashboard();
+    await waitForInitialActiveRunsLoad(["Root Flow"]);
 
-describe("Click navigates to /runs/:id (AC5, AC7)", () => {
-  let source: string;
+    const rootSource = findStream("run_root");
+    const initialCalls = harness.listRuns.mock.calls.length;
 
-  it("imports useNavigate from react-router", () => {
-    source = readSource(DASHBOARD_PATH);
-    expect(source).toMatch(/import.*useNavigate.*from\s*["']react-router["']/);
+    act(() => {
+      rootSource.emit("replay", { run_id: "run_root" });
+      rootSource.emit("context_resolution", { run_id: "run_root" });
+      rootSource.emit("node_eval_complete", { run_id: "run_root" });
+      rootSource.emit("child_run_completed", { run_id: "run_child" });
+    });
+
+    expectRunCost("Root Flow", "$1.25");
+    expect(harness.listRuns).toHaveBeenCalledTimes(initialCalls);
+    expect(screen.queryByText("Child Flow")).toBeNull();
+    expect(eventSources.map((source) => source.url)).toEqual(["/api/runs/run_root/stream"]);
   });
 
-  it("navigates to /runs/:id using the run id", () => {
-    source = readSource(DASHBOARD_PATH);
-    expect(source).toMatch(/\/runs\/\$\{.*run\.id|navigate\(\s*`\/runs\/\$\{run\.id\}`/);
-  });
+  it("closes root streams on unmount", async () => {
+    activeRunsData = [rootRun(), secondRootRun()];
 
-  it("has an onClick handler on the active run row", () => {
-    source = readSource(DASHBOARD_PATH);
-    // The run row needs a click handler that navigates — there should be at
-    // least two onClick handlers: one for New Workflow and one for run rows.
-    const matches = source.match(/onClick/g);
-    expect(matches).not.toBeNull();
-    expect(matches!.length).toBeGreaterThanOrEqual(2);
-  });
-});
+    const view = renderDashboard();
+    await waitForInitialActiveRunsLoad(["Root Flow", "Second Root Flow"]);
 
-// ===========================================================================
-// 6. Conditional rendering — hidden when no active runs (AC6)
-// ===========================================================================
+    expect(eventSources.map((source) => source.url).sort()).toEqual([
+      "/api/runs/run_root/stream",
+      "/api/runs/run_root_2/stream",
+    ]);
 
-describe("Section hidden when no active runs (AC6)", () => {
-  let source: string;
+    view.unmount();
 
-  it("imports useActiveRuns hook in the dashboard", () => {
-    source = readSource(DASHBOARD_PATH);
-    expect(source).toMatch(/import.*useActiveRuns.*from/);
-  });
-
-  it("conditionally renders the active runs section", () => {
-    source = readSource(DASHBOARD_PATH);
-    // Should have conditional rendering: check for array length or data existence
-    // Patterns like: {activeRuns?.length > 0 && ...} or {data?.items?.length ? ... : null}
-    const hasConditional =
-      /activeRuns.*&&|\.length\s*[>!]|\.items\?\.length|data\s*&&/.test(
-        source
-      );
-    expect(
-      hasConditional,
-      "Expected conditional rendering based on active runs data"
-    ).toBe(true);
-  });
-});
-
-// ===========================================================================
-// 7. Dashboard uses useActiveRuns (wiring check)
-// ===========================================================================
-
-describe("Dashboard wiring (useActiveRuns integration)", () => {
-  let source: string;
-
-  it("calls useActiveRuns() in the component", () => {
-    source = readSource(DASHBOARD_PATH);
-    expect(source).toMatch(/useActiveRuns\s*\(/);
-  });
-
-  it("displays workflow name for each active run", () => {
-    source = readSource(DASHBOARD_PATH);
-    // Should render the workflow_name from the run
-    expect(source).toMatch(/workflow_name/);
-  });
-
-  it("displays elapsed time for each active run", () => {
-    source = readSource(DASHBOARD_PATH);
-    // Should have elapsed time logic — referencing started_at or elapsed
-    const hasElapsed = /elapsed|started_at|duration/.test(source);
-    expect(
-      hasElapsed,
-      "Expected elapsed time display referencing started_at or elapsed"
-    ).toBe(true);
-  });
-
-  it("displays cost for each active run", () => {
-    source = readSource(DASHBOARD_PATH);
-    // Should reference total_cost_usd or cost
-    expect(source).toMatch(/total_cost_usd|cost/);
-  });
-});
-
-// ===========================================================================
-// 8. SSE subscription removes runs on completion/failure (AC9)
-// ===========================================================================
-
-describe("SSE removes completed/failed runs from active list (AC9)", () => {
-  let dashSource: string;
-  let queriesSource: string;
-
-  it("references EventSource or SSE stream in dashboard or queries layer", () => {
-    dashSource = readSource(DASHBOARD_PATH);
-    queriesSource = readSource(RUNS_QUERIES_PATH);
-    const combined = dashSource + queriesSource;
-    // There must be an EventSource instantiation or a /stream endpoint reference
-    const hasSSE = /EventSource|\/stream|event-source|useSSE|useSse/.test(
-      combined
-    );
-    expect(
-      hasSSE,
-      "Expected EventSource or /stream reference for SSE subscription"
-    ).toBe(true);
-  });
-
-  it("connects SSE per active run (uses run id in stream URL)", () => {
-    dashSource = readSource(DASHBOARD_PATH);
-    queriesSource = readSource(RUNS_QUERIES_PATH);
-    const combined = dashSource + queriesSource;
-    // The SSE connection should be per-run, referencing the run's id in the URL
-    // e.g. /api/v1/runs/${run.id}/stream or similar pattern
-    const hasPerRunStream =
-      /runs\/\$\{.*\.id\}\/stream|runs\/\$\{.*id\}\/stream|run\.id.*stream|runId.*stream/.test(
-        combined
-      );
-    expect(
-      hasPerRunStream,
-      "Expected per-run SSE connection using run id in the stream URL"
-    ).toBe(true);
-  });
-
-  it("handles run_completed or completed event to remove run from list", () => {
-    dashSource = readSource(DASHBOARD_PATH);
-    queriesSource = readSource(RUNS_QUERIES_PATH);
-    const combined = dashSource + queriesSource;
-    // Should listen for a completed event and remove/filter the run
-    const handlesCompleted =
-      /run_completed|["']completed["'].*remove|completed.*filter|onmessage.*completed|addEventListener.*completed/.test(
-        combined
-      );
-    expect(
-      handlesCompleted,
-      "Expected handler for run_completed/completed SSE event that removes run"
-    ).toBe(true);
-  });
-
-  it("handles run_failed or failed event to remove run from list", () => {
-    dashSource = readSource(DASHBOARD_PATH);
-    queriesSource = readSource(RUNS_QUERIES_PATH);
-    const combined = dashSource + queriesSource;
-    // Should listen for a failed event and remove/filter the run
-    const handlesFailed =
-      /run_failed|["']failed["'].*remove|failed.*filter|onmessage.*failed|addEventListener.*failed/.test(
-        combined
-      );
-    expect(
-      handlesFailed,
-      "Expected handler for run_failed/failed SSE event that removes run"
-    ).toBe(true);
+    expect(eventSources[0].close).toHaveBeenCalledTimes(1);
+    expect(eventSources[1].close).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/gui/src/queries/runs.ts
+++ b/apps/gui/src/queries/runs.ts
@@ -1,12 +1,25 @@
 import { useInfiniteQuery, useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { useCallback, useEffect, useMemo } from "react";
-import { ContextAuditEventV1Schema, type ContextAuditEventV1 } from "@runsight/shared/zod";
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import {
+  ContextAuditEventV1Schema,
+  type ContextAuditEventV1,
+  type RunResponse,
+} from "@runsight/shared/zod";
 import { toast } from "sonner";
 import { runsApi, type RunContextAuditParams, type RunQueryParams } from "../api/runs";
 import { useContextAuditStore } from "../store/contextAudit";
 import { queryKeys } from "./keys";
 
 const PRODUCTION_RUN_SOURCES = new Set(["manual", "webhook", "schedule"]);
+
+function hasSameRunMembership(currentRuns: RunResponse[], nextRuns: RunResponse[]) {
+  if (currentRuns.length !== nextRuns.length) {
+    return false;
+  }
+
+  const nextRunIds = new Set(nextRuns.map((run) => run.id));
+  return currentRuns.every((run) => nextRunIds.has(run.id));
+}
 
 export function useRuns(
   params?: RunQueryParams,
@@ -169,6 +182,7 @@ export function useChildRuns(runId: string) {
 
 export function useActiveRuns() {
   const queryClient = useQueryClient();
+  const activeRunsRef = useRef<RunResponse[]>([]);
 
   const query = useQuery({
     queryKey: [
@@ -193,10 +207,15 @@ export function useActiveRuns() {
     refetchIntervalInBackground: false,
   });
 
-  const activeRuns = useMemo(
+  const nextActiveRuns = useMemo(
     () =>
       [...(query.data?.items ?? [])]
-        .filter((run) => run.branch === "main" && PRODUCTION_RUN_SOURCES.has(run.source))
+        .filter(
+          (run) =>
+            run.parent_run_id == null &&
+            run.branch === "main" &&
+            PRODUCTION_RUN_SOURCES.has(run.source),
+        )
         .sort((left, right) => {
           const leftPriority = left.status === "running" ? 0 : 1;
           const rightPriority = right.status === "running" ? 0 : 1;
@@ -209,6 +228,16 @@ export function useActiveRuns() {
         }),
     [query.data?.items],
   );
+
+  const activeRuns = useMemo(() => {
+    if (!hasSameRunMembership(activeRunsRef.current, nextActiveRuns)) {
+      activeRunsRef.current = [...nextActiveRuns];
+      return activeRunsRef.current;
+    }
+
+    activeRunsRef.current.splice(0, activeRunsRef.current.length, ...nextActiveRuns);
+    return activeRunsRef.current;
+  }, [nextActiveRuns]);
 
   // SSE: subscribe to each active run's stream for real-time updates
   // Connect EventSource to /api/runs/${run.id}/stream for each active run

--- a/packages/core/src/runsight_core/blocks/workflow_block.py
+++ b/packages/core/src/runsight_core/blocks/workflow_block.py
@@ -119,10 +119,13 @@ class WorkflowBlock(BaseBlock):
 
         child_observer = None
         child_run_id = None
+        child_assertion_configs = self.child_workflow.assertion_configs()
         if observer:
             if self._observer_has_terminal_hooks(observer):
                 child_observer, child_run_id = build_child_observer(
-                    observer, block_id=self.block_id
+                    observer,
+                    block_id=self.block_id,
+                    assertion_configs=child_assertion_configs,
                 )
             else:
                 child_observer = observer

--- a/packages/core/src/runsight_core/blocks/workflow_block.py
+++ b/packages/core/src/runsight_core/blocks/workflow_block.py
@@ -614,6 +614,8 @@ def build(
     api_keys: Dict[str, str] | None = None,
     workflow_base_dir: str = ".",
     parent_file_def: Any | None = None,
+    _discovery_git_ref: str | None = None,
+    _discovery_git_service: Any = None,
     **_: Any,
 ) -> WorkflowBlock:
     """Build a WorkflowBlock from a block definition."""
@@ -637,6 +639,8 @@ def build(
         workflow_registry=workflow_registry,
         api_keys=api_keys,
         _base_dir=workflow_base_dir,
+        _discovery_git_ref=_discovery_git_ref,
+        _discovery_git_service=_discovery_git_service,
     )
 
     max_depth = (

--- a/packages/core/src/runsight_core/blocks/workflow_block.py
+++ b/packages/core/src/runsight_core/blocks/workflow_block.py
@@ -78,6 +78,12 @@ class WorkflowBlock(BaseBlock):
         for child_source_path in self.outputs.values():
             self._validate_child_output_source_path(child_source_path)
 
+    def _child_assertion_configs(self) -> dict[str, list[dict[str, Any]]] | None:
+        getter = getattr(self.child_workflow, "assertion_configs", None)
+        if callable(getter):
+            return getter()
+        return None
+
     async def execute(self, ctx: BlockContext) -> BlockOutput:
         """Execute WorkflowBlock with BlockContext, return BlockOutput."""
         state: WorkflowState = ctx.state_snapshot
@@ -119,7 +125,7 @@ class WorkflowBlock(BaseBlock):
 
         child_observer = None
         child_run_id = None
-        child_assertion_configs = self.child_workflow.assertion_configs()
+        child_assertion_configs = self._child_assertion_configs()
         if observer:
             if self._observer_has_terminal_hooks(observer):
                 child_observer, child_run_id = build_child_observer(

--- a/packages/core/src/runsight_core/isolation/handlers.py
+++ b/packages/core/src/runsight_core/isolation/handlers.py
@@ -16,6 +16,7 @@ import httpx
 from runsight_core.budget_enforcement import _active_budget
 from runsight_core.isolation.ipc_models import Handler
 from runsight_core.llm.client import LiteLLMClient
+from runsight_core.paths import is_path_within_base
 from runsight_core.runner import _detect_provider
 from runsight_core.security import SSRFError, validate_ssrf
 
@@ -165,7 +166,7 @@ def make_file_io_handler(
         resolved = (base / decoded_path).resolve()
 
         # Belt-and-suspenders: ensure resolved path is within base_dir
-        if not str(resolved).startswith(str(base)):
+        if not is_path_within_base(base, resolved):
             return {"error": f"Path escapes base directory: {raw_path}"}
 
         if action_type == "read":

--- a/packages/core/src/runsight_core/observer.py
+++ b/packages/core/src/runsight_core/observer.py
@@ -520,12 +520,32 @@ class CompositeObserver:
 
     def clone_for_child_run(self, *, child_run_id: str) -> "CompositeObserver":
         child_observers: list[WorkflowObserver] = []
+        child_stream_queue: Any | None = None
+        child_stream_queue_factory: Any | None = None
+        queue_binders: list[Any] = []
         for obs in self.observers:
             cloner = getattr(obs, "clone_for_child_run", None)
             if callable(cloner):
-                child_observers.append(cloner(child_run_id=child_run_id))
+                cloned = cloner(child_run_id=child_run_id)
             else:
-                child_observers.append(ChildObserverWrapper(obs))
+                cloned = ChildObserverWrapper(obs)
+            child_observers.append(cloned)
+
+            queue_factory = getattr(cloned, "child_queue_for_run", None)
+            if callable(queue_factory) and hasattr(cloned, "queue"):
+                child_stream_queue = getattr(cloned, "queue")
+                child_stream_queue_factory = queue_factory
+
+            queue_binder = getattr(cloned, "bind_sse_queue", None)
+            if callable(queue_binder):
+                queue_binders.append(queue_binder)
+
+        if child_stream_queue is not None:
+            for queue_binder in queue_binders:
+                queue_binder(
+                    sse_queue=child_stream_queue,
+                    child_sse_queue_factory=child_stream_queue_factory,
+                )
         return CompositeObserver(*child_observers)
 
     def record_workflow_input_snapshot(self, input_schema: Any, inputs: Any, **kwargs: Any) -> None:

--- a/packages/core/src/runsight_core/observer.py
+++ b/packages/core/src/runsight_core/observer.py
@@ -513,10 +513,22 @@ class CompositeObserver:
     def __init__(self, *observers: WorkflowObserver):
         self.observers = list(observers)
 
+    @staticmethod
+    def _child_run_getter(obs: WorkflowObserver) -> Any | None:
+        getter = getattr(type(obs), "get_child_run_id_for_block", None)
+        if not callable(getter):
+            return None
+        bound = getattr(obs, "get_child_run_id_for_block", None)
+        return bound if callable(bound) else None
+
+    @staticmethod
+    def _is_workflow_block_type(block_type: str) -> bool:
+        return block_type.strip().lower() in {"workflow", "workflowblock"}
+
     def get_child_run_id_for_block(self, block_id: str) -> Optional[str]:
         for obs in self.observers:
-            getter = getattr(obs, "get_child_run_id_for_block", None)
-            if not callable(getter):
+            getter = self._child_run_getter(obs)
+            if getter is None:
                 continue
             child_run_id = getter(block_id)
             if child_run_id:
@@ -594,18 +606,22 @@ class CompositeObserver:
         if soul is not None:
             kwargs["soul"] = soul
         handled_indices: set[int] = set()
-        if "child_run_id" not in kwargs:
+        if "child_run_id" not in kwargs and self._is_workflow_block_type(block_type):
+            getters: list[Any] = []
             for index, obs in enumerate(self.observers):
-                getter = getattr(obs, "get_child_run_id_for_block", None)
-                if not callable(getter):
+                getter = self._child_run_getter(obs)
+                if getter is None:
                     continue
                 self._safe_call(
                     obs, "on_block_start", workflow_name, block_id, block_type, **kwargs
                 )
                 handled_indices.add(index)
+                getters.append(getter)
+            for getter in getters:
                 child_run_id = getter(block_id)
                 if child_run_id:
                     kwargs["child_run_id"] = child_run_id
+                    break
 
         for index, obs in enumerate(self.observers):
             if index in handled_indices:

--- a/packages/core/src/runsight_core/observer.py
+++ b/packages/core/src/runsight_core/observer.py
@@ -377,6 +377,10 @@ def _call_observer_method(method: Any, *args: Any, **kwargs: Any) -> None:
     method(*args, **_filtered_observer_kwargs(method, kwargs))
 
 
+def _clone_child_observer(method: Any, *, child_run_id: str, **kwargs: Any) -> Any:
+    return method(child_run_id=child_run_id, **_filtered_observer_kwargs(method, kwargs))
+
+
 class ChildObserverWrapper:
     """Wraps a parent observer, forwarding non-terminal events and intercepting terminal ones.
 
@@ -479,6 +483,7 @@ def build_child_observer(
     parent_observer: WorkflowObserver,
     *,
     block_id: str,
+    **kwargs: Any,
 ) -> tuple[WorkflowObserver, Optional[str]]:
     """Derive a child observer when the parent can expose child-run context.
 
@@ -493,7 +498,7 @@ def build_child_observer(
 
     cloner = getattr(parent_observer, "clone_for_child_run", None)
     if child_run_id and callable(cloner):
-        return cloner(child_run_id=child_run_id), child_run_id
+        return _clone_child_observer(cloner, child_run_id=child_run_id, **kwargs), child_run_id
 
     return ChildObserverWrapper(parent_observer), child_run_id
 
@@ -518,7 +523,7 @@ class CompositeObserver:
                 return child_run_id
         return None
 
-    def clone_for_child_run(self, *, child_run_id: str) -> "CompositeObserver":
+    def clone_for_child_run(self, *, child_run_id: str, **kwargs: Any) -> "CompositeObserver":
         child_observers: list[WorkflowObserver] = []
         child_stream_queue: Any | None = None
         child_stream_queue_factory: Any | None = None
@@ -526,7 +531,7 @@ class CompositeObserver:
         for obs in self.observers:
             cloner = getattr(obs, "clone_for_child_run", None)
             if callable(cloner):
-                cloned = cloner(child_run_id=child_run_id)
+                cloned = _clone_child_observer(cloner, child_run_id=child_run_id, **kwargs)
             else:
                 cloned = ChildObserverWrapper(obs)
             child_observers.append(cloned)
@@ -588,7 +593,23 @@ class CompositeObserver:
         kwargs = dict(kwargs)
         if soul is not None:
             kwargs["soul"] = soul
-        for obs in self.observers:
+        handled_indices: set[int] = set()
+        if "child_run_id" not in kwargs:
+            for index, obs in enumerate(self.observers):
+                getter = getattr(obs, "get_child_run_id_for_block", None)
+                if not callable(getter):
+                    continue
+                self._safe_call(
+                    obs, "on_block_start", workflow_name, block_id, block_type, **kwargs
+                )
+                handled_indices.add(index)
+                child_run_id = getter(block_id)
+                if child_run_id:
+                    kwargs["child_run_id"] = child_run_id
+
+        for index, obs in enumerate(self.observers):
+            if index in handled_indices:
+                continue
             self._safe_call(obs, "on_block_start", workflow_name, block_id, block_type, **kwargs)
 
     def on_block_complete(

--- a/packages/core/src/runsight_core/paths.py
+++ b/packages/core/src/runsight_core/paths.py
@@ -1,0 +1,18 @@
+"""Shared path ancestry helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def is_path_within_base(resolved_base: Path, resolved_candidate: Path) -> bool:
+    """Return whether an already-resolved candidate is the base or a descendant.
+
+    Both arguments must already be fully resolved by the caller. This helper answers
+    only the ancestry question and does not normalize inputs or shape errors.
+    """
+    try:
+        resolved_candidate.relative_to(resolved_base)
+    except ValueError:
+        return False
+    return True

--- a/packages/core/src/runsight_core/tools/_catalog.py
+++ b/packages/core/src/runsight_core/tools/_catalog.py
@@ -179,6 +179,20 @@ def _tool_instance_name(tool_id: str) -> str:
     return tool_id.removesuffix("_tool")
 
 
+def _discovered_tools(
+    *,
+    base_dir: object,
+    git_ref: object = None,
+    git_service: object = None,
+) -> dict[str, ToolMeta]:
+    """Resolve the custom tool catalog from either the working tree or a git snapshot."""
+    scan_kwargs: dict[str, object] = {}
+    if isinstance(git_ref, str) and git_ref and git_service is not None:
+        scan_kwargs["git_ref"] = git_ref
+        scan_kwargs["git_service"] = git_service
+    return ToolScanner(base_dir).scan(**scan_kwargs).ids()
+
+
 def _resolve_custom_tool_id(
     tool_id: str,
     *,
@@ -191,7 +205,11 @@ def _resolve_custom_tool_id(
     if not isinstance(timeout_seconds, int):
         raise TypeError("timeout_seconds must be an int")
 
-    tool_meta = tool_meta or ToolScanner(base_dir).scan().ids().get(tool_id)
+    tool_meta = tool_meta or _discovered_tools(
+        base_dir=base_dir,
+        git_ref=kwargs.get("git_ref"),
+        git_service=kwargs.get("git_service"),
+    ).get(tool_id)
     if tool_meta is None:
         raise ValueError(f"Unknown custom tool source: {tool_id!r}")
     if tool_meta.executor != "python":
@@ -422,7 +440,11 @@ def _resolve_http_tool_id(
 ) -> ToolInstance:
     """Resolve a discovered HTTP tool from its canonical workflow ID."""
     base_dir = kwargs.get("base_dir", ".")
-    tool_meta = tool_meta or ToolScanner(base_dir).scan().ids().get(tool_id)
+    tool_meta = tool_meta or _discovered_tools(
+        base_dir=base_dir,
+        git_ref=kwargs.get("git_ref"),
+        git_service=kwargs.get("git_service"),
+    ).get(tool_id)
     if tool_meta is None:
         raise ValueError(f"Unknown HTTP tool source: {tool_id!r}")
     if tool_meta.executor != "request":
@@ -454,7 +476,11 @@ def resolve_tool_id(tool_id: str, **kwargs: object) -> ToolInstance:
         raise TypeError(f"tool_id must be a string, got {type(tool_id)!r}")
 
     base_dir = kwargs.get("base_dir", ".")
-    discovered_tools = ToolScanner(base_dir).scan().ids()
+    discovered_tools = _discovered_tools(
+        base_dir=base_dir,
+        git_ref=kwargs.get("git_ref"),
+        git_service=kwargs.get("git_service"),
+    )
 
     if tool_id in RESERVED_BUILTIN_TOOL_IDS:
         if tool_id in discovered_tools:

--- a/packages/core/src/runsight_core/tools/_catalog.py
+++ b/packages/core/src/runsight_core/tools/_catalog.py
@@ -200,10 +200,14 @@ def _discovered_tools(
     base_dir: object,
     git_ref: object = None,
     git_service: object = None,
+    ignore_tool_ids: object = None,
 ) -> dict[str, ToolMeta]:
     """Resolve the custom tool catalog from either the working tree or a git snapshot."""
     scan_kwargs = _snapshot_scan_kwargs(git_ref=git_ref, git_service=git_service)
-    return ToolScanner(base_dir).scan(**scan_kwargs).ids()
+    scanner_kwargs: dict[str, object] = {}
+    if ignore_tool_ids:
+        scanner_kwargs["ignored_tool_ids"] = ignore_tool_ids
+    return ToolScanner(base_dir, **scanner_kwargs).scan(**scan_kwargs).ids()
 
 
 def _resolve_custom_tool_id(
@@ -493,6 +497,7 @@ def resolve_tool_id(tool_id: str, **kwargs: object) -> ToolInstance:
         base_dir=base_dir,
         git_ref=kwargs.get("git_ref"),
         git_service=kwargs.get("git_service"),
+        ignore_tool_ids=kwargs.get("ignore_tool_ids"),
     )
 
     if tool_id in RESERVED_BUILTIN_TOOL_IDS:

--- a/packages/core/src/runsight_core/tools/_catalog.py
+++ b/packages/core/src/runsight_core/tools/_catalog.py
@@ -179,6 +179,22 @@ def _tool_instance_name(tool_id: str) -> str:
     return tool_id.removesuffix("_tool")
 
 
+def _snapshot_scan_kwargs(
+    *,
+    git_ref: object = None,
+    git_service: object = None,
+) -> dict[str, object]:
+    """Build scan kwargs for git-backed discovery or fail closed for incomplete snapshot context."""
+    if isinstance(git_ref, str) and git_ref:
+        if git_service is None:
+            raise ValueError(
+                f"Requested snapshot discovery could not be loaded for ref {git_ref!r}: "
+                "git service unavailable"
+            )
+        return {"git_ref": git_ref, "git_service": git_service}
+    return {}
+
+
 def _discovered_tools(
     *,
     base_dir: object,
@@ -186,10 +202,7 @@ def _discovered_tools(
     git_service: object = None,
 ) -> dict[str, ToolMeta]:
     """Resolve the custom tool catalog from either the working tree or a git snapshot."""
-    scan_kwargs: dict[str, object] = {}
-    if isinstance(git_ref, str) and git_ref and git_service is not None:
-        scan_kwargs["git_ref"] = git_ref
-        scan_kwargs["git_service"] = git_service
+    scan_kwargs = _snapshot_scan_kwargs(git_ref=git_ref, git_service=git_service)
     return ToolScanner(base_dir).scan(**scan_kwargs).ids()
 
 

--- a/packages/core/src/runsight_core/tools/file_io.py
+++ b/packages/core/src/runsight_core/tools/file_io.py
@@ -6,6 +6,7 @@ import os
 from pathlib import Path
 from typing import Any, Dict
 
+from runsight_core.paths import is_path_within_base
 from runsight_core.tools._catalog import ToolInstance, register_builtin
 
 _PARAMETERS_SCHEMA: Dict[str, Any] = {
@@ -27,8 +28,9 @@ def _validate_path(base_dir: Path, relative_path: str) -> Path:
     if ".." in Path(relative_path).parts:
         raise PermissionError(f"Path traversal is not allowed: {relative_path}")
 
-    resolved = (base_dir / relative_path).resolve()
-    if not str(resolved).startswith(str(base_dir.resolve())):
+    resolved_base = base_dir.resolve()
+    resolved = (resolved_base / relative_path).resolve()
+    if not is_path_within_base(resolved_base, resolved):
         raise PermissionError(f"Path escapes base directory: {relative_path}")
 
     return resolved

--- a/packages/core/src/runsight_core/workflow.py
+++ b/packages/core/src/runsight_core/workflow.py
@@ -417,6 +417,15 @@ class Workflow:
         """Read-only access to the block registry keyed by block_id."""
         return self._blocks
 
+    def assertion_configs(self) -> Optional[Dict[str, list[dict[str, Any]]]]:
+        """Return block-owned assertion configs for this workflow only."""
+        configs: Dict[str, list[dict[str, Any]]] = {}
+        for block_id, block in self._blocks.items():
+            block_assertions = getattr(block, "assertions", None)
+            if block_assertions:
+                configs[block_id] = list(block_assertions)
+        return configs or None
+
     def add_block(self, block: RuntimeBlock) -> "Workflow":
         """
         Register a block in this workflow.

--- a/packages/core/src/runsight_core/yaml/discovery/_assertion.py
+++ b/packages/core/src/runsight_core/yaml/discovery/_assertion.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import ast
-import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Annotated, Any, Literal
@@ -189,36 +188,16 @@ class AssertionScanner(BaseScanner[AssertionMeta]):
         return ScanIndex(results)
 
     def _scan_git(self, git_ref: str, git_service: Any) -> ScanIndex[AssertionMeta]:
-        command = [
-            "git",
-            "ls-tree",
-            "-r",
-            "--name-only",
-            git_ref,
-            "--",
-            f"{self.asset_subdir}/",
-        ]
-        result = subprocess.run(
-            command,
-            cwd=str(git_service.repo_path),
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        if result.returncode != 0:
-            return ScanIndex()
-
         results: list[ScanResult[AssertionMeta]] = []
         seen_ids: set[str] = set()
-        for line in result.stdout.splitlines():
-            candidate = line.strip()
+        for candidate in self._list_git_files(git_ref, git_service):
             if not candidate or not candidate.endswith(".yaml"):
                 continue
-            candidate_path = Path(candidate)
             try:
                 raw_yaml = git_service.read_file(candidate, git_ref)
             except Exception:
                 continue
+            candidate_path = self._resolve_git_candidate_path(candidate, git_service)
             result_item = self._scan_yaml_content(candidate_path, raw_yaml)
             if result_item is not None:
                 if result_item.entity_id in seen_ids:

--- a/packages/core/src/runsight_core/yaml/discovery/_base.py
+++ b/packages/core/src/runsight_core/yaml/discovery/_base.py
@@ -168,12 +168,21 @@ class BaseScanner(Generic[T], abc.ABC):
                 results.append(result)
         return self._build_scan_index(results)
 
-    def _scan_git(self, git_ref: str, git_service: Any) -> ScanIndex[T]:
-        asset_dir = self.asset_dir
-        if not asset_dir.exists():
-            # The git ref may still be valid even if the local checkout lacks the directory,
-            # so only short-circuit when we know we cannot enumerate.
-            pass
+    def _list_git_files(self, git_ref: str, git_service: Any) -> list[str]:
+        list_files = getattr(git_service, "list_files", None)
+        if callable(list_files):
+            try:
+                return [
+                    str(candidate).strip()
+                    for candidate in list_files(git_ref, f"{self.asset_subdir}/")
+                    if str(candidate).strip()
+                ]
+            except Exception:
+                return []
+
+        repo_path = getattr(git_service, "repo_path", None)
+        if repo_path is None:
+            return []
 
         command = [
             "git",
@@ -186,24 +195,43 @@ class BaseScanner(Generic[T], abc.ABC):
         ]
         result = subprocess.run(
             command,
-            cwd=str(git_service.repo_path),
+            cwd=str(repo_path),
             capture_output=True,
             text=True,
             check=False,
         )
         if result.returncode != 0:
-            return ScanIndex()
+            return []
+        return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+    def _resolve_git_candidate_path(self, candidate: str, git_service: Any) -> Path:
+        candidate_path = Path(candidate)
+        if candidate_path.is_absolute():
+            return candidate_path.resolve()
+
+        repo_path = getattr(git_service, "repo_path", None)
+        base_path = Path(repo_path) if repo_path is not None else self.base_dir
+        return (base_path / candidate_path).resolve()
+
+    def _scan_git(self, git_ref: str, git_service: Any) -> ScanIndex[T]:
+        asset_dir = self.asset_dir
+        if not asset_dir.exists():
+            # The git ref may still be valid even if the local checkout lacks the directory,
+            # so only short-circuit when we know we cannot enumerate.
+            pass
 
         results: list[ScanResult[T]] = []
-        for line in result.stdout.splitlines():
-            candidate = line.strip()
+        for candidate in self._list_git_files(git_ref, git_service):
             if not candidate or not candidate.endswith((".yaml", ".yml")):
                 continue
             try:
                 raw_yaml = git_service.read_file(candidate, git_ref)
             except Exception:
                 continue
-            result_item = self._scan_yaml_content(Path(candidate), raw_yaml)
+            result_item = self._scan_yaml_content(
+                self._resolve_git_candidate_path(candidate, git_service),
+                raw_yaml,
+            )
             if result_item is not None:
                 results.append(result_item)
         return self._build_scan_index(results)

--- a/packages/core/src/runsight_core/yaml/discovery/_base.py
+++ b/packages/core/src/runsight_core/yaml/discovery/_base.py
@@ -168,6 +168,14 @@ class BaseScanner(Generic[T], abc.ABC):
                 results.append(result)
         return self._build_scan_index(results)
 
+    def _git_repo_path(self, git_service: Any) -> Path | None:
+        repo_path = getattr(git_service, "repo_path", None)
+        if isinstance(repo_path, Path):
+            return repo_path
+        if isinstance(repo_path, str):
+            return Path(repo_path)
+        return None
+
     def _list_git_files(self, git_ref: str, git_service: Any) -> list[str]:
         list_files = getattr(git_service, "list_files", None)
         if callable(list_files):
@@ -178,9 +186,9 @@ class BaseScanner(Generic[T], abc.ABC):
                     if str(candidate).strip()
                 ]
             except Exception:
-                return []
+                pass
 
-        repo_path = getattr(git_service, "repo_path", None)
+        repo_path = self._git_repo_path(git_service)
         if repo_path is None:
             return []
 
@@ -209,8 +217,7 @@ class BaseScanner(Generic[T], abc.ABC):
         if candidate_path.is_absolute():
             return candidate_path.resolve()
 
-        repo_path = getattr(git_service, "repo_path", None)
-        base_path = Path(repo_path) if repo_path is not None else self.base_dir
+        base_path = self._git_repo_path(git_service) or self.base_dir
         return (base_path / candidate_path).resolve()
 
     def _scan_git(self, git_ref: str, git_service: Any) -> ScanIndex[T]:

--- a/packages/core/src/runsight_core/yaml/discovery/_soul.py
+++ b/packages/core/src/runsight_core/yaml/discovery/_soul.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import subprocess
 from pathlib import Path
 from typing import Any, Collection
 
@@ -104,36 +103,16 @@ class SoulScanner(BaseScanner[Soul]):
         return ScanIndex(results)
 
     def _scan_git(self, git_ref: str, git_service: Any) -> ScanIndex[Soul]:
-        command = [
-            "git",
-            "ls-tree",
-            "-r",
-            "--name-only",
-            git_ref,
-            "--",
-            f"{self.asset_subdir}/",
-        ]
-        result = subprocess.run(
-            command,
-            cwd=str(git_service.repo_path),
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        if result.returncode != 0:
-            return ScanIndex()
-
         results: list[ScanResult[Soul]] = []
         seen_ids: set[str] = set()
-        for line in result.stdout.splitlines():
-            candidate = line.strip()
+        for candidate in self._list_git_files(git_ref, git_service):
             if not candidate or not candidate.endswith(".yaml"):
                 continue
-            candidate_path = Path(candidate)
             try:
                 raw_yaml = git_service.read_file(candidate, git_ref)
             except Exception:
                 continue
+            candidate_path = self._resolve_git_candidate_path(candidate, git_service)
             result_item = self._scan_yaml_content(candidate_path, raw_yaml)
             if result_item is not None:
                 if result_item.entity_id in seen_ids:

--- a/packages/core/src/runsight_core/yaml/discovery/_tool.py
+++ b/packages/core/src/runsight_core/yaml/discovery/_tool.py
@@ -157,9 +157,11 @@ class ToolScanner(BaseScanner[ToolMeta]):
         base_dir: str | Path,
         *,
         tools_subdir: str = "custom/tools",
+        ignored_tool_ids: set[str] | frozenset[str] | None = None,
     ) -> None:
         super().__init__(base_dir)
         self._tools_subdir = tools_subdir
+        self._ignored_tool_ids = frozenset(ignored_tool_ids or ())
 
     @property
     def asset_subdir(self) -> str:
@@ -204,6 +206,8 @@ class ToolScanner(BaseScanner[ToolMeta]):
         results: list[ScanResult[ToolMeta]] = []
         seen_ids: set[str] = set()
         for yaml_file in self._glob_yaml_files(asset_dir):
+            if yaml_file.stem in self._ignored_tool_ids:
+                continue
             result = self._scan_yaml_file(yaml_file)
             if result is not None:
                 if result.entity_id in seen_ids:
@@ -220,6 +224,8 @@ class ToolScanner(BaseScanner[ToolMeta]):
         seen_ids: set[str] = set()
         for candidate in self._list_git_files(git_ref, git_service):
             if not candidate or not candidate.endswith(".yaml"):
+                continue
+            if Path(candidate).stem in self._ignored_tool_ids:
                 continue
             try:
                 raw_yaml = git_service.read_file(candidate, git_ref)

--- a/packages/core/src/runsight_core/yaml/discovery/_tool.py
+++ b/packages/core/src/runsight_core/yaml/discovery/_tool.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import ast
 import logging
-import subprocess
 from pathlib import Path
 from typing import Annotated, Any
 
@@ -217,36 +216,16 @@ class ToolScanner(BaseScanner[ToolMeta]):
         return ScanIndex(results)
 
     def _scan_git(self, git_ref: str, git_service: Any) -> ScanIndex[ToolMeta]:
-        command = [
-            "git",
-            "ls-tree",
-            "-r",
-            "--name-only",
-            git_ref,
-            "--",
-            f"{self.asset_subdir}/",
-        ]
-        result = subprocess.run(
-            command,
-            cwd=str(git_service.repo_path),
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        if result.returncode != 0:
-            return ScanIndex()
-
         results: list[ScanResult[ToolMeta]] = []
         seen_ids: set[str] = set()
-        for line in result.stdout.splitlines():
-            candidate = line.strip()
+        for candidate in self._list_git_files(git_ref, git_service):
             if not candidate or not candidate.endswith(".yaml"):
                 continue
-            candidate_path = Path(candidate)
             try:
                 raw_yaml = git_service.read_file(candidate, git_ref)
             except Exception:
                 continue
+            candidate_path = self._resolve_git_candidate_path(candidate, git_service)
             result_item = self._scan_yaml_content(candidate_path, raw_yaml)
             if result_item is not None:
                 if result_item.entity_id in seen_ids:

--- a/packages/core/src/runsight_core/yaml/parser.py
+++ b/packages/core/src/runsight_core/yaml/parser.py
@@ -541,6 +541,81 @@ def _attach_tool_runtime_metadata(
     return tool
 
 
+def _build_runtime_blocks(
+    file_def: RunsightWorkflowFile,
+    *,
+    workflow_registry: Optional["WorkflowRegistry"],
+    api_keys: Optional[Dict[str, str]],
+    runner: Any,
+    workflow_base_dir: str,
+    souls_map: Dict[str, Soul],
+    git_ref: str | None,
+    git_service: Any,
+) -> Dict[str, BaseBlock]:
+    built_blocks: Dict[str, BaseBlock] = {}
+    for block_id, block_def in file_def.blocks.items():
+        from runsight_core.blocks._registry import get_builder
+
+        builder = get_builder(block_def.type)
+        if builder is None:
+            from runsight_core.blocks._registry import BLOCK_BUILDER_REGISTRY
+
+            raise ValueError(
+                f"Unknown block type '{block_def.type}' for block '{block_id}'. "
+                f"Available types: {sorted(BLOCK_BUILDER_REGISTRY.keys())}"
+            )
+        builder_kwargs: Dict[str, Any] = {
+            "workflow_registry": workflow_registry,
+            "api_keys": api_keys,
+            "workflow_base_dir": workflow_base_dir,
+            "parent_file_def": file_def,
+        }
+        if block_def.type == "workflow":
+            builder_kwargs["_discovery_git_ref"] = git_ref
+            builder_kwargs["_discovery_git_service"] = git_service
+        built_blocks[block_id] = builder(
+            block_id,
+            block_def,
+            souls_map,
+            runner,
+            built_blocks,
+            **builder_kwargs,
+        )
+    return built_blocks
+
+
+def _validate_and_resolve_tools(
+    file_def: RunsightWorkflowFile,
+    souls_map: Dict[str, Soul],
+    workflow_base_dir: str,
+    *,
+    require_custom_metadata: bool,
+    git_ref: str | None,
+    git_service: Any,
+) -> None:
+    validation_result = validate_tool_governance(file_def, souls_map)
+    validation_result.merge(
+        _validate_declared_tool_definitions(
+            file_def,
+            base_dir=workflow_base_dir,
+            require_custom_metadata=require_custom_metadata,
+            git_ref=git_ref,
+            git_service=git_service,
+            fail_closed=git_ref is not None,
+        )
+    )
+    if validation_result.has_errors:
+        raise ValueError(validation_result.error_summary or "Tool governance validation failed")
+    _resolve_tools_for_souls(
+        file_def,
+        souls_map,
+        workflow_base_dir,
+        git_ref=git_ref,
+        git_service=git_service,
+        strict=git_ref is not None,
+    )
+
+
 # Trigger auto-discovery of co-located blocks and rebuild the discriminated
 # union so that BlockDef includes all registered block types.
 import runsight_core.blocks  # noqa: E402, F401
@@ -808,6 +883,40 @@ def _find_block_for_soul(file_def: RunsightWorkflowFile, soul_key: str) -> tuple
     return None, None
 
 
+def _tool_snapshot_kwargs(git_ref: str | None, git_service: Any) -> dict[str, Any]:
+    if git_ref is None:
+        return {}
+    return {"git_ref": git_ref, "git_service": git_service}
+
+
+def _resolve_tool_for_soul(
+    *,
+    soul_key: str,
+    tool_id: str,
+    file_def: RunsightWorkflowFile,
+    workflow_base_dir: str,
+    snapshot_kwargs: dict[str, Any],
+    strict: bool,
+) -> object | None:
+    kwargs = {"base_dir": workflow_base_dir, **snapshot_kwargs}
+    if tool_id == "delegate":
+        block_id_for_soul, block_def_for_soul = _find_block_for_soul(file_def, soul_key)
+        exits = getattr(block_def_for_soul, "exits", None) if block_def_for_soul else None
+        if not exits:
+            raise ValueError(
+                f"Soul '{soul_key}' uses delegate tool but block '{block_id_for_soul}' "
+                "has no exits defined"
+            )
+        kwargs["exits"] = exits
+    try:
+        return _resolve_tool_for_parser(tool_id, **kwargs)
+    except Exception as exc:
+        if strict:
+            raise
+        logger.warning("Skipping unresolved tool '%s' for soul '%s': %s", tool_id, soul_key, exc)
+        return None
+
+
 def _resolve_tools_for_souls(
     file_def: RunsightWorkflowFile,
     souls_map: Dict[str, Soul],
@@ -818,10 +927,7 @@ def _resolve_tools_for_souls(
     strict: bool = False,
 ) -> None:
     """Resolve ToolInstance objects per soul and assign to soul.resolved_tools."""
-    snapshot_kwargs: dict[str, Any] = {}
-    if git_ref is not None:
-        snapshot_kwargs["git_ref"] = git_ref
-        snapshot_kwargs["git_service"] = git_service
+    snapshot_kwargs = _tool_snapshot_kwargs(git_ref, git_service)
     for soul_key in _collect_referenced_soul_keys(file_def):
         soul = souls_map.get(soul_key)
         if soul is None or not soul.tools:
@@ -831,42 +937,16 @@ def _resolve_tools_for_souls(
             tool_id = _resolve_soul_tool_definition(tool_name, file_def.tools)
             if tool_id is None:
                 continue
-            if tool_id == "delegate":
-                block_id_for_soul, block_def_for_soul = _find_block_for_soul(file_def, soul_key)
-                exits = getattr(block_def_for_soul, "exits", None) if block_def_for_soul else None
-                if not exits:
-                    raise ValueError(
-                        f"Soul '{soul_key}' uses delegate tool but block "
-                        f"'{block_id_for_soul}' has no exits defined"
-                    )
-                try:
-                    resolved_tool = _resolve_tool_for_parser(
-                        tool_id,
-                        exits=exits,
-                        base_dir=workflow_base_dir,
-                        **snapshot_kwargs,
-                    )
-                except Exception as exc:
-                    if strict:
-                        raise
-                    logger.warning(
-                        "Skipping unresolved tool '%s' for soul '%s': %s", tool_id, soul_key, exc
-                    )
-                    continue
-            else:
-                try:
-                    resolved_tool = _resolve_tool_for_parser(
-                        tool_id,
-                        base_dir=workflow_base_dir,
-                        **snapshot_kwargs,
-                    )
-                except Exception as exc:
-                    if strict:
-                        raise
-                    logger.warning(
-                        "Skipping unresolved tool '%s' for soul '%s': %s", tool_id, soul_key, exc
-                    )
-                    continue
+            resolved_tool = _resolve_tool_for_soul(
+                soul_key=soul_key,
+                tool_id=tool_id,
+                file_def=file_def,
+                workflow_base_dir=workflow_base_dir,
+                snapshot_kwargs=snapshot_kwargs,
+                strict=strict,
+            )
+            if resolved_tool is None:
+                continue
             resolved_tools.append(
                 _attach_tool_runtime_metadata(
                     resolved_tool,
@@ -1068,12 +1148,9 @@ def parse_workflow_yaml(
     file_def, workflow_base_dir, require_custom_metadata = _normalize_workflow_input(
         yaml_str_or_dict, _base_dir
     )
-
     discovery_scan_kwargs = _snapshot_discovery_scan_kwargs(
-        git_ref=_discovery_git_ref,
-        git_service=_discovery_git_service,
+        git_ref=_discovery_git_ref, git_service=_discovery_git_service
     )
-
     assertion_index = AssertionScanner(workflow_base_dir).scan(**discovery_scan_kwargs)
     register_custom_assertions(assertion_index)
     _validate_custom_assertion_refs(
@@ -1081,7 +1158,6 @@ def parse_workflow_yaml(
         assertion_index.ids(),
         workflow_base_dir=workflow_base_dir,
     )
-
     souls_dir = Path(workflow_base_dir) / "custom" / "souls"
     external_souls = _discover_external_souls(
         souls_dir,
@@ -1090,69 +1166,31 @@ def parse_workflow_yaml(
         git_service=_discovery_git_service,
     )
     souls_map: Dict[str, Soul] = _merge_inline_souls(file_def, external_souls)
-
     if runner is None:
         model_name = _bootstrap_runner_model_name(souls_map)
         runner = RunsightTeamRunner(model_name=model_name, api_keys=api_keys)
-
     _validate_reserved_context_block_ids(file_def)
-    built_blocks: Dict[str, BaseBlock] = {}
-    for block_id, block_def in file_def.blocks.items():
-        from runsight_core.blocks._registry import get_builder
-
-        builder = get_builder(block_def.type)
-        if builder is None:
-            from runsight_core.blocks._registry import BLOCK_BUILDER_REGISTRY
-
-            raise ValueError(
-                f"Unknown block type '{block_def.type}' for block '{block_id}'. "
-                f"Available types: {sorted(BLOCK_BUILDER_REGISTRY.keys())}"
-            )
-        builder_kwargs: Dict[str, Any] = {
-            "workflow_registry": workflow_registry,
-            "api_keys": api_keys,
-            "workflow_base_dir": workflow_base_dir,
-            "parent_file_def": file_def,
-        }
-        if block_def.type == "workflow":
-            builder_kwargs["_discovery_git_ref"] = _discovery_git_ref
-            builder_kwargs["_discovery_git_service"] = _discovery_git_service
-        built_blocks[block_id] = builder(
-            block_id,
-            block_def,
-            souls_map,
-            runner,
-            built_blocks,
-            **builder_kwargs,
-        )
-
+    built_blocks = _build_runtime_blocks(
+        file_def,
+        workflow_registry=workflow_registry,
+        api_keys=api_keys,
+        runner=runner,
+        workflow_base_dir=workflow_base_dir,
+        souls_map=souls_map,
+        git_ref=_discovery_git_ref,
+        git_service=_discovery_git_service,
+    )
     for block_id, block_def in file_def.blocks.items():
         if block_id in built_blocks:
             _bridge_block_attributes(block_id, block_def, built_blocks[block_id])
-
     _wrap_llm_blocks_with_isolation(file_def, built_blocks, api_keys)
-
-    validation_result = validate_tool_governance(file_def, souls_map)
-    validation_result.merge(
-        _validate_declared_tool_definitions(
-            file_def,
-            base_dir=workflow_base_dir,
-            require_custom_metadata=require_custom_metadata,
-            git_ref=_discovery_git_ref,
-            git_service=_discovery_git_service,
-            fail_closed=_discovery_git_ref is not None,
-        )
-    )
-    if validation_result.has_errors:
-        raise ValueError(validation_result.error_summary or "Tool governance validation failed")
-
-    _resolve_tools_for_souls(
+    _validate_and_resolve_tools(
         file_def,
         souls_map,
         workflow_base_dir,
+        require_custom_metadata=require_custom_metadata,
         git_ref=_discovery_git_ref,
         git_service=_discovery_git_service,
-        strict=_discovery_git_ref is not None,
     )
     _validate_inputs_and_detect_cycles(file_def, built_blocks)
     return _assemble_workflow(file_def, built_blocks)

--- a/packages/core/src/runsight_core/yaml/parser.py
+++ b/packages/core/src/runsight_core/yaml/parser.py
@@ -140,10 +140,16 @@ def _discover_external_souls(
     souls_dir: Path,
     *,
     inline_soul_keys: Collection[str],
+    git_ref: str | None = None,
+    git_service: Any = None,
 ) -> Dict[str, Soul]:
     """Discover external soul files through the shared discovery seam."""
     base_dir = souls_dir.parent.parent
-    return SoulScanner(base_dir).scan(ignore_keys=inline_soul_keys).ids()
+    scan_kwargs: dict[str, Any] = {}
+    if git_ref is not None and git_service is not None:
+        scan_kwargs["git_ref"] = git_ref
+        scan_kwargs["git_service"] = git_service
+    return SoulScanner(base_dir).scan(ignore_keys=inline_soul_keys, **scan_kwargs).ids()
 
 
 def _normalize_depends(depends: str | list[str] | None) -> list[str]:
@@ -354,6 +360,9 @@ def _validate_declared_tool_definitions(
     *,
     base_dir: str,
     require_custom_metadata: bool = False,
+    git_ref: str | None = None,
+    git_service: Any = None,
+    fail_closed: bool = False,
 ) -> ValidationResult:
     """Validate that declared canonical tool IDs are parse-time resolvable."""
     result = ValidationResult()
@@ -376,10 +385,16 @@ def _validate_declared_tool_definitions(
     if result.has_errors:
         return result
 
+    scan_kwargs: dict[str, Any] = {}
+    if git_ref is not None and git_service is not None:
+        scan_kwargs["git_ref"] = git_ref
+        scan_kwargs["git_service"] = git_service
+
     try:
-        discovered_tools = ToolScanner(base_dir).scan().ids()
+        discovered_tools = ToolScanner(base_dir).scan(**scan_kwargs).ids()
     except ValueError as exc:
         scanner_message = str(exc)
+        add_issue = result.add_error if fail_closed else result.add_warning
         for tool_id in file_def.tools:
             expected_file = Path(base_dir) / "custom" / "tools" / f"{tool_id}.yaml"
             if tool_id in RESERVED_BUILTIN_TOOL_IDS:
@@ -402,7 +417,7 @@ def _validate_declared_tool_definitions(
                 "Tool code must define" in scanner_message
                 or "Tool code has a syntax error" in scanner_message
             ):
-                result.add_warning(
+                add_issue(
                     f"Tool '{tool_id}': {scanner_message}",
                     source="tool_definitions",
                     context=tool_id,
@@ -437,8 +452,9 @@ def _validate_declared_tool_definitions(
         tool_meta = discovered_tools.get(tool_id)
         if tool_meta is None:
             tool_ref = str(EntityRef(EntityKind.TOOL, tool_id))
+            add_issue = result.add_error if fail_closed else result.add_warning
             if require_custom_metadata:
-                result.add_warning(
+                add_issue(
                     (
                         f"{tool_ref} references missing custom tool metadata. "
                         f"Expected metadata at {expected_file}"
@@ -447,7 +463,7 @@ def _validate_declared_tool_definitions(
                     context=tool_id,
                 )
             else:
-                result.add_warning(
+                add_issue(
                     (
                         f"Workflow declares unknown {tool_ref}. "
                         f"Available builtin IDs: {available_builtin_ids}. "
@@ -459,11 +475,15 @@ def _validate_declared_tool_definitions(
             continue
 
         try:
-            _resolve_tool_for_parser(tool_id, base_dir=base_dir)
-        except ValueError as exc:
-            result.add_warning(
-                f"Tool '{tool_id}': {exc}", source="tool_definitions", context=tool_id
+            _resolve_tool_for_parser(
+                tool_id,
+                base_dir=base_dir,
+                git_ref=git_ref,
+                git_service=git_service,
             )
+        except ValueError as exc:
+            add_issue = result.add_error if fail_closed else result.add_warning
+            add_issue(f"Tool '{tool_id}': {exc}", source="tool_definitions", context=tool_id)
 
     return result
 
@@ -473,6 +493,8 @@ def _resolve_tool_for_parser(
     *,
     base_dir: str,
     exits: object | None = None,
+    git_ref: str | None = None,
+    git_service: Any = None,
 ) -> object:
     """Resolve a tool with only the parser context that its canonical ID needs."""
     kwargs: Dict[str, object] = {}
@@ -483,16 +505,31 @@ def _resolve_tool_for_parser(
     elif tool_id not in RESERVED_BUILTIN_TOOL_IDS:
         kwargs["base_dir"] = base_dir
 
+    if git_ref is not None and git_service is not None:
+        kwargs["git_ref"] = git_ref
+        kwargs["git_service"] = git_service
+
     return resolve_tool_id(tool_id, **kwargs)
 
 
-def _attach_tool_runtime_metadata(tool: object, tool_id: str, *, base_dir: str) -> object:
+def _attach_tool_runtime_metadata(
+    tool: object,
+    tool_id: str,
+    *,
+    base_dir: str,
+    git_ref: str | None = None,
+    git_service: Any = None,
+) -> object:
     """Annotate a resolved ToolInstance with ID/type metadata for isolation."""
     setattr(tool, "source", tool_id)
     if tool_id in RESERVED_BUILTIN_TOOL_IDS:
         setattr(tool, "tool_type", "builtin")
     else:
-        tool_meta = ToolScanner(base_dir).scan().ids().get(tool_id)
+        scan_kwargs: dict[str, Any] = {}
+        if git_ref is not None and git_service is not None:
+            scan_kwargs["git_ref"] = git_ref
+            scan_kwargs["git_service"] = git_service
+        tool_meta = ToolScanner(base_dir).scan(**scan_kwargs).ids().get(tool_id)
         setattr(tool, "tool_type", tool_meta.type if tool_meta is not None else "")
     setattr(tool, "config", {"id": tool_id})
     return tool
@@ -769,6 +806,10 @@ def _resolve_tools_for_souls(
     file_def: RunsightWorkflowFile,
     souls_map: Dict[str, Soul],
     workflow_base_dir: str,
+    *,
+    git_ref: str | None = None,
+    git_service: Any = None,
+    strict: bool = False,
 ) -> None:
     """Resolve ToolInstance objects per soul and assign to soul.resolved_tools."""
     for soul_key in _collect_referenced_soul_keys(file_def):
@@ -790,25 +831,76 @@ def _resolve_tools_for_souls(
                     )
                 try:
                     resolved_tool = _resolve_tool_for_parser(
-                        tool_id, exits=exits, base_dir=workflow_base_dir
+                        tool_id,
+                        exits=exits,
+                        base_dir=workflow_base_dir,
+                        git_ref=git_ref,
+                        git_service=git_service,
                     )
                 except Exception as exc:
+                    if strict:
+                        raise
                     logger.warning(
                         "Skipping unresolved tool '%s' for soul '%s': %s", tool_id, soul_key, exc
                     )
                     continue
             else:
                 try:
-                    resolved_tool = _resolve_tool_for_parser(tool_id, base_dir=workflow_base_dir)
+                    resolved_tool = _resolve_tool_for_parser(
+                        tool_id,
+                        base_dir=workflow_base_dir,
+                        git_ref=git_ref,
+                        git_service=git_service,
+                    )
                 except Exception as exc:
+                    if strict:
+                        raise
                     logger.warning(
                         "Skipping unresolved tool '%s' for soul '%s': %s", tool_id, soul_key, exc
                     )
                     continue
             resolved_tools.append(
-                _attach_tool_runtime_metadata(resolved_tool, tool_id, base_dir=workflow_base_dir)
+                _attach_tool_runtime_metadata(
+                    resolved_tool,
+                    tool_id,
+                    base_dir=workflow_base_dir,
+                    git_ref=git_ref,
+                    git_service=git_service,
+                )
             )
         soul.resolved_tools = resolved_tools
+
+
+def _validate_custom_assertion_refs(
+    file_def: RunsightWorkflowFile,
+    assertion_ids: Collection[str],
+    *,
+    workflow_base_dir: str,
+) -> None:
+    """Ensure every referenced custom assertion exists in the active discovery scope."""
+    available_ids = set(assertion_ids)
+    for block_id, block_def in file_def.blocks.items():
+        for assertion in getattr(block_def, "assertions", None) or []:
+            assertion_type = (
+                assertion.get("type")
+                if isinstance(assertion, dict)
+                else getattr(assertion, "type", None)
+            )
+            if not isinstance(assertion_type, str):
+                continue
+            base_type = assertion_type.removeprefix("not-")
+            if not base_type.startswith("custom:"):
+                continue
+            assertion_id = base_type.split(":", 1)[1]
+            if assertion_id in available_ids:
+                continue
+            expected_path = (
+                Path(workflow_base_dir) / "custom" / "assertions" / f"{assertion_id}.yaml"
+            )
+            raise ValueError(
+                f"Block '{block_id}' references missing custom assertion '{assertion_id}'. "
+                f"Expected metadata at {expected_path}"
+            )
 
 
 def _validate_inputs_and_detect_cycles(
@@ -962,17 +1054,34 @@ def parse_workflow_yaml(
     api_keys: Optional[Dict[str, str]] = None,
     runner: Optional[Any] = None,
     _base_dir: Optional[str] = None,
+    _discovery_git_ref: str | None = None,
+    _discovery_git_service: Any = None,
 ) -> Workflow:
     """Parse a YAML workflow definition into a validated, runnable Workflow object."""
     file_def, workflow_base_dir, require_custom_metadata = _normalize_workflow_input(
         yaml_str_or_dict, _base_dir
     )
 
-    assertion_index = AssertionScanner(workflow_base_dir).scan()
+    discovery_scan_kwargs: dict[str, Any] = {}
+    if _discovery_git_ref is not None and _discovery_git_service is not None:
+        discovery_scan_kwargs["git_ref"] = _discovery_git_ref
+        discovery_scan_kwargs["git_service"] = _discovery_git_service
+
+    assertion_index = AssertionScanner(workflow_base_dir).scan(**discovery_scan_kwargs)
     register_custom_assertions(assertion_index)
+    _validate_custom_assertion_refs(
+        file_def,
+        assertion_index.ids(),
+        workflow_base_dir=workflow_base_dir,
+    )
 
     souls_dir = Path(workflow_base_dir) / "custom" / "souls"
-    external_souls = _discover_external_souls(souls_dir, inline_soul_keys=file_def.souls)
+    external_souls = _discover_external_souls(
+        souls_dir,
+        inline_soul_keys=file_def.souls,
+        git_ref=_discovery_git_ref,
+        git_service=_discovery_git_service,
+    )
     souls_map: Dict[str, Soul] = _merge_inline_souls(file_def, external_souls)
 
     if runner is None:
@@ -1013,13 +1122,25 @@ def parse_workflow_yaml(
     validation_result = validate_tool_governance(file_def, souls_map)
     validation_result.merge(
         _validate_declared_tool_definitions(
-            file_def, base_dir=workflow_base_dir, require_custom_metadata=require_custom_metadata
+            file_def,
+            base_dir=workflow_base_dir,
+            require_custom_metadata=require_custom_metadata,
+            git_ref=_discovery_git_ref,
+            git_service=_discovery_git_service,
+            fail_closed=_discovery_git_ref is not None,
         )
     )
     if validation_result.has_errors:
         raise ValueError(validation_result.error_summary or "Tool governance validation failed")
 
-    _resolve_tools_for_souls(file_def, souls_map, workflow_base_dir)
+    _resolve_tools_for_souls(
+        file_def,
+        souls_map,
+        workflow_base_dir,
+        git_ref=_discovery_git_ref,
+        git_service=_discovery_git_service,
+        strict=_discovery_git_ref is not None,
+    )
     _validate_inputs_and_detect_cycles(file_def, built_blocks)
     return _assemble_workflow(file_def, built_blocks)
 

--- a/packages/core/src/runsight_core/yaml/parser.py
+++ b/packages/core/src/runsight_core/yaml/parser.py
@@ -1108,16 +1108,22 @@ def parse_workflow_yaml(
                 f"Unknown block type '{block_def.type}' for block '{block_id}'. "
                 f"Available types: {sorted(BLOCK_BUILDER_REGISTRY.keys())}"
             )
+        builder_kwargs: Dict[str, Any] = {
+            "workflow_registry": workflow_registry,
+            "api_keys": api_keys,
+            "workflow_base_dir": workflow_base_dir,
+            "parent_file_def": file_def,
+        }
+        if block_def.type == "workflow":
+            builder_kwargs["_discovery_git_ref"] = _discovery_git_ref
+            builder_kwargs["_discovery_git_service"] = _discovery_git_service
         built_blocks[block_id] = builder(
             block_id,
             block_def,
             souls_map,
             runner,
             built_blocks,
-            workflow_registry=workflow_registry,
-            api_keys=api_keys,
-            workflow_base_dir=workflow_base_dir,
-            parent_file_def=file_def,
+            **builder_kwargs,
         )
 
     for block_id, block_def in file_def.blocks.items():

--- a/packages/core/src/runsight_core/yaml/parser.py
+++ b/packages/core/src/runsight_core/yaml/parser.py
@@ -409,6 +409,9 @@ def _collect_warning_only_declared_tool_issues(
     git_ref: str | None,
     git_service: Any,
 ) -> dict[str, str]:
+    if git_ref is None:
+        return {}
+
     tool_scanner = ToolScanner(base_dir)
     issues: dict[str, str] = {}
 
@@ -573,11 +576,10 @@ def _validate_declared_tool_definitions(
             continue
 
         try:
-            _resolve_tool_for_parser(
-                tool_id,
-                ignore_tool_ids=warning_only_tool_ids,
-                **resolve_kwargs,
-            )
+            tool_resolve_kwargs = dict(resolve_kwargs)
+            if warning_only_tool_ids:
+                tool_resolve_kwargs["ignore_tool_ids"] = warning_only_tool_ids
+            _resolve_tool_for_parser(tool_id, **tool_resolve_kwargs)
         except ValueError as exc:
             add_issue = result.add_error if fail_closed else result.add_warning
             add_issue(f"Tool '{tool_id}': {exc}", source="tool_definitions", context=tool_id)
@@ -606,7 +608,7 @@ def _resolve_tool_for_parser(
     if git_ref is not None and git_service is not None:
         kwargs["git_ref"] = git_ref
         kwargs["git_service"] = git_service
-    if ignore_tool_ids:
+    if ignore_tool_ids and tool_id not in RESERVED_BUILTIN_TOOL_IDS:
         kwargs["ignore_tool_ids"] = tuple(ignore_tool_ids)
 
     return resolve_tool_id(tool_id, **kwargs)
@@ -1010,11 +1012,10 @@ def _resolve_tool_for_soul(
             )
         kwargs["exits"] = exits
     try:
-        return _resolve_tool_for_parser(
-            tool_id,
-            ignore_tool_ids=warning_only_tool_ids,
-            **kwargs,
-        )
+        resolve_kwargs = dict(kwargs)
+        if warning_only_tool_ids and tool_id not in RESERVED_BUILTIN_TOOL_IDS:
+            resolve_kwargs["ignore_tool_ids"] = warning_only_tool_ids
+        return _resolve_tool_for_parser(tool_id, **resolve_kwargs)
     except Exception as exc:
         if strict:
             raise

--- a/packages/core/src/runsight_core/yaml/parser.py
+++ b/packages/core/src/runsight_core/yaml/parser.py
@@ -145,11 +145,24 @@ def _discover_external_souls(
 ) -> Dict[str, Soul]:
     """Discover external soul files through the shared discovery seam."""
     base_dir = souls_dir.parent.parent
-    scan_kwargs: dict[str, Any] = {}
-    if git_ref is not None and git_service is not None:
-        scan_kwargs["git_ref"] = git_ref
-        scan_kwargs["git_service"] = git_service
+    scan_kwargs = _snapshot_discovery_scan_kwargs(git_ref=git_ref, git_service=git_service)
     return SoulScanner(base_dir).scan(ignore_keys=inline_soul_keys, **scan_kwargs).ids()
+
+
+def _snapshot_discovery_scan_kwargs(
+    *,
+    git_ref: str | None = None,
+    git_service: Any = None,
+) -> dict[str, Any]:
+    """Build snapshot discovery kwargs or fail closed for incomplete explicit snapshot context."""
+    if git_ref is None:
+        return {}
+    if git_service is None:
+        raise ValueError(
+            f"Requested snapshot discovery could not be loaded for ref {git_ref!r}: "
+            "git service unavailable"
+        )
+    return {"git_ref": git_ref, "git_service": git_service}
 
 
 def _normalize_depends(depends: str | list[str] | None) -> list[str]:
@@ -385,10 +398,11 @@ def _validate_declared_tool_definitions(
     if result.has_errors:
         return result
 
-    scan_kwargs: dict[str, Any] = {}
-    if git_ref is not None and git_service is not None:
-        scan_kwargs["git_ref"] = git_ref
-        scan_kwargs["git_service"] = git_service
+    scan_kwargs = _snapshot_discovery_scan_kwargs(git_ref=git_ref, git_service=git_service)
+    resolve_kwargs: dict[str, Any] = {"base_dir": base_dir}
+    if git_ref is not None:
+        resolve_kwargs["git_ref"] = git_ref
+        resolve_kwargs["git_service"] = git_service
 
     try:
         discovered_tools = ToolScanner(base_dir).scan(**scan_kwargs).ids()
@@ -475,12 +489,7 @@ def _validate_declared_tool_definitions(
             continue
 
         try:
-            _resolve_tool_for_parser(
-                tool_id,
-                base_dir=base_dir,
-                git_ref=git_ref,
-                git_service=git_service,
-            )
+            _resolve_tool_for_parser(tool_id, **resolve_kwargs)
         except ValueError as exc:
             add_issue = result.add_error if fail_closed else result.add_warning
             add_issue(f"Tool '{tool_id}': {exc}", source="tool_definitions", context=tool_id)
@@ -525,10 +534,7 @@ def _attach_tool_runtime_metadata(
     if tool_id in RESERVED_BUILTIN_TOOL_IDS:
         setattr(tool, "tool_type", "builtin")
     else:
-        scan_kwargs: dict[str, Any] = {}
-        if git_ref is not None and git_service is not None:
-            scan_kwargs["git_ref"] = git_ref
-            scan_kwargs["git_service"] = git_service
+        scan_kwargs = _snapshot_discovery_scan_kwargs(git_ref=git_ref, git_service=git_service)
         tool_meta = ToolScanner(base_dir).scan(**scan_kwargs).ids().get(tool_id)
         setattr(tool, "tool_type", tool_meta.type if tool_meta is not None else "")
     setattr(tool, "config", {"id": tool_id})
@@ -812,6 +818,10 @@ def _resolve_tools_for_souls(
     strict: bool = False,
 ) -> None:
     """Resolve ToolInstance objects per soul and assign to soul.resolved_tools."""
+    snapshot_kwargs: dict[str, Any] = {}
+    if git_ref is not None:
+        snapshot_kwargs["git_ref"] = git_ref
+        snapshot_kwargs["git_service"] = git_service
     for soul_key in _collect_referenced_soul_keys(file_def):
         soul = souls_map.get(soul_key)
         if soul is None or not soul.tools:
@@ -834,8 +844,7 @@ def _resolve_tools_for_souls(
                         tool_id,
                         exits=exits,
                         base_dir=workflow_base_dir,
-                        git_ref=git_ref,
-                        git_service=git_service,
+                        **snapshot_kwargs,
                     )
                 except Exception as exc:
                     if strict:
@@ -849,8 +858,7 @@ def _resolve_tools_for_souls(
                     resolved_tool = _resolve_tool_for_parser(
                         tool_id,
                         base_dir=workflow_base_dir,
-                        git_ref=git_ref,
-                        git_service=git_service,
+                        **snapshot_kwargs,
                     )
                 except Exception as exc:
                     if strict:
@@ -864,8 +872,7 @@ def _resolve_tools_for_souls(
                     resolved_tool,
                     tool_id,
                     base_dir=workflow_base_dir,
-                    git_ref=git_ref,
-                    git_service=git_service,
+                    **snapshot_kwargs,
                 )
             )
         soul.resolved_tools = resolved_tools
@@ -1062,10 +1069,10 @@ def parse_workflow_yaml(
         yaml_str_or_dict, _base_dir
     )
 
-    discovery_scan_kwargs: dict[str, Any] = {}
-    if _discovery_git_ref is not None and _discovery_git_service is not None:
-        discovery_scan_kwargs["git_ref"] = _discovery_git_ref
-        discovery_scan_kwargs["git_service"] = _discovery_git_service
+    discovery_scan_kwargs = _snapshot_discovery_scan_kwargs(
+        git_ref=_discovery_git_ref,
+        git_service=_discovery_git_service,
+    )
 
     assertion_index = AssertionScanner(workflow_base_dir).scan(**discovery_scan_kwargs)
     register_custom_assertions(assertion_index)

--- a/packages/core/src/runsight_core/yaml/parser.py
+++ b/packages/core/src/runsight_core/yaml/parser.py
@@ -368,6 +368,72 @@ def validate_tool_governance(
     return result
 
 
+def _is_warning_only_tool_definition_error(message: str) -> bool:
+    return "Tool code must define" in message or "Tool code has a syntax error" in message
+
+
+def _warning_only_declared_tool_ids(validation_result: ValidationResult) -> set[str]:
+    return {
+        issue.context
+        for issue in validation_result.warnings
+        if issue.source == "tool_definitions"
+        and issue.context is not None
+        and _is_warning_only_tool_definition_error(issue.message)
+    }
+
+
+def _read_declared_tool_yaml(
+    tool_id: str,
+    *,
+    base_dir: str,
+    git_ref: str | None,
+    git_service: Any,
+) -> str | None:
+    relative_path = f"custom/tools/{tool_id}.yaml"
+    if git_ref is not None:
+        try:
+            return git_service.read_file(relative_path, git_ref)
+        except Exception:
+            return None
+
+    expected_file = Path(base_dir) / relative_path
+    if not expected_file.exists():
+        return None
+    return expected_file.read_text(encoding="utf-8")
+
+
+def _collect_warning_only_declared_tool_issues(
+    file_def: RunsightWorkflowFile,
+    *,
+    base_dir: str,
+    git_ref: str | None,
+    git_service: Any,
+) -> dict[str, str]:
+    tool_scanner = ToolScanner(base_dir)
+    issues: dict[str, str] = {}
+
+    for tool_id in file_def.tools:
+        if tool_id in RESERVED_BUILTIN_TOOL_IDS:
+            continue
+        raw_yaml = _read_declared_tool_yaml(
+            tool_id,
+            base_dir=base_dir,
+            git_ref=git_ref,
+            git_service=git_service,
+        )
+        if raw_yaml is None:
+            continue
+        expected_file = Path(base_dir) / "custom" / "tools" / f"{tool_id}.yaml"
+        try:
+            tool_scanner._scan_yaml_content(expected_file, raw_yaml)
+        except ValueError as exc:
+            message = str(exc)
+            if expected_file.name in message and _is_warning_only_tool_definition_error(message):
+                issues[tool_id] = message
+
+    return issues
+
+
 def _validate_declared_tool_definitions(
     file_def: RunsightWorkflowFile,
     *,
@@ -404,8 +470,25 @@ def _validate_declared_tool_definitions(
         resolve_kwargs["git_ref"] = git_ref
         resolve_kwargs["git_service"] = git_service
 
+    warning_only_tool_issues = _collect_warning_only_declared_tool_issues(
+        file_def,
+        base_dir=base_dir,
+        git_ref=git_ref,
+        git_service=git_service,
+    )
+    for tool_id, message in warning_only_tool_issues.items():
+        result.add_warning(
+            f"Tool '{tool_id}': {message}",
+            source="tool_definitions",
+            context=tool_id,
+        )
+    warning_only_tool_ids = set(warning_only_tool_issues)
+
     try:
-        discovered_tools = ToolScanner(base_dir).scan(**scan_kwargs).ids()
+        scanner_kwargs: dict[str, Any] = {}
+        if warning_only_tool_ids:
+            scanner_kwargs["ignored_tool_ids"] = warning_only_tool_ids
+        discovered_tools = ToolScanner(base_dir, **scanner_kwargs).scan(**scan_kwargs).ids()
     except ValueError as exc:
         scanner_message = str(exc)
         add_issue = result.add_error if fail_closed else result.add_warning
@@ -427,11 +510,10 @@ def _validate_declared_tool_definitions(
                     return result
                 continue
 
-            if expected_file.name in scanner_message and (
-                "Tool code must define" in scanner_message
-                or "Tool code has a syntax error" in scanner_message
+            if expected_file.name in scanner_message and _is_warning_only_tool_definition_error(
+                scanner_message
             ):
-                add_issue(
+                result.add_warning(
                     f"Tool '{tool_id}': {scanner_message}",
                     source="tool_definitions",
                     context=tool_id,
@@ -462,6 +544,8 @@ def _validate_declared_tool_definitions(
 
         if tool_id in RESERVED_BUILTIN_TOOL_IDS:
             continue
+        if tool_id in warning_only_tool_ids:
+            continue
 
         tool_meta = discovered_tools.get(tool_id)
         if tool_meta is None:
@@ -489,7 +573,11 @@ def _validate_declared_tool_definitions(
             continue
 
         try:
-            _resolve_tool_for_parser(tool_id, **resolve_kwargs)
+            _resolve_tool_for_parser(
+                tool_id,
+                ignore_tool_ids=warning_only_tool_ids,
+                **resolve_kwargs,
+            )
         except ValueError as exc:
             add_issue = result.add_error if fail_closed else result.add_warning
             add_issue(f"Tool '{tool_id}': {exc}", source="tool_definitions", context=tool_id)
@@ -504,6 +592,7 @@ def _resolve_tool_for_parser(
     exits: object | None = None,
     git_ref: str | None = None,
     git_service: Any = None,
+    ignore_tool_ids: Collection[str] = (),
 ) -> object:
     """Resolve a tool with only the parser context that its canonical ID needs."""
     kwargs: Dict[str, object] = {}
@@ -517,6 +606,8 @@ def _resolve_tool_for_parser(
     if git_ref is not None and git_service is not None:
         kwargs["git_ref"] = git_ref
         kwargs["git_service"] = git_service
+    if ignore_tool_ids:
+        kwargs["ignore_tool_ids"] = tuple(ignore_tool_ids)
 
     return resolve_tool_id(tool_id, **kwargs)
 
@@ -528,6 +619,7 @@ def _attach_tool_runtime_metadata(
     base_dir: str,
     git_ref: str | None = None,
     git_service: Any = None,
+    ignore_tool_ids: Collection[str] = (),
 ) -> object:
     """Annotate a resolved ToolInstance with ID/type metadata for isolation."""
     setattr(tool, "source", tool_id)
@@ -535,7 +627,10 @@ def _attach_tool_runtime_metadata(
         setattr(tool, "tool_type", "builtin")
     else:
         scan_kwargs = _snapshot_discovery_scan_kwargs(git_ref=git_ref, git_service=git_service)
-        tool_meta = ToolScanner(base_dir).scan(**scan_kwargs).ids().get(tool_id)
+        scanner_kwargs: dict[str, object] = {}
+        if ignore_tool_ids:
+            scanner_kwargs["ignored_tool_ids"] = ignore_tool_ids
+        tool_meta = ToolScanner(base_dir, **scanner_kwargs).scan(**scan_kwargs).ids().get(tool_id)
         setattr(tool, "tool_type", tool_meta.type if tool_meta is not None else "")
     setattr(tool, "config", {"id": tool_id})
     return tool
@@ -606,6 +701,7 @@ def _validate_and_resolve_tools(
     )
     if validation_result.has_errors:
         raise ValueError(validation_result.error_summary or "Tool governance validation failed")
+    warning_only_tool_ids = _warning_only_declared_tool_ids(validation_result)
     _resolve_tools_for_souls(
         file_def,
         souls_map,
@@ -613,6 +709,7 @@ def _validate_and_resolve_tools(
         git_ref=git_ref,
         git_service=git_service,
         strict=git_ref is not None,
+        warning_only_tool_ids=warning_only_tool_ids,
     )
 
 
@@ -897,7 +994,11 @@ def _resolve_tool_for_soul(
     workflow_base_dir: str,
     snapshot_kwargs: dict[str, Any],
     strict: bool,
+    warning_only_tool_ids: Collection[str],
 ) -> object | None:
+    if strict and tool_id in warning_only_tool_ids:
+        logger.warning("Skipping warning-only tool '%s' for soul '%s'", tool_id, soul_key)
+        return None
     kwargs = {"base_dir": workflow_base_dir, **snapshot_kwargs}
     if tool_id == "delegate":
         block_id_for_soul, block_def_for_soul = _find_block_for_soul(file_def, soul_key)
@@ -909,11 +1010,20 @@ def _resolve_tool_for_soul(
             )
         kwargs["exits"] = exits
     try:
-        return _resolve_tool_for_parser(tool_id, **kwargs)
+        return _resolve_tool_for_parser(
+            tool_id,
+            ignore_tool_ids=warning_only_tool_ids,
+            **kwargs,
+        )
     except Exception as exc:
         if strict:
             raise
-        logger.warning("Skipping unresolved tool '%s' for soul '%s': %s", tool_id, soul_key, exc)
+        logger.warning(
+            "Skipping unresolved tool '%s' for soul '%s': %s",
+            tool_id,
+            soul_key,
+            exc,
+        )
         return None
 
 
@@ -925,6 +1035,7 @@ def _resolve_tools_for_souls(
     git_ref: str | None = None,
     git_service: Any = None,
     strict: bool = False,
+    warning_only_tool_ids: Collection[str] = (),
 ) -> None:
     """Resolve ToolInstance objects per soul and assign to soul.resolved_tools."""
     snapshot_kwargs = _tool_snapshot_kwargs(git_ref, git_service)
@@ -944,6 +1055,7 @@ def _resolve_tools_for_souls(
                 workflow_base_dir=workflow_base_dir,
                 snapshot_kwargs=snapshot_kwargs,
                 strict=strict,
+                warning_only_tool_ids=warning_only_tool_ids,
             )
             if resolved_tool is None:
                 continue
@@ -952,6 +1064,7 @@ def _resolve_tools_for_souls(
                     resolved_tool,
                     tool_id,
                     base_dir=workflow_base_dir,
+                    ignore_tool_ids=warning_only_tool_ids,
                     **snapshot_kwargs,
                 )
             )

--- a/packages/core/tests/test_iso_008_credentials.py
+++ b/packages/core/tests/test_iso_008_credentials.py
@@ -1130,6 +1130,29 @@ class TestFileIOPathTraversal:
         # Ensure the file was NOT written outside base_dir
         assert not (tmp_path / "escape.txt").exists()
 
+    @pytest.mark.asyncio
+    async def test_symlink_to_sibling_prefix_directory_rejected(self, tmp_path: Path):
+        """Symlink escapes to a similarly named sibling must be rejected."""
+        from runsight_core.isolation.handlers import make_file_io_handler
+
+        base = tmp_path / "wf-safe"
+        sibling = tmp_path / "wf-safe-escape"
+        base.mkdir()
+        sibling.mkdir()
+        (sibling / "secret.txt").write_text("outside")
+        (base / "escape-link").symlink_to(sibling, target_is_directory=True)
+
+        handler = make_file_io_handler(base_dir=str(base))
+        result = await handler(
+            {
+                "action_type": "read",
+                "path": "escape-link/secret.txt",
+            }
+        )
+
+        assert "error" in result
+        assert "escape" in result["error"].lower() or "base" in result["error"].lower()
+
 
 # ---------------------------------------------------------------------------
 # AC7: ${ENV_VAR} resolved at engine level

--- a/packages/core/tests/test_observer.py
+++ b/packages/core/tests/test_observer.py
@@ -121,6 +121,26 @@ class TestCompositeObserver:
         composite.on_block_error("wf", "b1", "LinearBlock", 1.0, err)
         obs1.on_block_error.assert_called_once_with("wf", "b1", "LinearBlock", 1.0, err)
 
+    def test_child_run_id_does_not_leak_into_later_non_workflow_block_starts(self):
+        class ChildRunIdObserver:
+            def __init__(self) -> None:
+                self.on_block_start = MagicMock()
+
+            def get_child_run_id_for_block(self, block_id: str) -> str | None:
+                return "child_run_1" if block_id == "delegate" else None
+
+        child_run_id_observer = ChildRunIdObserver()
+        passive_observer = MagicMock()
+        composite = CompositeObserver(child_run_id_observer, passive_observer)
+
+        composite.on_block_start("wf", "delegate", "workflow")
+        composite.on_block_start("wf", "analyze", "linear")
+
+        assert passive_observer.on_block_start.call_args_list[0].kwargs["child_run_id"] == (
+            "child_run_1"
+        )
+        assert "child_run_id" not in passive_observer.on_block_start.call_args_list[1].kwargs
+
 
 class TestWorkflowObserverProtocol:
     def test_logging_observer_is_workflow_observer(self):

--- a/packages/core/tests/test_parser_workflow_block.py
+++ b/packages/core/tests/test_parser_workflow_block.py
@@ -7,6 +7,7 @@ This module tests:
 - Special-case handler for workflow blocks (placed before BLOCK_TYPE_REGISTRY lookup)
 - Input/output mapping configuration
 - max_depth resolution from block-level or global config
+- snapshot discovery context forwarding for nested workflow parses
 """
 
 import pytest
@@ -222,6 +223,79 @@ class TestParseWorkflowBlock:
         # Assert name-based invocation mappings are correctly set
         assert workflow_block.inputs == {"topic": "shared_memory.research_topic"}
         assert workflow_block.outputs == {"results.child_result": "results.child_step"}
+
+    def test_parse_workflow_block_forwards_snapshot_discovery_context_to_child_parse(self):
+        """Nested workflow parsing must preserve explicit snapshot discovery context."""
+        import runsight_core.yaml.parser as parser_module
+
+        child_yaml_dict = {
+            "version": "1.0",
+            "souls": _RESEARCHER_SOUL,
+            "blocks": {
+                "child_step": {
+                    "type": "linear",
+                    "soul_ref": "researcher",
+                }
+            },
+            "workflow": {
+                "name": "child_workflow",
+                "entry": "child_step",
+                "transitions": [{"from": "child_step", "to": None}],
+            },
+        }
+        child_file = RunsightWorkflowFile.model_validate(
+            _with_workflow_identity(child_yaml_dict, "child_workflow")
+        )
+
+        registry = WorkflowRegistry()
+        registry.register("child_workflow", child_file)
+
+        parent_yaml_dict = {
+            "version": "1.0",
+            "blocks": {
+                "invoke_child": {
+                    "type": "workflow",
+                    "workflow_ref": "child_workflow",
+                },
+            },
+            "workflow": {
+                "name": "parent_workflow",
+                "entry": "invoke_child",
+                "transitions": [{"from": "invoke_child", "to": None}],
+            },
+        }
+
+        original_parse = parser_module.parse_workflow_yaml
+        child_parse_calls: list[dict[str, object]] = []
+        git_service = type("GitServiceDouble", (), {"repo_path": "."})()
+
+        def _record_child_parse(*args, **kwargs):
+            child_parse_calls.append(kwargs)
+            return original_parse(*args, **kwargs)
+
+        from unittest.mock import patch
+
+        with (
+            patch.object(parser_module, "parse_workflow_yaml", side_effect=_record_child_parse),
+            patch.object(parser_module.AssertionScanner, "scan") as mock_assertion_scan,
+            patch.object(parser_module.SoulScanner, "scan") as mock_soul_scan,
+            patch.object(parser_module.ToolScanner, "scan") as mock_tool_scan,
+        ):
+            mock_assertion_scan.return_value.ids.return_value = {}
+            mock_soul_scan.return_value.ids.return_value = {}
+            mock_tool_scan.return_value.ids.return_value = {}
+
+            parent_workflow = original_parse(
+                _with_workflow_identity(parent_yaml_dict, "parent_workflow"),
+                workflow_registry=registry,
+                _discovery_git_ref="main",
+                _discovery_git_service=git_service,
+            )
+
+        assert isinstance(parent_workflow._blocks["invoke_child"], WorkflowBlock)
+        assert len(child_parse_calls) == 1
+        assert child_parse_calls[0]["_discovery_git_ref"] == "main"
+        assert child_parse_calls[0]["_discovery_git_service"] is git_service
 
     def test_parse_workflow_block_no_registry_raises(self):
         """

--- a/packages/core/tests/test_run789_tool_scanner_callers.py
+++ b/packages/core/tests/test_run789_tool_scanner_callers.py
@@ -8,6 +8,7 @@ from runsight_core.yaml.discovery import ToolMeta
 from runsight_core.yaml.parser import (
     _attach_tool_runtime_metadata,
     _validate_declared_tool_definitions,
+    parse_workflow_yaml,
 )
 from runsight_core.yaml.validation import ValidationResult, ValidationSeverity
 
@@ -91,6 +92,39 @@ def test_validate_declared_tool_definitions_warns_for_unknown_tool_id(tmp_path):
     assert warning.source == "tool_definitions"
     assert warning.context == "foo"
     assert "foo" in warning.message
+
+
+def test_parse_workflow_yaml_rejects_snapshot_discovery_without_git_service() -> None:
+    yaml_str = """\
+version: "1.0"
+id: wf_snapshot_contract
+kind: workflow
+blocks:
+  step:
+    type: code
+    code: |
+      def main(data):
+        return {"ok": True}
+workflow:
+  name: Snapshot Contract Workflow
+  entry: step
+  transitions:
+    - from: step
+      to: null
+"""
+
+    with patch("runsight_core.yaml.parser.AssertionScanner") as mock_assertion_scanner:
+        try:
+            parse_workflow_yaml(yaml_str, _discovery_git_ref="main")
+        except ValueError as exc:
+            assert "main" in str(exc)
+            assert "git service unavailable" in str(exc).lower()
+        else:
+            raise AssertionError(
+                "Expected parse_workflow_yaml to reject incomplete snapshot discovery context"
+            )
+
+    mock_assertion_scanner.assert_not_called()
 
 
 def test_validate_declared_tool_definitions_warns_for_missing_custom_metadata_when_required(
@@ -229,6 +263,23 @@ def test_attach_tool_runtime_metadata_uses_tool_scanner(tmp_path):
     mock_scanner.assert_called_once_with(str(tmp_path))
     mock_scanner.return_value.scan.assert_called_once()
     mock_scanner.return_value.scan.return_value.ids.assert_called_once()
+
+
+def test_resolve_custom_tool_id_rejects_snapshot_discovery_without_git_service(tmp_path):
+    from runsight_core.tools._catalog import _resolve_custom_tool_id
+
+    with patch("runsight_core.tools._catalog.ToolScanner") as mock_scanner:
+        try:
+            _resolve_custom_tool_id("lookup_profile", base_dir=str(tmp_path), git_ref="main")
+        except ValueError as exc:
+            assert "main" in str(exc)
+            assert "git service unavailable" in str(exc).lower()
+        else:
+            raise AssertionError(
+                "Expected _resolve_custom_tool_id to reject incomplete snapshot discovery context"
+            )
+
+    mock_scanner.assert_not_called()
 
 
 def test_resolve_custom_tool_id_uses_tool_scanner(tmp_path):

--- a/packages/core/tests/test_workflow_block_execute.py
+++ b/packages/core/tests/test_workflow_block_execute.py
@@ -110,14 +110,15 @@ async def test_private_child_state_input_mapping_raises(base_parent_state, mock_
 
 
 @pytest.mark.asyncio
-async def test_workflow_block_execute_requires_child_doubles_to_expose_assertion_configs(
+async def test_workflow_block_execute_uses_child_double_without_assertion_configs(
     base_parent_state,
 ):
-    """WorkflowBlock.execute must not assume child doubles expose assertion_configs()."""
+    """WorkflowBlock.execute must accept child doubles without assertion_configs()."""
 
+    child_final_state = WorkflowState()
     child_workflow = SimpleNamespace(
         name="child_wf",
-        run=AsyncMock(return_value=WorkflowState()),
+        run=AsyncMock(return_value=child_final_state),
     )
     observer = MagicMock()
     block = WorkflowBlock(
@@ -128,8 +129,10 @@ async def test_workflow_block_execute_requires_child_doubles_to_expose_assertion
         max_depth=10,
     )
 
-    with pytest.raises(AttributeError, match="assertion_configs"):
-        await _run_block(block, base_parent_state, observer=observer)
+    result = await _run_block(block, base_parent_state, observer=observer)
+
+    assert isinstance(result, WorkflowState)
+    child_workflow.run.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/packages/core/tests/test_workflow_block_execute.py
+++ b/packages/core/tests/test_workflow_block_execute.py
@@ -2,18 +2,21 @@
 Tests for WorkflowBlock execution, mapping, and state isolation.
 """
 
-from unittest.mock import AsyncMock
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from runsight_core import WorkflowBlock
 from runsight_core.state import BlockResult, WorkflowState
 
 
-async def _run_block(block, state: WorkflowState) -> WorkflowState:
+async def _run_block(block, state: WorkflowState, *, observer=None) -> WorkflowState:
     """Helper: build BlockContext, run block, apply output → WorkflowState."""
     from runsight_core.block_io import BlockOutput, apply_block_output, build_block_context
 
     ctx = build_block_context(block, state)
+    if observer is not None:
+        ctx.inputs["observer"] = observer
     output = await block.execute(ctx)
     if isinstance(output, WorkflowState):
         return output
@@ -104,6 +107,29 @@ async def test_private_child_state_input_mapping_raises(base_parent_state, mock_
             max_depth=10,
         )
         await _run_block(block, base_parent_state)
+
+
+@pytest.mark.asyncio
+async def test_workflow_block_execute_requires_child_doubles_to_expose_assertion_configs(
+    base_parent_state,
+):
+    """WorkflowBlock.execute must not assume child doubles expose assertion_configs()."""
+
+    child_workflow = SimpleNamespace(
+        name="child_wf",
+        run=AsyncMock(return_value=WorkflowState()),
+    )
+    observer = MagicMock()
+    block = WorkflowBlock(
+        block_id="test_missing_assertion_configs",
+        child_workflow=child_workflow,
+        inputs={},
+        outputs={},
+        max_depth=10,
+    )
+
+    with pytest.raises(AttributeError, match="assertion_configs"):
+        await _run_block(block, base_parent_state, observer=observer)
 
 
 @pytest.mark.asyncio

--- a/packages/core/tests/unit/test_builtin_tools.py
+++ b/packages/core/tests/unit/test_builtin_tools.py
@@ -693,6 +693,23 @@ class TestFileIoToolExecute:
             await tool.execute({"action": "read", "path": "/etc/passwd"})
 
     @pytest.mark.asyncio
+    async def test_symlink_to_sibling_prefix_directory_rejected(self, tmp_path: Path):
+        """A symlink escape to a similarly named sibling must be rejected."""
+        from runsight_core.tools.file_io import create_file_io_tool
+
+        base = tmp_path / "sandbox"
+        sibling = tmp_path / "sandbox-escape"
+        base.mkdir()
+        sibling.mkdir()
+        (sibling / "secret.txt").write_text("outside")
+        (base / "escape-link").symlink_to(sibling, target_is_directory=True)
+
+        tool = create_file_io_tool(base_dir=str(base))
+
+        with pytest.raises((ValueError, PermissionError)):
+            await tool.execute({"action": "read", "path": "escape-link/secret.txt"})
+
+    @pytest.mark.asyncio
     async def test_read_nonexistent_file_returns_error(self, tmp_path: Path):
         """Reading a file that doesn't exist returns an error (not crash)."""
         from runsight_core.tools.file_io import create_file_io_tool

--- a/packages/core/tests/unit/test_parser_tool_validation.py
+++ b/packages/core/tests/unit/test_parser_tool_validation.py
@@ -75,6 +75,26 @@ def _write_custom_tool_file(tmp_path, slug: str, contents: str) -> None:
     (tools_dir / f"{slug}.yaml").write_text(content, encoding="utf-8")
 
 
+class _SnapshotGitService:
+    def __init__(self, base_dir):
+        self._base_dir = base_dir
+
+    def list_files(self, ref: str, path_prefix: str) -> list[str]:
+        del ref
+        root = self._base_dir / path_prefix.rstrip("/")
+        if not root.exists():
+            return []
+        return sorted(
+            path.relative_to(self._base_dir).as_posix()
+            for path in root.rglob("*")
+            if path.is_file() and path.suffix in {".yaml", ".yml"}
+        )
+
+    def read_file(self, path: str, ref: str) -> str:
+        del ref
+        return (self._base_dir / path).read_text(encoding="utf-8")
+
+
 # ===========================================================================
 # AC1: Valid YAML — soul.resolved_tools populated with ToolInstance objects
 # ===========================================================================
@@ -861,6 +881,151 @@ souls:
 
         assert soul.tools == [slug]
         assert soul.resolved_tools == []
+
+    def test_strict_snapshot_skips_multiple_warning_only_corrupt_tools_and_resolves_sibling(
+        self, tmp_path
+    ):
+        """Strict snapshot parsing should skip all warning-only corrupt tools without blocking siblings."""
+        _write_custom_tool_file(
+            tmp_path,
+            "bad_one",
+            """
+            version: "1.0"
+            type: custom
+            executor: python
+            name: Bad One
+            description: Corrupt metadata should warn and skip.
+            parameters:
+              type: object
+            code: |
+              def main(args):
+                  return {"broken":
+            """,
+        )
+        _write_custom_tool_file(
+            tmp_path,
+            "bad_two",
+            """
+            version: "1.0"
+            type: custom
+            executor: python
+            name: Bad Two
+            description: Another corrupt tool should also warn and skip.
+            parameters:
+              type: object
+            code: |
+              def main(args):
+                  return {"still_broken":
+            """,
+        )
+        _write_custom_tool_file(
+            tmp_path,
+            "good_three",
+            """
+            version: "1.0"
+            type: custom
+            executor: python
+            name: Good Three
+            description: Valid metadata should still resolve.
+            parameters:
+              type: object
+            code: |
+              def main(args):
+                  return {"ok": True}
+            """,
+        )
+        workflow_file = _write_workflow_file(
+            tmp_path,
+            _make_yaml(
+                tools="""\
+tools:
+  - bad_one
+  - bad_two
+  - good_three""",
+                souls="""\
+souls:
+  my_agent:
+    id: my_agent
+    kind: soul
+    name: Agent
+    role: Agent
+    system_prompt: Do things.
+    tools:
+      - bad_one
+      - bad_two
+      - good_three""",
+                blocks="""\
+  my_block:
+    type: linear
+    soul_ref: my_agent""",
+                transitions="""\
+    - from: my_block
+      to: null""",
+            ),
+        )
+
+        workflow = parse_workflow_yaml(
+            workflow_file,
+            _discovery_git_ref="main",
+            _discovery_git_service=_SnapshotGitService(tmp_path),
+        )
+
+        soul = workflow.blocks["my_block"].soul
+        assert soul.tools == ["bad_one", "bad_two", "good_three"]
+        assert soul.resolved_tools is not None
+        assert [tool.name for tool in soul.resolved_tools] == ["good_three"]
+
+    def test_strict_snapshot_still_fails_closed_for_missing_sibling_tool(self, tmp_path):
+        """Warning-only corrupt tools must not hide other missing declared snapshot assets."""
+        _write_custom_tool_file(
+            tmp_path,
+            "bad_one",
+            """
+            version: "1.0"
+            type: custom
+            executor: python
+            name: Bad One
+            description: Corrupt metadata should warn and skip.
+            parameters:
+              type: object
+            code: |
+              def main(args):
+                  return {"broken":
+            """,
+        )
+        workflow_file = _write_workflow_file(
+            tmp_path,
+            _make_yaml(
+                tools="""\
+tools:
+  - bad_one
+  - missing_unused""",
+                souls="""\
+souls:
+  my_agent:
+    id: my_agent
+    kind: soul
+    name: Agent
+    role: Agent
+    system_prompt: Do things.
+    tools:
+      - bad_one""",
+                blocks="""\
+  my_block:
+    type: linear
+    soul_ref: my_agent""",
+                transitions="""\
+    - from: my_block
+      to: null""",
+            ),
+        )
+
+        with pytest.raises(ValueError, match="missing_unused"):
+            parse_workflow_yaml(
+                workflow_file,
+                _discovery_git_ref="main",
+                _discovery_git_service=_SnapshotGitService(tmp_path),
+            )
 
     def test_valid_builtin_and_discovered_custom_tool_ids_parse_successfully(self, tmp_path):
         """A workflow mixing canonical builtin and discovered custom IDs should parse cleanly."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runsight-workspace"
-version = "0.4.19"
+version = "0.4.20"
 requires-python = ">=3.11"
 dependencies = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runsight-workspace"
-version = "0.4.15"
+version = "0.4.16"
 requires-python = ">=3.11"
 dependencies = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runsight-workspace"
-version = "0.4.20"
+version = "0.4.15"
 requires-python = ">=3.11"
 dependencies = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runsight-workspace"
-version = "0.4.18"
+version = "0.4.19"
 requires-python = ">=3.11"
 dependencies = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runsight-workspace"
-version = "0.4.14"
+version = "0.4.15"
 requires-python = ">=3.11"
 dependencies = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runsight-workspace"
-version = "0.4.16"
+version = "0.4.17"
 requires-python = ">=3.11"
 dependencies = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runsight-workspace"
-version = "0.4.17"
+version = "0.4.18"
 requires-python = ">=3.11"
 dependencies = []
 

--- a/uv.lock
+++ b/uv.lock
@@ -2088,7 +2088,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "runsight-workspace"
-version = "0.4.20"
+version = "0.4.15"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -2088,7 +2088,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "runsight-workspace"
-version = "0.4.15"
+version = "0.4.16"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -2088,7 +2088,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "runsight-workspace"
-version = "0.4.17"
+version = "0.4.18"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -2088,7 +2088,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "runsight-workspace"
-version = "0.4.14"
+version = "0.4.15"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -2088,7 +2088,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "runsight-workspace"
-version = "0.4.18"
+version = "0.4.20"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -2088,7 +2088,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "runsight-workspace"
-version = "0.4.16"
+version = "0.4.17"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- complete the RUN-976 branch work for nested child stream ownership and root-only dashboard behavior
- resolve reviewer follow-ups so late child subscribers receive terminal events, parent node_started emits child_run_id, child workflows use child-owned assertion configs, and parent child queues are cleaned up
- tighten explicit snapshot discovery so fake git services use `list_files(...)`, warning-only corrupt custom tool metadata stays warning-only across the full strict snapshot parse, valid siblings still resolve, and missing siblings still fail closed
- correct the workspace release version to 0.4.15 to match main at 0.4.14

Closes #62
Closes #64
Closes #65
Closes #66
Closes #67

## Validation
- uv run pytest -q apps/api/tests/logic/test_run952_stream_subscription.py::TestChildRunStreamOwnership::test_late_child_subscriber_still_receives_completed_terminal_event apps/api/tests/logic/test_run952_stream_subscription.py::TestChildRunStreamOwnership::test_late_child_subscriber_still_receives_failed_terminal_event apps/api/tests/logic/test_run607_nested_run_lifecycle.py::TestParentNodeStoresChildRunId::test_parent_node_started_event_includes_allocated_child_run_id apps/api/tests/logic/test_eval_observer.py::TestEvalObserverChildAssertionOwnership::test_nested_child_workflow_uses_its_own_assertions_without_mutating_parent_surface apps/api/tests/logic/test_run207_streaming_observer.py::TestChildStreamingObserverIsolation::test_child_queue_is_removed_after_child_completion apps/api/tests/logic/test_run207_streaming_observer.py::TestChildStreamingObserverIsolation::test_child_queue_is_removed_after_child_failure
- uv run pytest -q apps/api/tests/logic/test_run952_stream_subscription.py::TestChildRunStreamOwnership apps/api/tests/logic/test_run207_streaming_observer.py::TestChildStreamingObserverIsolation apps/api/tests/logic/test_eval_observer.py::TestEvalObserverChildStreamIsolation apps/api/tests/logic/test_eval_observer.py::TestEvalObserverChildAssertionOwnership apps/api/tests/logic/test_run607_nested_run_lifecycle.py::TestParentNodeStoresChildRunId
- uv run pytest -q apps/api/tests/logic/test_run347_wire_assertion_configs.py apps/api/tests/logic/test_run207_streaming_observer.py::TestStreamingObserverInCompositeChain
- uv run pytest -q packages/core/tests/unit/test_parser_tool_validation.py::TestCanonicalDiscoveredToolValidation::test_strict_snapshot_skips_multiple_warning_only_corrupt_tools_and_resolves_sibling packages/core/tests/unit/test_parser_tool_validation.py::TestCanonicalDiscoveredToolValidation::test_strict_snapshot_still_fails_closed_for_missing_sibling_tool apps/api/tests/test_run845_parser_warnings_e2e.py::test_bind_loop_warning_from_corrupt_metadata_does_not_block_execution
- uv run pytest -q packages/core/tests/unit/test_parser_tool_validation.py::TestCanonicalDiscoveredToolValidation::test_strict_snapshot_skips_multiple_warning_only_corrupt_tools_and_resolves_sibling packages/core/tests/unit/test_parser_tool_validation.py::TestCanonicalDiscoveredToolValidation::test_strict_snapshot_still_fails_closed_for_missing_sibling_tool packages/core/tests/test_observer.py packages/core/tests/test_workflow_block_execute.py packages/core/tests/test_run850_parser_decomposition.py apps/api/tests/logic/test_run606_execution_service_snapshot_resolution.py apps/api/tests/test_run707_sse_streaming_e2e.py apps/api/tests/logic/test_run800_eval_observer_custom_assertion.py apps/api/tests/test_run705_assertions_fire_e2e.py apps/api/tests/test_run706_api_e2e.py apps/api/tests/test_run958_execution_transport_integration.py apps/api/tests/test_run845_parser_warnings_e2e.py apps/api/tests/test_run929_workflow_input_redaction_integration.py::test_child_run_records_own_safe_snapshot_and_inherits_redaction_context -q
- uv run ruff check packages/core/src/runsight_core/yaml/discovery/_tool.py packages/core/src/runsight_core/tools/_catalog.py packages/core/src/runsight_core/yaml/discovery/_base.py packages/core/src/runsight_core/yaml/parser.py packages/core/tests/unit/test_parser_tool_validation.py apps/api/tests/logic/test_run606_execution_service_snapshot_resolution.py apps/api/tests/logic/test_run800_eval_observer_custom_assertion.py apps/api/tests/test_run705_assertions_fire_e2e.py apps/api/tests/test_run706_api_e2e.py apps/api/tests/test_run707_sse_streaming_e2e.py apps/api/tests/test_run845_parser_warnings_e2e.py apps/api/tests/test_run929_workflow_input_redaction_integration.py

## Review
- Blue: approve on final tip a6499246
- Yellow: approve on final tip a6499246
