### PR TITLE
docs(run-848): default local Docker exposure to loopback

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,15 @@ the onboarding flow helps you create your first workflow.
 Or use Docker:
 
 ```bash
-docker run -p 8000:8000 -v $(pwd):/workspace ghcr.io/runsight-ai/runsight
+docker run -p 127.0.0.1:8000:8000 -v "$(pwd)":/workspace ghcr.io/runsight-ai/runsight
 ```
 
 Mount the whole workspace root, not only `custom/`, if you want `.runsight/` DB and
 settings persistence across container restarts. Runsight keeps runtime-owned files under
 that workspace root in `.runsight/`.
+
+The self-hosted API is unauthenticated today. Keep local Docker usage bound to
+`127.0.0.1` unless you add your own proxy and authentication controls.
 
 **[Documentation](https://runsight.ai/docs)** · [GitHub Discussions](https://github.com/runsight-ai/runsight/discussions) · [Issues](https://github.com/runsight-ai/runsight/issues)
 

--- a/apps/site/src/content/docs/docs/getting-started/installation.md
+++ b/apps/site/src/content/docs/docs/getting-started/installation.md
@@ -3,6 +3,13 @@ title: Installation
 description: Install Runsight via uvx, Docker, or from source for development.
 ---
 
+:::caution
+Runsight's self-hosted API is unauthenticated today. For `uvx runsight`, use
+`--host 127.0.0.1` for local-only access instead of the default `0.0.0.0`. For
+Docker, keep host port publishing on loopback, for example
+`-p 127.0.0.1:8000:8000`, unless you add your own proxy and auth controls.
+:::
+
 ## uvx (recommended)
 
 The fastest way to run Runsight. Requires Python 3.11+ and [uv](https://docs.astral.sh/uv/).
@@ -12,6 +19,12 @@ uvx runsight
 ```
 
 This downloads and runs the `runsight` package in an isolated environment. Open [http://localhost:8000](http://localhost:8000).
+
+For loopback-only local use:
+
+```bash
+uvx runsight --host 127.0.0.1
+```
 
 Don't have `uv`? Install it first:
 
@@ -35,7 +48,7 @@ runsight [--host HOST] [--port PORT]
 Run Runsight in a container with the current directory mounted as the workspace.
 
 ```bash
-docker run -p 8000:8000 -v $(pwd):/workspace ghcr.io/runsight-ai/runsight
+docker run -p 127.0.0.1:8000:8000 -v "$(pwd)":/workspace ghcr.io/runsight-ai/runsight
 ```
 
 Or use Docker Compose:
@@ -44,13 +57,19 @@ Or use Docker Compose:
 docker compose up
 ```
 
-The included `docker-compose.yml` mounts the current directory at `/workspace`, exposes port 8000, and adds a healthcheck at `/health`.
+The included `docker-compose.yml` publishes `127.0.0.1:8000:8000`, stores the
+workspace in the named volume `workspace_data`, and adds a healthcheck at `/health`.
+If you want your current directory to be the workspace instead, use the `docker run`
+command above or edit `docker-compose.yml` to replace the named volume with a bind
+mount.
 
 ### What the container does
 
 - **Multi-stage build**: Node 20 builds the frontend, Python 3.12 runs the API server
 - **System dependencies**: git (required for GitOps features) and curl (healthcheck)
-- **Workspace**: `RUNSIGHT_BASE_PATH` defaults to `/workspace`. If no volume is mounted, a warning is printed and data won't persist when the container stops.
+- **Image runtime**: runs as a non-root `runsight` user
+- **Compose hardening**: the included `docker-compose.yml` drops Linux capabilities and sets `no-new-privileges`
+- **Workspace**: `RUNSIGHT_BASE_PATH` defaults to `/workspace`
 - **Healthcheck**: `curl -f http://localhost:8000/health` every 30 seconds
 
 ### Environment variables
@@ -94,11 +113,11 @@ uv run runsight
 ```
 
 ```bash
-# Terminal 2 — GUI dev server with hot-reload (port 5173)
+# Terminal 2 — GUI dev server with hot-reload (port 3000)
 pnpm -C apps/gui dev
 ```
 
-In development, the frontend dev server runs on [http://localhost:5173](http://localhost:5173) with Vite hot-reload. In production (Docker/uvx), the API server serves the built frontend directly on port 8000.
+In development, the frontend dev server runs on [http://localhost:3000](http://localhost:3000) with Vite hot-reload. In production (Docker/uvx), the API server serves the built frontend directly on port 8000.
 
 ### Project structure
 
@@ -138,6 +157,16 @@ pnpm run lint
 
 ## Git requirement
 
-Runsight requires git in the environment. When running for the first time, Runsight auto-initializes a git repository in the workspace if one doesn't exist. All workflow saves commit to git, simulation runs create branches, and run history is tied to commit SHAs.
+Runsight requires git in the environment. When running for the first time, Runsight
+auto-initializes a git repository in the workspace if one doesn't exist. Under the
+workspace root, it scaffolds `custom/workflows`, `custom/workflows/.canvas`,
+`custom/souls`, `custom/tools`, and `.runsight`. The default SQLite database lives at
+`.runsight/runsight.db`.
 
-If git is not available, the API server will start but git-dependent features (save, commit, simulation branches, fork recovery) will fail.
+All workflow saves commit to git, simulation runs create branches, and run history is
+tied to commit SHAs.
+
+If git is not available, the API server will start but git-dependent features (save,
+commit, simulation branches, fork recovery) will fail.
+
+<!-- Linear: RUN-821, RUN-847, RUN-848, RUN-944 — last verified against codebase 2026-04-26 -->

--- a/apps/site/src/content/docs/docs/getting-started/quickstart.mdx
+++ b/apps/site/src/content/docs/docs/getting-started/quickstart.mdx
@@ -9,16 +9,16 @@ import { Steps, FileTree } from '@astrojs/starlight/components';
 
 1. **Install and start Runsight**
 
-   The fastest way is `uvx`:
+   For local-only access with `uvx`:
 
    ```bash
-   uvx runsight
+   uvx runsight --host 127.0.0.1
    ```
 
    Or use Docker:
 
    ```bash
-   docker run -p 8000:8000 -v "$(pwd)":/workspace ghcr.io/runsight-ai/runsight
+   docker run -p 127.0.0.1:8000:8000 -v "$(pwd)":/workspace ghcr.io/runsight-ai/runsight
    ```
 
    Don't have `uv`? Install it first: `curl -LsSf https://astral.sh/uv/install.sh | sh`
@@ -119,3 +119,5 @@ import { Steps, FileTree } from '@astrojs/starlight/components';
 - [Custom Tools](/docs/tools/custom-tools) — give your agents tools defined as YAML files
 - [Assertions & Eval](/docs/evaluation/assertions) — add quality checks to your workflows
 - [Git Integration](/docs/execution/git-integration) — save, commit, and simulation branches
+
+{/* Linear: RUN-821, RUN-847, RUN-848, RUN-944 — last verified against codebase 2026-04-26 */}

--- a/apps/site/src/content/docs/docs/reference/cli-reference.md
+++ b/apps/site/src/content/docs/docs/reference/cli-reference.md
@@ -66,11 +66,11 @@ Runsight ships a multi-stage Dockerfile that bundles the frontend and backend in
 # Build the image
 docker build -t runsight .
 
-# Run with defaults
-docker run -p 8000:8000 runsight
+# Run for local-only access
+docker run -p 127.0.0.1:8000:8000 runsight
 
-# Mount a workspace directory for your workflows, souls, and tools
-docker run -p 8000:8000 -v $(pwd)/custom:/workspace/custom runsight
+# Mount the whole workspace root so .runsight state persists too
+docker run -p 127.0.0.1:8000:8000 -v "$(pwd)":/workspace runsight
 ```
 
 ### Environment variables
@@ -83,13 +83,20 @@ docker run -p 8000:8000 -v $(pwd)/custom:/workspace/custom runsight
 
 The container exposes port `8000` and includes a health check at `/health`.
 
+:::caution
+Publishing the container on a non-loopback interface exposes an unauthenticated API
+unless you add your own proxy or authentication controls.
+:::
+
 ### Passing CLI flags in Docker
 
 The default Docker `CMD` is `["runsight"]`. Override it to pass flags:
 
 ```bash
-docker run -p 3000:3000 runsight runsight --port 3000
+docker run -p 127.0.0.1:3000:3000 runsight runsight --port 3000
 ```
+
+<!-- Linear: RUN-821, RUN-847, RUN-848, RUN-944 — last verified against codebase 2026-04-26 -->
 
 ## Requirements
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
   runsight:
     build: .
     ports:
-      - "8000:8000"
+      - "127.0.0.1:8000:8000"
     volumes:
       - workspace_data:/workspace
     environment:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runsight-workspace"
-version = "0.4.18"
+version = "0.4.19"
 requires-python = ">=3.11"
 dependencies = []
 


### PR DESCRIPTION
## Summary
- default the included `docker-compose.yml` host publishing to `127.0.0.1:8000:8000`
- update install / quickstart / CLI docs and README to match the safer local-default Docker posture
- clarify local-only guidance for `uvx runsight` vs Docker host publishing
- bump the workspace version for the behavior/docs change

## Verification
- `pnpm -C apps/site build`

## Related
- GitHub roadmap issue: #43
- Linear: RUN-848, RUN-944

## Notes
- I did not find a direct existing GitHub issue for this exact Docker/local-defaults cleanup, so this PR links the closest related public GitHub issue (`#43`) plus the Linear tracking.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default local Docker exposure to `127.0.0.1` and update README, Installation, Quickstart, and CLI docs to promote safer local defaults and clarify the unauthenticated API (Linear: RUN-848, RUN-944). Also bumps `runsight-workspace` to `0.4.19`.

- **Migration**
  - `docker-compose.yml` now publishes `127.0.0.1:8000:8000`. To expose outside localhost, change to `0.0.0.0:8000:8000` and add your own proxy/auth.
  - For local-only `uvx` usage, run `uvx runsight --host 127.0.0.1`.

<sup>Written for commit 14d45835c3e564337c05e42d64280d0a55ce44e8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

