### PR TITLE
feat(RUN-85): add workflow-scoped Direct API invocation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,7 +77,7 @@ ENV RUNSIGHT_BASE_PATH=/workspace \
 EXPOSE 8000
 
 ENTRYPOINT ["/app/docker-entrypoint.sh"]
-CMD ["runsight"]
+CMD ["runsight", "--host", "0.0.0.0"]
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
     CMD curl -f http://localhost:8000/health || exit 1

--- a/apps/api/src/runsight_api/alembic/versions/004_add_run_source_provenance.py
+++ b/apps/api/src/runsight_api/alembic/versions/004_add_run_source_provenance.py
@@ -1,0 +1,63 @@
+"""Add run source provenance columns.
+
+Revision ID: 004_add_run_source_provenance
+Revises: 003_add_run_workflow_input_snapshots
+Create Date: 2026-04-26
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "004_add_run_source_provenance"
+down_revision: Union[str, None] = "003_add_run_workflow_input_snapshots"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _run_columns() -> set[str]:
+    bind = op.get_bind()
+    return {column["name"] for column in sa.inspect(bind).get_columns("run")}
+
+
+def _run_index_names() -> set[str]:
+    bind = op.get_bind()
+    return {index["name"] for index in sa.inspect(bind).get_indexes("run")}
+
+
+def upgrade() -> None:
+    """Add nullable source provenance fields and lookup indexes."""
+    existing_columns = _run_columns()
+    with op.batch_alter_table("run") as batch_op:
+        if "source_correlation_id" not in existing_columns:
+            batch_op.add_column(sa.Column("source_correlation_id", sa.String(), nullable=True))
+        if "source_metadata" not in existing_columns:
+            batch_op.add_column(sa.Column("source_metadata", sa.JSON(), nullable=True))
+
+    existing_indexes = _run_index_names()
+    if "ix_run_source_created_at" not in existing_indexes:
+        op.create_index("ix_run_source_created_at", "run", ["source", "created_at"])
+    if "ix_run_workflow_source_created_at" not in existing_indexes:
+        op.create_index(
+            "ix_run_workflow_source_created_at",
+            "run",
+            ["workflow_id", "source", "created_at"],
+        )
+
+
+def downgrade() -> None:
+    """Remove source provenance fields and lookup indexes."""
+    existing_indexes = _run_index_names()
+    if "ix_run_workflow_source_created_at" in existing_indexes:
+        op.drop_index("ix_run_workflow_source_created_at", table_name="run")
+    if "ix_run_source_created_at" in existing_indexes:
+        op.drop_index("ix_run_source_created_at", table_name="run")
+
+    existing_columns = _run_columns()
+    with op.batch_alter_table("run") as batch_op:
+        if "source_metadata" in existing_columns:
+            batch_op.drop_column("source_metadata")
+        if "source_correlation_id" in existing_columns:
+            batch_op.drop_column("source_correlation_id")

--- a/apps/api/src/runsight_api/cli.py
+++ b/apps/api/src/runsight_api/cli.py
@@ -7,7 +7,7 @@ import uvicorn
 
 def main() -> None:
     # Parse --host and --port from argv (keep it minimal)
-    host = "0.0.0.0"
+    host = "127.0.0.1"
     port = 8000
 
     args = sys.argv[1:]
@@ -25,7 +25,7 @@ def main() -> None:
             print("Start the Runsight server.")
             print()
             print("Options:")
-            print("  --host HOST  Bind address (default: 0.0.0.0)")
+            print("  --host HOST  Bind address (default: 127.0.0.1)")
             print("  --port PORT  Bind port (default: 8000)")
             sys.exit(0)
         else:

--- a/apps/api/src/runsight_api/core/config.py
+++ b/apps/api/src/runsight_api/core/config.py
@@ -47,11 +47,16 @@ class Settings(BaseSettings):
     base_path: str = Field(default_factory=_default_base_path)
     db_url: str = _DB_URL_SENTINEL
     debug: bool = False
-    host: str = "0.0.0.0"
+    host: str = "127.0.0.1"
     port: int = 8000
     cors_origins: str = "http://localhost:3000"
     log_level: str = "INFO"
     log_format: str = "json"
+    external_invocation_enabled: bool = True
+    public_base_url: str | None = None
+    external_invocation_body_limit_bytes: int = 1_048_576
+    max_concurrent_runs: int = 5
+    max_pending_external_invocations: int = 32
 
     model_config = SettingsConfigDict(env_prefix="RUNSIGHT_")
 

--- a/apps/api/src/runsight_api/data/filesystem/workflow_repo.py
+++ b/apps/api/src/runsight_api/data/filesystem/workflow_repo.py
@@ -221,12 +221,15 @@ class WorkflowRepository:
                 git_service=git_service,
             )
 
-        return build_workflow_entity(
-            data=data,
-            stem=workflow_id,
-            validate_yaml_content=validate_snapshot_yaml,
-            raw_yaml=raw_yaml,
-        )
+        try:
+            return build_workflow_entity(
+                data=data,
+                stem=workflow_id,
+                validate_yaml_content=validate_snapshot_yaml,
+                raw_yaml=raw_yaml,
+            )
+        except ValueError as exc:
+            raise InputValidationError(str(exc)) from exc
 
     def _assert_valid_yaml_for_write(self, workflow_id: str, raw_yaml: str) -> None:
         assert_valid_yaml_for_write(workflow_id, raw_yaml)

--- a/apps/api/src/runsight_api/data/filesystem/workflow_repo.py
+++ b/apps/api/src/runsight_api/data/filesystem/workflow_repo.py
@@ -105,7 +105,12 @@ class WorkflowRepository:
         )
 
     def _validate_yaml_content(
-        self, workflow_id: str, raw_yaml: Optional[str]
+        self,
+        workflow_id: str,
+        raw_yaml: Optional[str],
+        *,
+        git_ref: str | None = None,
+        git_service: Any = None,
     ) -> tuple[bool, Optional[str], list[dict[str, Optional[str]]]]:
         return validate_yaml_content(
             base_path=self.base_path,
@@ -116,6 +121,8 @@ class WorkflowRepository:
             tool_governance_validator=validate_tool_governance,
             has_workflow_blocks=self._has_workflow_blocks,
             soul_scanner_cls=SoulScanner,
+            git_ref=git_ref,
+            git_service=git_service,
         )
 
     def _read_canvas_sidecar(self, stem: str) -> Optional[dict[str, Any]]:
@@ -187,6 +194,38 @@ class WorkflowRepository:
             canvas_state=canvas_state,
             raw_yaml=raw_yaml,
             extra_warnings=extra_warnings,
+        )
+
+    def build_entity_from_yaml(
+        self,
+        workflow_id: str,
+        raw_yaml: str,
+        *,
+        git_ref: str | None = None,
+        git_service: Any = None,
+    ) -> WorkflowEntity:
+        try:
+            data = yaml_mod.safe_load(raw_yaml) or {}
+        except Exception as exc:
+            raise InputValidationError(f"Malformed YAML: {exc}") from exc
+        if not isinstance(data, dict):
+            raise InputValidationError("YAML content is not a mapping")
+
+        def validate_snapshot_yaml(
+            stem: str, content: Optional[str]
+        ) -> tuple[bool, Optional[str], list[dict[str, Optional[str]]]]:
+            return self._validate_yaml_content(
+                stem,
+                content,
+                git_ref=git_ref,
+                git_service=git_service,
+            )
+
+        return build_workflow_entity(
+            data=data,
+            stem=workflow_id,
+            validate_yaml_content=validate_snapshot_yaml,
+            raw_yaml=raw_yaml,
         )
 
     def _assert_valid_yaml_for_write(self, workflow_id: str, raw_yaml: str) -> None:

--- a/apps/api/src/runsight_api/data/filesystem/workflow_yaml_validation.py
+++ b/apps/api/src/runsight_api/data/filesystem/workflow_yaml_validation.py
@@ -62,6 +62,8 @@ def validate_yaml_content(
     tool_governance_validator: Callable[..., Any],
     has_workflow_blocks: Callable[[RunsightWorkflowFile], bool],
     soul_scanner_cls: Callable[..., Any] = SoulScanner,
+    git_ref: str | None = None,
+    git_service: Any = None,
 ) -> tuple[bool, Optional[str], list[dict[str, Optional[str]]]]:
     """Validate raw YAML into the repository entity-facing result shape."""
     if not raw_yaml:
@@ -75,13 +77,19 @@ def validate_yaml_content(
 
         file_def = RunsightWorkflowFile.model_validate(data)
         effective_workflow_input_schema(file_def)
-        souls_map = soul_scanner_cls(base_path).scan().ids()
+        scan_kwargs = {}
+        if git_ref is not None:
+            scan_kwargs = {"git_ref": git_ref, "git_service": git_service}
+        souls_map = soul_scanner_cls(base_path).scan(**scan_kwargs).ids()
         validation_result = tool_governance_validator(file_def, souls_map)
         validation_result.merge(
             declared_tool_definitions_validator(
                 file_def,
                 base_dir=str(base_path),
                 require_custom_metadata=True,
+                git_ref=git_ref,
+                git_service=git_service,
+                fail_closed=git_ref is not None,
             )
         )
         warnings = validation_result.warnings_as_dicts()
@@ -94,7 +102,7 @@ def validate_yaml_content(
 
         if has_workflow_blocks(file_def):
             try:
-                registry_builder(workflow_id, raw_yaml)
+                registry_builder(workflow_id, raw_yaml, git_ref=git_ref, git_service=git_service)
             except ValueError as exc:
                 return False, str(exc), warnings
 

--- a/apps/api/src/runsight_api/data/repositories/run_read_model.py
+++ b/apps/api/src/runsight_api/data/repositories/run_read_model.py
@@ -80,6 +80,8 @@ class RunReadModel:
             if eval_total > 0:
                 eval_pass_pct = float(eval_pass_count or 0) / eval_total * 100
 
+            if not isinstance(run.__dict__.get("source_metadata"), dict):
+                run.__dict__["source_metadata"] = {}
             run.__dict__["run_number"] = int(run_number or 0)
             run.__dict__["eval_pass_pct"] = eval_pass_pct
             items.append(run)

--- a/apps/api/src/runsight_api/domain/entities/run.py
+++ b/apps/api/src/runsight_api/domain/entities/run.py
@@ -73,6 +73,7 @@ _SENSITIVE_SOURCE_METADATA_KEYS = {
     "password",
     "raw_body",
     "secret",
+    "token",
     "workflow_inputs",
 }
 

--- a/apps/api/src/runsight_api/domain/entities/run.py
+++ b/apps/api/src/runsight_api/domain/entities/run.py
@@ -1,8 +1,9 @@
+import json
 import time
 from enum import Enum
-from typing import Any, Dict, List, Literal, Optional, TypeAlias
+from typing import Any, Dict, Iterable, List, Literal, Optional, TypeAlias
 
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 from sqlmodel import JSON, Column, Field, SQLModel
 
 
@@ -56,8 +57,72 @@ class InvalidStateTransition(ValueError):
         super().__init__(f"Invalid state transition: {current.value} -> {target.value}")
 
 
+MAX_SOURCE_METADATA_BYTES = 4096
+_SENSITIVE_SOURCE_METADATA_KEYS = {
+    "authorization",
+    "auth",
+    "authentication",
+    "body",
+    "cookie",
+    "cookies",
+    "headers",
+    "idempotency",
+    "idempotency_key",
+    "input",
+    "inputs",
+    "password",
+    "raw_body",
+    "secret",
+    "workflow_inputs",
+}
+
+
+def _iter_source_metadata_keys(value: Any) -> Iterable[str]:
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            if isinstance(key, str):
+                yield key
+            yield from _iter_source_metadata_keys(nested)
+    elif isinstance(value, list):
+        for item in value:
+            yield from _iter_source_metadata_keys(item)
+
+
+def _is_sensitive_source_metadata_key(key: str) -> bool:
+    normalized = key.lower()
+    return normalized in _SENSITIVE_SOURCE_METADATA_KEYS or normalized.endswith("_token")
+
+
 class _RunCreationValidator(BaseModel):
     branch: str
+    source_metadata: Optional[Dict[str, Any]] = None
+
+    @field_validator("source_metadata", mode="before")
+    @classmethod
+    def validate_source_metadata(cls, value: Any) -> Dict[str, Any]:
+        if value is None:
+            return {}
+        if not isinstance(value, dict):
+            raise ValueError("source_metadata must be an object")
+
+        blocked_keys = sorted(
+            {
+                key
+                for key in _iter_source_metadata_keys(value)
+                if _is_sensitive_source_metadata_key(key)
+            }
+        )
+        if blocked_keys:
+            raise ValueError(f"source_metadata contains unsafe keys: {', '.join(blocked_keys)}")
+
+        try:
+            encoded = json.dumps(value, sort_keys=True, separators=(",", ":"))
+        except (TypeError, ValueError) as exc:
+            raise ValueError("source_metadata must be JSON serializable") from exc
+        if len(encoded.encode("utf-8")) > MAX_SOURCE_METADATA_BYTES:
+            raise ValueError("source_metadata is too large")
+
+        return value
 
 
 def validate_transition(current: RunStatus, target: RunStatus) -> None:
@@ -75,7 +140,9 @@ def validate_transition(current: RunStatus, target: RunStatus) -> None:
 
 class Run(SQLModel, table=True):
     def __init__(self, **data: Any):
-        _RunCreationValidator.model_validate(data)
+        validated = _RunCreationValidator.model_validate(data)
+        if "source_metadata" in data:
+            data["source_metadata"] = validated.source_metadata
         super().__init__(**data)
 
     id: str = Field(primary_key=True)
@@ -95,6 +162,10 @@ class Run(SQLModel, table=True):
     branch: str
     source: str = Field(default="manual")
     commit_sha: Optional[str] = Field(default=None)
+    source_correlation_id: Optional[str] = Field(default=None)
+    source_metadata: Dict[str, Any] = Field(
+        default_factory=dict, sa_column=Column(JSON, nullable=True)
+    )
     created_at: float = Field(default_factory=time.time)
     updated_at: float = Field(default_factory=time.time)
 

--- a/apps/api/src/runsight_api/domain/entities/run.py
+++ b/apps/api/src/runsight_api/domain/entities/run.py
@@ -101,29 +101,29 @@ class _RunCreationValidator(BaseModel):
     @field_validator("source_metadata", mode="before")
     @classmethod
     def validate_source_metadata(cls, value: Any) -> Dict[str, Any]:
-        if value is None:
-            return {}
-        if not isinstance(value, dict):
-            raise ValueError("source_metadata must be an object")
+        return validate_source_metadata(value)
 
-        blocked_keys = sorted(
-            {
-                key
-                for key in _iter_source_metadata_keys(value)
-                if _is_sensitive_source_metadata_key(key)
-            }
-        )
-        if blocked_keys:
-            raise ValueError(f"source_metadata contains unsafe keys: {', '.join(blocked_keys)}")
 
-        try:
-            encoded = json.dumps(value, sort_keys=True, separators=(",", ":"))
-        except (TypeError, ValueError) as exc:
-            raise ValueError("source_metadata must be JSON serializable") from exc
-        if len(encoded.encode("utf-8")) > MAX_SOURCE_METADATA_BYTES:
-            raise ValueError("source_metadata is too large")
+def validate_source_metadata(value: Any) -> Dict[str, Any]:
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise ValueError("source_metadata must be an object")
 
-        return value
+    blocked_keys = sorted(
+        {key for key in _iter_source_metadata_keys(value) if _is_sensitive_source_metadata_key(key)}
+    )
+    if blocked_keys:
+        raise ValueError(f"source_metadata contains unsafe keys: {', '.join(blocked_keys)}")
+
+    try:
+        encoded = json.dumps(value, sort_keys=True, separators=(",", ":"))
+    except (TypeError, ValueError) as exc:
+        raise ValueError("source_metadata must be JSON serializable") from exc
+    if len(encoded.encode("utf-8")) > MAX_SOURCE_METADATA_BYTES:
+        raise ValueError("source_metadata is too large")
+
+    return value
 
 
 def validate_transition(current: RunStatus, target: RunStatus) -> None:

--- a/apps/api/src/runsight_api/logic/services/api_run_service.py
+++ b/apps/api/src/runsight_api/logic/services/api_run_service.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from ...domain.errors import InputValidationError, RunFailed, RunNotFound, RunsightError
+from .workflow_run_invoker import (
+    WorkflowRunInvocation,
+    WorkflowRunInvocationFailureCode,
+    WorkflowRunInvoker,
+)
+
+
+class ApiRunService:
+    """Route-facing service for external Direct API workflow invocations."""
+
+    def __init__(
+        self,
+        *,
+        run_service: Any,
+        execution_service: Any,
+        runtime_admission: Any,
+    ) -> None:
+        self.run_service = run_service
+        self.execution_service = execution_service
+        self.runtime_admission = runtime_admission
+
+    async def create_direct_api_run(
+        self,
+        *,
+        workflow_id: str,
+        inputs: Mapping[str, Any],
+        source_correlation_id: str | None,
+        source_metadata: Mapping[str, Any],
+    ) -> Any:
+        if self.execution_service is None:
+            raise RunsightError(
+                "Execution runtime is unavailable",
+                error_code="RUNTIME_UNAVAILABLE",
+                status_code=503,
+            )
+
+        invocation = WorkflowRunInvocation.direct_api(
+            workflow_id=workflow_id,
+            inputs=inputs,
+            source_correlation_id=source_correlation_id,
+            source_metadata=source_metadata,
+        )
+        result = await WorkflowRunInvoker(
+            run_service=self.run_service,
+            execution_service=self.execution_service,
+            runtime_admission=self.runtime_admission,
+        ).invoke(invocation)
+
+        if not result.accepted:
+            self._raise_failure(result)
+
+        if result.run_id is None:
+            raise RunFailed("Run failed during launch")
+        run = self.run_service.get_run(result.run_id)
+        if run is None:
+            raise RunNotFound(f"Run {result.run_id} not found")
+        return run
+
+    def _raise_failure(self, result: Any) -> None:
+        failure_code = _failure_code_value(result.failure_code)
+        if failure_code == WorkflowRunInvocationFailureCode.runtime_unavailable.value:
+            raise RunsightError(
+                "Execution runtime is unavailable",
+                error_code="RUNTIME_UNAVAILABLE",
+                status_code=result.status_code or 503,
+                details=_safe_details(result.details),
+            )
+        if failure_code == WorkflowRunInvocationFailureCode.admission_saturated.value:
+            raise RunsightError(
+                "External invocation admission is saturated",
+                error_code="ADMISSION_SATURATED",
+                status_code=result.status_code or 429,
+                details=_safe_details(result.details),
+            )
+        if failure_code == WorkflowRunInvocationFailureCode.workflow_not_found.value:
+            raise RunsightError(
+                "Workflow not found",
+                error_code="WORKFLOW_NOT_FOUND",
+                status_code=404,
+            )
+        if failure_code == WorkflowRunInvocationFailureCode.workflow_input_validation_failed.value:
+            error_payload = result.details if isinstance(result.details, dict) else {}
+            details = error_payload.get("details")
+            raise InputValidationError(
+                "Workflow input validation failed",
+                error_code="WORKFLOW_INPUT_VALIDATION_ERROR",
+                status_code=422,
+                details=details if isinstance(details, dict) else None,
+            )
+        if failure_code == WorkflowRunInvocationFailureCode.execution_launch_failed.value:
+            raise RunFailed("Run failed during launch", run_id=result.run_id)
+        raise RunsightError("Run invocation failed", status_code=result.status_code or 500)
+
+
+def _failure_code_value(value: Any) -> str:
+    return str(getattr(value, "value", value))
+
+
+def _safe_details(value: Any) -> dict[str, Any] | None:
+    return value if isinstance(value, dict) else None

--- a/apps/api/src/runsight_api/logic/services/eval_service.py
+++ b/apps/api/src/runsight_api/logic/services/eval_service.py
@@ -266,7 +266,7 @@ class EvalService:
         source = getattr(run, "source", None)
         if not isinstance(branch, str) or not isinstance(source, str):
             return False
-        return branch == "main" and source in {"manual", "webhook", "schedule"}
+        return branch == "main" and source in {"manual", "api", "webhook", "schedule"}
 
     def get_run_regressions(self, run_id: str) -> dict | None:
         """Compute comparison-based regressions for a single run."""

--- a/apps/api/src/runsight_api/logic/services/execution_preparation.py
+++ b/apps/api/src/runsight_api/logic/services/execution_preparation.py
@@ -77,6 +77,14 @@ class PreparedWorkflow:
     commit_sha: Optional[str]
 
 
+@dataclass(frozen=True)
+class ResolvedWorkflowSnapshot:
+    workflow_id: str
+    yaml_content: str
+    commit_sha: Optional[str]
+    git_ref: Optional[str]
+
+
 class ExecutionPreparationService:
     """Owns requested-snapshot loading and runnable workflow construction."""
 
@@ -139,6 +147,47 @@ class ExecutionPreparationService:
             yaml_content = wf_entity.yaml
             commit_sha = get_workflow_commit_sha(workflow_path)
 
+        return self._prepare_yaml_for_launch(
+            workflow_id=workflow_id,
+            yaml_content=yaml_content,
+            commit_sha=commit_sha,
+            git_ref=registry_git_ref,
+            git_service=registry_git_service,
+            parser=parser,
+            prepare_runtime_workflow=prepare_runtime_workflow,
+            requested_ref=explicit_branch,
+        )
+
+    def prepare_resolved_snapshot_for_launch(
+        self,
+        *,
+        snapshot: ResolvedWorkflowSnapshot,
+        parser: Callable[..., Any],
+        prepare_runtime_workflow: Callable[..., tuple[dict[str, Any], RunsightTeamRunner | None]],
+    ) -> PreparedWorkflow:
+        return self._prepare_yaml_for_launch(
+            workflow_id=snapshot.workflow_id,
+            yaml_content=snapshot.yaml_content,
+            commit_sha=snapshot.commit_sha,
+            git_ref=snapshot.git_ref,
+            git_service=self.git_service if snapshot.git_ref is not None else None,
+            parser=parser,
+            prepare_runtime_workflow=prepare_runtime_workflow,
+            requested_ref=snapshot.git_ref,
+        )
+
+    def _prepare_yaml_for_launch(
+        self,
+        *,
+        workflow_id: str,
+        yaml_content: str,
+        commit_sha: Optional[str],
+        git_ref: str | None,
+        git_service: Any,
+        parser: Callable[..., Any],
+        prepare_runtime_workflow: Callable[..., tuple[dict[str, Any], RunsightTeamRunner | None]],
+        requested_ref: str | None,
+    ) -> PreparedWorkflow:
         api_keys = self.resolve_api_keys()
         try:
             workflow_definition, runner = prepare_runtime_workflow(
@@ -154,8 +203,8 @@ class ExecutionPreparationService:
                 workflow_registry = registry_builder(
                     workflow_id,
                     yaml_content,
-                    git_ref=registry_git_ref,
-                    git_service=registry_git_service,
+                    git_ref=git_ref,
+                    git_service=git_service,
                 )
 
             workflow = parser(
@@ -164,14 +213,14 @@ class ExecutionPreparationService:
                 api_keys=api_keys,
                 runner=runner,
                 _base_dir=str(getattr(self.workflow_repo, "base_path", ".")),
-                _discovery_git_ref=registry_git_ref,
-                _discovery_git_service=registry_git_service,
+                _discovery_git_ref=git_ref,
+                _discovery_git_service=git_service,
             )
         except Exception as exc:
-            if explicit_branch is not None:
+            if requested_ref is not None:
                 raise ValueError(
                     f"Requested snapshot could not be loaded for workflow "
-                    f"{_workflow_ref(workflow_id)} on ref {explicit_branch!r}: "
+                    f"{_workflow_ref(workflow_id)} on ref {requested_ref!r}: "
                     f"{_snapshot_failure_reason(exc)}"
                 ) from exc
             raise

--- a/apps/api/src/runsight_api/logic/services/execution_runtime.py
+++ b/apps/api/src/runsight_api/logic/services/execution_runtime.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import traceback
 from collections.abc import Mapping
+from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
 from runsight_core.observer import CompositeObserver, LoggingObserver
@@ -14,6 +15,18 @@ from ..observers.execution_observer import ExecutionObserver
 from ..observers.streaming_observer import StreamingObserver
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class BackgroundTaskHandle:
+    task: asyncio.Task
+    release_external_invocation_on_done: bool = True
+
+    def add_done_callback(self, callback) -> None:
+        self.task.add_done_callback(callback)
+
+    def done(self) -> bool:
+        return self.task.done()
 
 
 def _split_runtime_inputs(inputs: Any) -> tuple[dict[str, Any], Any | None]:
@@ -51,10 +64,11 @@ class ExecutionRuntimeCoordinator:
         self.running_tasks: Dict[str, asyncio.Task] = {}
         self.semaphore = asyncio.Semaphore(max_concurrent_runs)
 
-    def track_background_task(self, run_id: str, coroutine) -> None:
+    def track_background_task(self, run_id: str, coroutine) -> BackgroundTaskHandle:
         task = asyncio.create_task(coroutine)
         self.running_tasks[run_id] = task
         task.add_done_callback(lambda t: self.running_tasks.pop(run_id, None))
+        return BackgroundTaskHandle(task)
 
     def cancel(self, run_id: str) -> bool:
         task = self.running_tasks.get(run_id)

--- a/apps/api/src/runsight_api/logic/services/execution_service.py
+++ b/apps/api/src/runsight_api/logic/services/execution_service.py
@@ -25,7 +25,11 @@ from .execution_preparation import (
     get_workflow_commit_sha,
     has_workflow_blocks,
 )
-from .execution_runtime import ExecutionRuntimeCoordinator, build_assertion_configs
+from .execution_runtime import (
+    BackgroundTaskHandle,
+    ExecutionRuntimeCoordinator,
+    build_assertion_configs,
+)
 from .execution_stream_registry import ExecutionStreamRegistry
 
 logger = logging.getLogger(__name__)
@@ -454,7 +458,7 @@ class ExecutionService:
         workflow_id: str,
         inputs: PreparedRunInputs,
         branch: str | None = None,
-    ) -> None:
+    ) -> BackgroundTaskHandle | None:
         """Prepare a workflow snapshot, then schedule background execution."""
         if not isinstance(inputs, PreparedRunInputs):
             raise TypeError("launch_execution inputs must be PreparedRunInputs")
@@ -473,7 +477,7 @@ class ExecutionService:
                 logger.info(
                     "Run %s was cancelled during prepare; skipping execution launch", run_id
                 )
-                return
+                return None
         except Exception as e:
             logger.exception(
                 "Failed to prepare workflow for run %s (workflow=%s, requested_ref=%r): %s",
@@ -483,9 +487,9 @@ class ExecutionService:
                 e,
             )
             self._fail_run_on_prepare_error(run_id, e)
-            return
+            return None
 
-        self._runtime.track_background_task(
+        return self._runtime.track_background_task(
             run_id, self._run_workflow(run_id, prepared.workflow, inputs)
         )
 
@@ -581,7 +585,7 @@ class ExecutionService:
         inputs: PreparedRunInputs,
         *,
         snapshot: WorkflowRunSnapshot,
-    ) -> None:
+    ) -> BackgroundTaskHandle | None:
         if workflow_id != snapshot.workflow_id:
             raise ValueError("workflow_id must match resolved workflow snapshot")
         if not isinstance(inputs, PreparedRunInputs):
@@ -598,7 +602,7 @@ class ExecutionService:
                 logger.info(
                     "Run %s was cancelled during prepare; skipping execution launch", run_id
                 )
-                return
+                return None
         except Exception as e:
             logger.exception(
                 "Failed to prepare workflow for run %s (workflow=%s, requested_ref=%r): %s",
@@ -608,9 +612,9 @@ class ExecutionService:
                 e,
             )
             self._fail_run_on_prepare_error(run_id, e)
-            return
+            return None
 
-        self._runtime.track_background_task(
+        return self._runtime.track_background_task(
             run_id, self._run_workflow(run_id, prepared.workflow, inputs)
         )
 

--- a/apps/api/src/runsight_api/logic/services/execution_service.py
+++ b/apps/api/src/runsight_api/logic/services/execution_service.py
@@ -1,5 +1,6 @@
 """ExecutionService facade for execution collaborators."""
 
+import asyncio
 import copy
 import logging
 from collections.abc import Iterator, Mapping
@@ -592,10 +593,9 @@ class ExecutionService:
             raise TypeError("launch_execution inputs must be PreparedRunInputs")
 
         try:
-            prepared = self._preparation.prepare_resolved_snapshot_for_launch(
-                snapshot=snapshot.execution_snapshot(),
-                parser=parse_workflow_yaml,
-                prepare_runtime_workflow=self._prepare_runtime_workflow,
+            prepared = await asyncio.to_thread(
+                self._prepare_resolved_snapshot_for_launch,
+                snapshot,
             )
             self._store_branch_and_sha(run_id, snapshot.branch, prepared.commit_sha)
             if self._is_run_cancelled(run_id):
@@ -616,6 +616,13 @@ class ExecutionService:
 
         return self._runtime.track_background_task(
             run_id, self._run_workflow(run_id, prepared.workflow, inputs)
+        )
+
+    def _prepare_resolved_snapshot_for_launch(self, snapshot: WorkflowRunSnapshot):
+        return self._preparation.prepare_resolved_snapshot_for_launch(
+            snapshot=snapshot.execution_snapshot(),
+            parser=parse_workflow_yaml,
+            prepare_runtime_workflow=self._prepare_runtime_workflow,
         )
 
     def _resolve_git_ref_sha(self, ref: str, workflow_path: str) -> str | None:

--- a/apps/api/src/runsight_api/logic/services/execution_service.py
+++ b/apps/api/src/runsight_api/logic/services/execution_service.py
@@ -516,9 +516,6 @@ class ExecutionService:
             inputs,
         )
 
-    def workflow_snapshot_for_run(self, workflow_id: str, *, branch: str) -> WorkflowEntity:
-        return self.resolve_workflow_run_snapshot(workflow_id, branch=branch).workflow
-
     def resolve_workflow_run_snapshot(
         self, workflow_id: str, *, branch: str
     ) -> WorkflowRunSnapshot:

--- a/apps/api/src/runsight_api/logic/services/execution_service.py
+++ b/apps/api/src/runsight_api/logic/services/execution_service.py
@@ -590,7 +590,7 @@ class ExecutionService:
         if workflow_id != snapshot.workflow_id:
             raise ValueError("workflow_id must match resolved workflow snapshot")
         if not isinstance(inputs, PreparedRunInputs):
-            raise TypeError("launch_execution inputs must be PreparedRunInputs")
+            raise TypeError("launch_execution_from_snapshot inputs must be PreparedRunInputs")
 
         try:
             prepared = await asyncio.to_thread(

--- a/apps/api/src/runsight_api/logic/services/execution_service.py
+++ b/apps/api/src/runsight_api/logic/services/execution_service.py
@@ -17,6 +17,7 @@ import yaml
 from ...core.secrets import SecretsEnvLoader
 from ...domain.entities.run import RunStatus
 from ...domain.errors import InputValidationError, WorkflowNotFound
+from ...domain.value_objects import WorkflowEntity
 from .execution_persistence import ExecutionRunStore
 from .execution_preparation import (
     ExecutionPreparationService,
@@ -494,6 +495,43 @@ class ExecutionService:
             workflow_id,
             _workflow_input_schema_from_yaml(workflow_id, yaml_content),
             inputs,
+        )
+
+    def workflow_snapshot_for_run(self, workflow_id: str, *, branch: str) -> WorkflowEntity:
+        workflow_path = str(self.workflow_repo._get_path(workflow_id))
+        explicit_branch = _explicit_branch(branch)
+        if explicit_branch is None:
+            workflow = self.workflow_repo.get_by_id(workflow_id)
+            if workflow is None:
+                raise WorkflowNotFound(f"Workflow {_workflow_ref(workflow_id)} not found")
+            return workflow
+        if self.git_service is None:
+            raise ValueError(
+                f"Requested snapshot could not be loaded for workflow "
+                f"{_workflow_ref(workflow_id)} on ref {explicit_branch!r}: git service unavailable"
+            )
+        try:
+            yaml_content = self.git_service.read_file(workflow_path, explicit_branch)
+        except Exception as exc:
+            raise WorkflowNotFound(
+                f"Workflow {_workflow_ref(workflow_id)} not found on {explicit_branch!r}"
+            ) from exc
+        data = yaml.safe_load(yaml_content) or {}
+        if not isinstance(data, dict):
+            raise InputValidationError("Workflow YAML content is not a mapping")
+        workflow_section = data.get("workflow")
+        name = workflow_id
+        if isinstance(workflow_section, dict) and isinstance(workflow_section.get("name"), str):
+            name = workflow_section["name"]
+        return WorkflowEntity(
+            kind="workflow",
+            id=workflow_id,
+            name=name,
+            yaml=yaml_content,
+            valid=True,
+            validation_error=None,
+            filename=f"{workflow_id}.yaml",
+            warnings=[],
         )
 
     async def _run_workflow(self, run_id: str, wf: Any, inputs: PreparedRunInputs) -> None:

--- a/apps/api/src/runsight_api/logic/services/execution_service.py
+++ b/apps/api/src/runsight_api/logic/services/execution_service.py
@@ -21,6 +21,7 @@ from ...domain.value_objects import WorkflowEntity
 from .execution_persistence import ExecutionRunStore
 from .execution_preparation import (
     ExecutionPreparationService,
+    ResolvedWorkflowSnapshot,
     get_workflow_commit_sha,
     has_workflow_blocks,
 )
@@ -55,6 +56,24 @@ class PreparedRunInputs(Mapping[str, Any]):
         if isinstance(other, Mapping):
             return self.normalized_inputs == dict(other)
         return False
+
+
+@dataclass(frozen=True, slots=True)
+class WorkflowRunSnapshot:
+    workflow_id: str
+    branch: str
+    yaml_content: str
+    commit_sha: str | None
+    git_ref: str | None
+    workflow: WorkflowEntity
+
+    def execution_snapshot(self) -> ResolvedWorkflowSnapshot:
+        return ResolvedWorkflowSnapshot(
+            workflow_id=self.workflow_id,
+            yaml_content=self.yaml_content,
+            commit_sha=self.commit_sha,
+            git_ref=self.git_ref,
+        )
 
 
 def _workflow_ref(workflow_id: str) -> str:
@@ -498,24 +517,127 @@ class ExecutionService:
         )
 
     def workflow_snapshot_for_run(self, workflow_id: str, *, branch: str) -> WorkflowEntity:
+        return self.resolve_workflow_run_snapshot(workflow_id, branch=branch).workflow
+
+    def resolve_workflow_run_snapshot(
+        self, workflow_id: str, *, branch: str
+    ) -> WorkflowRunSnapshot:
         workflow_path = str(self.workflow_repo._get_path(workflow_id))
         explicit_branch = _explicit_branch(branch)
+        stored_branch = _stored_branch(explicit_branch)
         if explicit_branch is None:
             workflow = self.workflow_repo.get_by_id(workflow_id)
-            if workflow is None:
+            if workflow is None or workflow.yaml is None:
                 raise WorkflowNotFound(f"Workflow {_workflow_ref(workflow_id)} not found")
-            return workflow
+            return WorkflowRunSnapshot(
+                workflow_id=workflow_id,
+                branch=stored_branch,
+                yaml_content=workflow.yaml,
+                commit_sha=get_workflow_commit_sha(workflow_path),
+                git_ref=None,
+                workflow=workflow,
+            )
         if self.git_service is None:
             raise ValueError(
                 f"Requested snapshot could not be loaded for workflow "
                 f"{_workflow_ref(workflow_id)} on ref {explicit_branch!r}: git service unavailable"
             )
+        git_ref = self._resolve_git_ref_sha(explicit_branch, workflow_path)
+        if git_ref is None:
+            raise WorkflowNotFound(
+                f"Workflow {_workflow_ref(workflow_id)} not found on {explicit_branch!r}"
+            )
         try:
-            yaml_content = self.git_service.read_file(workflow_path, explicit_branch)
+            yaml_content = self.git_service.read_file(workflow_path, git_ref)
         except Exception as exc:
             raise WorkflowNotFound(
                 f"Workflow {_workflow_ref(workflow_id)} not found on {explicit_branch!r}"
             ) from exc
+        return WorkflowRunSnapshot(
+            workflow_id=workflow_id,
+            branch=stored_branch,
+            yaml_content=yaml_content,
+            commit_sha=git_ref,
+            git_ref=git_ref,
+            workflow=self._workflow_entity_from_snapshot(
+                workflow_id,
+                yaml_content,
+                git_ref=git_ref,
+            ),
+        )
+
+    def prepare_run_inputs_from_snapshot(
+        self,
+        snapshot: WorkflowRunSnapshot,
+        inputs: Mapping[str, Any],
+    ) -> PreparedRunInputs:
+        return _prepare_run_inputs_from_schema(
+            snapshot.workflow_id,
+            _workflow_input_schema_from_yaml(snapshot.workflow_id, snapshot.yaml_content),
+            inputs,
+        )
+
+    async def launch_execution_from_snapshot(
+        self,
+        run_id: str,
+        workflow_id: str,
+        inputs: PreparedRunInputs,
+        *,
+        snapshot: WorkflowRunSnapshot,
+    ) -> None:
+        if workflow_id != snapshot.workflow_id:
+            raise ValueError("workflow_id must match resolved workflow snapshot")
+        if not isinstance(inputs, PreparedRunInputs):
+            raise TypeError("launch_execution inputs must be PreparedRunInputs")
+
+        try:
+            prepared = self._preparation.prepare_resolved_snapshot_for_launch(
+                snapshot=snapshot.execution_snapshot(),
+                parser=parse_workflow_yaml,
+                prepare_runtime_workflow=self._prepare_runtime_workflow,
+            )
+            self._store_branch_and_sha(run_id, snapshot.branch, prepared.commit_sha)
+            if self._is_run_cancelled(run_id):
+                logger.info(
+                    "Run %s was cancelled during prepare; skipping execution launch", run_id
+                )
+                return
+        except Exception as e:
+            logger.exception(
+                "Failed to prepare workflow for run %s (workflow=%s, requested_ref=%r): %s",
+                run_id,
+                workflow_id,
+                snapshot.git_ref,
+                e,
+            )
+            self._fail_run_on_prepare_error(run_id, e)
+            return
+
+        self._runtime.track_background_task(
+            run_id, self._run_workflow(run_id, prepared.workflow, inputs)
+        )
+
+    def _resolve_git_ref_sha(self, ref: str, workflow_path: str) -> str | None:
+        get_ref_sha = getattr(self.git_service, "get_ref_sha", None)
+        if callable(get_ref_sha):
+            return get_ref_sha(ref)
+        return self.git_service.get_sha(ref, workflow_path)
+
+    def _workflow_entity_from_snapshot(
+        self,
+        workflow_id: str,
+        yaml_content: str,
+        *,
+        git_ref: str,
+    ) -> WorkflowEntity:
+        builder = getattr(self.workflow_repo, "build_entity_from_yaml", None)
+        if callable(builder):
+            return builder(
+                workflow_id,
+                yaml_content,
+                git_ref=git_ref,
+                git_service=self.git_service,
+            )
         data = yaml.safe_load(yaml_content) or {}
         if not isinstance(data, dict):
             raise InputValidationError("Workflow YAML content is not a mapping")

--- a/apps/api/src/runsight_api/logic/services/git_service.py
+++ b/apps/api/src/runsight_api/logic/services/git_service.py
@@ -107,6 +107,11 @@ class GitService:
         sha = result.stdout.strip()
         return sha if sha else None
 
+    def get_ref_sha(self, ref: str) -> Optional[str]:
+        result = self._run("rev-parse", "--verify", f"{ref}^{{commit}}", check=False)
+        sha = result.stdout.strip()
+        return sha if result.returncode == 0 and sha else None
+
     def create_sim_branch(
         self, workflow_slug: str, yaml_content: str, yaml_path: str
     ) -> SimBranchResult:

--- a/apps/api/src/runsight_api/logic/services/run_service.py
+++ b/apps/api/src/runsight_api/logic/services/run_service.py
@@ -95,8 +95,15 @@ class RunService:
         *,
         branch: str,
         source: str = "manual",
+        source_correlation_id: str | None = None,
+        source_metadata: Mapping[str, Any] | None = None,
+        workflow_snapshot: Any | None = None,
     ) -> Run:
-        workflow = self.workflow_repo.get_by_id(workflow_id)
+        workflow = (
+            workflow_snapshot
+            if workflow_snapshot is not None
+            else self.workflow_repo.get_by_id(workflow_id)
+        )
         if not workflow:
             raise WorkflowNotFound(f"Workflow {_workflow_ref(workflow_id)} not found")
 
@@ -119,6 +126,8 @@ class RunService:
             task_json="{}",
             branch=branch,
             source=source,
+            source_correlation_id=source_correlation_id,
+            source_metadata=copy.deepcopy(dict(source_metadata or {})),
             warnings_json=warnings_json,
             workflow_inputs=workflow_inputs,
             workflow_input_schema=workflow_input_schema,

--- a/apps/api/src/runsight_api/logic/services/trigger_runtime.py
+++ b/apps/api/src/runsight_api/logic/services/trigger_runtime.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from threading import Lock
+from typing import Any, Mapping
+
+
+SENSITIVE_INPUT_KEY_PARTS = (
+    "api_key",
+    "apikey",
+    "auth",
+    "authorization",
+    "bearer",
+    "client_secret",
+    "credential",
+    "key",
+    "password",
+    "secret",
+    "token",
+)
+SENSITIVE_HEADER_NAMES = {
+    "authorization",
+    "cookie",
+    "proxy-authorization",
+    "set-cookie",
+    "x-api-key",
+    "x-auth-token",
+}
+REDACTED = "[redacted]"
+
+
+@dataclass(frozen=True, slots=True)
+class TriggerRuntimeConfig:
+    external_invocation_enabled: bool
+    max_concurrent_runs: int
+    max_pending_external_invocations: int
+    body_limit_bytes: int
+    public_base_url: str | None = None
+    tunnel_base_url: str | None = None
+    proxy_base_url: str | None = None
+
+    @classmethod
+    def from_settings(cls, settings: Any) -> TriggerRuntimeConfig:
+        return cls(
+            external_invocation_enabled=bool(settings.external_invocation_enabled),
+            max_concurrent_runs=int(settings.max_concurrent_runs),
+            max_pending_external_invocations=int(settings.max_pending_external_invocations),
+            body_limit_bytes=int(settings.external_invocation_body_limit_bytes),
+            public_base_url=settings.public_base_url,
+        )
+
+    @property
+    def external_invocation_available(self) -> bool:
+        return self.external_invocation_enabled
+
+    @property
+    def public_base_url_explicit(self) -> bool:
+        return self.public_base_url is not None
+
+    @property
+    def tunnel_explicit(self) -> bool:
+        return self.tunnel_base_url is not None
+
+    @property
+    def proxy_explicit(self) -> bool:
+        return self.proxy_base_url is not None
+
+    @property
+    def public_exposure_explicit(self) -> bool:
+        return self.public_base_url_explicit or self.tunnel_explicit or self.proxy_explicit
+
+
+@dataclass(frozen=True, slots=True)
+class ExternalInvocationAdmissionDecision:
+    allowed: bool
+    failure_code: str | None = None
+    status_code: int | None = None
+    reason: str | None = None
+
+
+class ExternalInvocationAdmission:
+    def __init__(
+        self,
+        config: TriggerRuntimeConfig,
+        *,
+        pending_external_invocations: int = 0,
+    ) -> None:
+        self.config = config
+        self._pending_external_invocations = pending_external_invocations
+        self._lock = Lock()
+
+    def check_external_invocation(self, invocation: Any) -> ExternalInvocationAdmissionDecision:
+        del invocation
+        if not self.config.external_invocation_available:
+            return ExternalInvocationAdmissionDecision(
+                allowed=False,
+                failure_code="runtime_unavailable",
+                status_code=503,
+                reason="external invocation disabled by runtime config",
+            )
+
+        with self._lock:
+            pending = self._pending_external_invocations
+        if pending >= self.config.max_pending_external_invocations:
+            return ExternalInvocationAdmissionDecision(
+                allowed=False,
+                failure_code="admission_saturated",
+                status_code=429,
+                reason="external invocation admission is saturated",
+            )
+
+        return ExternalInvocationAdmissionDecision(allowed=True)
+
+
+def _is_sensitive_key(key: object) -> bool:
+    normalized = str(key).lower().replace("-", "_")
+    return any(part in normalized for part in SENSITIVE_INPUT_KEY_PARTS)
+
+
+def _redact_mapping_values(values: Mapping[str, Any]) -> dict[str, Any]:
+    redacted: dict[str, Any] = {}
+    for key, value in values.items():
+        if _is_sensitive_key(key):
+            redacted[str(key)] = REDACTED
+        elif isinstance(value, Mapping):
+            redacted[str(key)] = _redact_mapping_values(value)
+        else:
+            redacted[str(key)] = value
+    return redacted
+
+
+def _redact_headers(headers: Mapping[str, Any]) -> dict[str, Any]:
+    redacted: dict[str, Any] = {}
+    for key, value in headers.items():
+        header_name = str(key).lower()
+        redacted[str(key)] = (
+            REDACTED
+            if header_name in SENSITIVE_HEADER_NAMES or _is_sensitive_key(header_name)
+            else value
+        )
+    return redacted
+
+
+def redact_external_invocation_log_context(
+    *,
+    method: str,
+    path: str,
+    headers: Mapping[str, Any],
+    body: bytes | None,
+    inputs: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    del body
+    return {
+        "method": method,
+        "path": path,
+        "headers": _redact_headers(headers),
+        "raw_body": REDACTED,
+        "inputs": _redact_mapping_values(inputs or {}),
+    }

--- a/apps/api/src/runsight_api/logic/services/trigger_runtime.py
+++ b/apps/api/src/runsight_api/logic/services/trigger_runtime.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from threading import Lock
 from typing import Any, Mapping
@@ -89,6 +91,21 @@ class ExternalInvocationAdmission:
         self._pending_external_invocations = pending_external_invocations
         self._lock = Lock()
 
+    @property
+    def pending_external_invocations(self) -> int:
+        with self._lock:
+            return self._pending_external_invocations
+
+    @property
+    def _capacity(self) -> int:
+        return max(
+            0,
+            min(
+                self.config.max_concurrent_runs,
+                self.config.max_pending_external_invocations,
+            ),
+        )
+
     def check_external_invocation(self, invocation: Any) -> ExternalInvocationAdmissionDecision:
         del invocation
         if not self.config.external_invocation_available:
@@ -100,15 +117,47 @@ class ExternalInvocationAdmission:
             )
 
         with self._lock:
-            pending = self._pending_external_invocations
-        if pending >= self.config.max_pending_external_invocations:
+            return self._check_capacity_locked()
+
+    def acquire_external_invocation(self, invocation: Any) -> ExternalInvocationAdmissionDecision:
+        del invocation
+        if not self.config.external_invocation_available:
+            return ExternalInvocationAdmissionDecision(
+                allowed=False,
+                failure_code="runtime_unavailable",
+                status_code=503,
+                reason="external invocation disabled by runtime config",
+            )
+
+        with self._lock:
+            decision = self._check_capacity_locked()
+            if decision.allowed:
+                self._pending_external_invocations += 1
+            return decision
+
+    def release_external_invocation(self) -> None:
+        with self._lock:
+            self._pending_external_invocations = max(0, self._pending_external_invocations - 1)
+
+    @contextmanager
+    def external_invocation_slot(
+        self, invocation: Any
+    ) -> Iterator[ExternalInvocationAdmissionDecision]:
+        decision = self.acquire_external_invocation(invocation)
+        try:
+            yield decision
+        finally:
+            if decision.allowed:
+                self.release_external_invocation()
+
+    def _check_capacity_locked(self) -> ExternalInvocationAdmissionDecision:
+        if self._pending_external_invocations >= self._capacity:
             return ExternalInvocationAdmissionDecision(
                 allowed=False,
                 failure_code="admission_saturated",
                 status_code=429,
                 reason="external invocation admission is saturated",
             )
-
         return ExternalInvocationAdmissionDecision(allowed=True)
 
 

--- a/apps/api/src/runsight_api/logic/services/trigger_runtime.py
+++ b/apps/api/src/runsight_api/logic/services/trigger_runtime.py
@@ -117,15 +117,23 @@ def _is_sensitive_key(key: object) -> bool:
     return any(part in normalized for part in SENSITIVE_INPUT_KEY_PARTS)
 
 
+def _redact_json_value(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return _redact_mapping_values(value)
+    if isinstance(value, list):
+        return [_redact_json_value(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_redact_json_value(item) for item in value)
+    return value
+
+
 def _redact_mapping_values(values: Mapping[str, Any]) -> dict[str, Any]:
     redacted: dict[str, Any] = {}
     for key, value in values.items():
         if _is_sensitive_key(key):
             redacted[str(key)] = REDACTED
-        elif isinstance(value, Mapping):
-            redacted[str(key)] = _redact_mapping_values(value)
         else:
-            redacted[str(key)] = value
+            redacted[str(key)] = _redact_json_value(value)
     return redacted
 
 

--- a/apps/api/src/runsight_api/logic/services/workflow_run_invoker.py
+++ b/apps/api/src/runsight_api/logic/services/workflow_run_invoker.py
@@ -191,7 +191,7 @@ class WorkflowRunInvoker:
             invocation.workflow_id, branch=invocation.branch
         )
         workflow_snapshot = getattr(resolved_snapshot, "workflow", None)
-        if _workflow_snapshot_is_explicitly_disabled(workflow_snapshot):
+        if _workflow_snapshot_is_explicitly_disabled(workflow_snapshot, invocation):
             raise WorkflowNotFound(
                 f"Workflow {invocation.workflow_id!r} not found on {invocation.branch!r}"
             )
@@ -259,13 +259,23 @@ class WorkflowRunInvoker:
         return True
 
 
-def _workflow_snapshot_is_explicitly_disabled(workflow_snapshot: Any) -> bool:
-    if getattr(workflow_snapshot, "enabled", True) is not False:
+def _workflow_snapshot_is_explicitly_disabled(
+    workflow_snapshot: Any,
+    invocation: WorkflowRunInvocation,
+) -> bool:
+    if workflow_snapshot is None or not hasattr(workflow_snapshot, "enabled"):
         return False
+    if getattr(workflow_snapshot, "enabled", False) is not False:
+        return False
+
+    request_path = invocation.source_metadata.get("request_path")
+    if isinstance(request_path, str) and request_path.endswith("/runs"):
+        return True
 
     fields_set = getattr(workflow_snapshot, "model_fields_set", None)
     if fields_set is None:
         fields_set = getattr(workflow_snapshot, "__fields_set__", None)
-    if isinstance(fields_set, set):
-        return "enabled" in fields_set
-    return True
+    if isinstance(fields_set, set) and "enabled" in fields_set:
+        return True
+
+    return not bool(getattr(workflow_snapshot, "yaml", None))

--- a/apps/api/src/runsight_api/logic/services/workflow_run_invoker.py
+++ b/apps/api/src/runsight_api/logic/services/workflow_run_invoker.py
@@ -56,6 +56,7 @@ class WorkflowRunInvocationResult:
     run_id: str | None = None
     status: RunStatus | str | None = None
     failure_code: WorkflowRunInvocationFailureCode | str | None = None
+    status_code: int | None = None
     details: dict[str, Any] | None = None
     commit_sha: str | None = None
 
@@ -66,6 +67,7 @@ class WorkflowRunInvocationResult:
         *,
         run_id: str | None = None,
         status: RunStatus | str | None = None,
+        status_code: int | None = None,
         details: dict[str, Any] | None = None,
     ) -> WorkflowRunInvocationResult:
         return cls(
@@ -73,6 +75,7 @@ class WorkflowRunInvocationResult:
             run_id=run_id,
             status=status,
             failure_code=failure_code,
+            status_code=status_code,
             details=details,
         )
 
@@ -164,7 +167,16 @@ class WorkflowRunInvoker:
             "failure_code",
             WorkflowRunInvocationFailureCode.runtime_unavailable,
         )
-        return WorkflowRunInvocationResult.failure(failure_code)
+        status_code = getattr(decision, "status_code", None)
+        details = getattr(decision, "details", None)
+        reason = getattr(decision, "reason", None)
+        if details is None and reason:
+            details = {"reason": reason}
+        return WorkflowRunInvocationResult.failure(
+            failure_code,
+            status_code=status_code,
+            details=details,
+        )
 
     def _check_admission(self, invocation: WorkflowRunInvocation) -> Any:
         for method_name in ("check_external_invocation", "check", "admit"):

--- a/apps/api/src/runsight_api/logic/services/workflow_run_invoker.py
+++ b/apps/api/src/runsight_api/logic/services/workflow_run_invoker.py
@@ -87,10 +87,23 @@ class WorkflowRunInvoker:
         self.runtime_admission = runtime_admission
 
     async def invoke(self, invocation: WorkflowRunInvocation) -> WorkflowRunInvocationResult:
-        admission_failure = self._admission_failure(invocation)
+        slot = getattr(self.runtime_admission, "external_invocation_slot", None)
+        if callable(slot):
+            with slot(invocation) as decision:
+                admission_failure = self._admission_decision_failure(decision)
+                if admission_failure is not None:
+                    return admission_failure
+                return await self._invoke_admitted(invocation)
+
+        admission_failure = self._check_admission_failure(invocation)
         if admission_failure is not None:
             return admission_failure
 
+        return await self._invoke_admitted(invocation)
+
+    async def _invoke_admitted(
+        self, invocation: WorkflowRunInvocation
+    ) -> WorkflowRunInvocationResult:
         try:
             resolved_snapshot = self.execution_service.resolve_workflow_run_snapshot(
                 invocation.workflow_id, branch=invocation.branch
@@ -149,10 +162,13 @@ class WorkflowRunInvoker:
             commit_sha=getattr(refreshed, "commit_sha", None),
         )
 
-    def _admission_failure(
+    def _check_admission_failure(
         self, invocation: WorkflowRunInvocation
     ) -> WorkflowRunInvocationResult | None:
         decision = self._check_admission(invocation)
+        return self._admission_decision_failure(decision)
+
+    def _admission_decision_failure(self, decision: Any) -> WorkflowRunInvocationResult | None:
         if decision is None or decision is True:
             return None
         if decision is False:

--- a/apps/api/src/runsight_api/logic/services/workflow_run_invoker.py
+++ b/apps/api/src/runsight_api/logic/services/workflow_run_invoker.py
@@ -89,16 +89,30 @@ class WorkflowRunInvoker:
         if admission_failure is not None:
             return admission_failure
 
+        resolved_snapshot = None
         try:
-            prepared_inputs = self.execution_service.prepare_run_inputs(
-                invocation.workflow_id,
-                invocation.inputs,
-                branch=invocation.branch,
+            resolve_snapshot = getattr(
+                self.execution_service, "resolve_workflow_run_snapshot", None
             )
-            workflow_snapshot = self.execution_service.workflow_snapshot_for_run(
-                invocation.workflow_id,
-                branch=invocation.branch,
-            )
+            if callable(resolve_snapshot):
+                resolved_snapshot = resolve_snapshot(
+                    invocation.workflow_id, branch=invocation.branch
+                )
+                prepared_inputs = self.execution_service.prepare_run_inputs_from_snapshot(
+                    resolved_snapshot,
+                    invocation.inputs,
+                )
+                workflow_snapshot = resolved_snapshot.workflow
+            else:
+                prepared_inputs = self.execution_service.prepare_run_inputs(
+                    invocation.workflow_id,
+                    invocation.inputs,
+                    branch=invocation.branch,
+                )
+                workflow_snapshot = self.execution_service.workflow_snapshot_for_run(
+                    invocation.workflow_id,
+                    branch=invocation.branch,
+                )
         except InputValidationError as exc:
             return WorkflowRunInvocationResult.failure(
                 WorkflowRunInvocationFailureCode.workflow_input_validation_failed,
@@ -121,12 +135,23 @@ class WorkflowRunInvoker:
 
         try:
             with self._temporary_run_update_sink():
-                await self.execution_service.launch_execution(
-                    run.id,
-                    run.workflow_id,
-                    prepared_inputs,
-                    branch=invocation.branch,
+                launch_from_snapshot = getattr(
+                    self.execution_service, "launch_execution_from_snapshot", None
                 )
+                if resolved_snapshot is not None and callable(launch_from_snapshot):
+                    await launch_from_snapshot(
+                        run.id,
+                        run.workflow_id,
+                        prepared_inputs,
+                        snapshot=resolved_snapshot,
+                    )
+                else:
+                    await self.execution_service.launch_execution(
+                        run.id,
+                        run.workflow_id,
+                        prepared_inputs,
+                        branch=invocation.branch,
+                    )
         except Exception as exc:
             failed_run = self.run_service.fail_run(run.id, str(exc))
             return WorkflowRunInvocationResult.failure(
@@ -136,6 +161,12 @@ class WorkflowRunInvoker:
             )
 
         refreshed = self.run_service.get_run(run.id) or run
+        if getattr(refreshed, "status", None) in {RunStatus.failed, RunStatus.failed.value}:
+            return WorkflowRunInvocationResult.failure(
+                WorkflowRunInvocationFailureCode.execution_launch_failed,
+                run_id=run.id,
+                status=getattr(refreshed, "status", None),
+            )
         return WorkflowRunInvocationResult(
             accepted=True,
             run_id=run.id,

--- a/apps/api/src/runsight_api/logic/services/workflow_run_invoker.py
+++ b/apps/api/src/runsight_api/logic/services/workflow_run_invoker.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+import asyncio
 import copy
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Literal, Mapping
+from typing import Any, Callable, Literal, Mapping
 
 from ...domain.entities.run import RunStatus, validate_source_metadata
 from ...domain.errors import InputValidationError, WorkflowNotFound
@@ -87,40 +88,52 @@ class WorkflowRunInvoker:
         self.runtime_admission = runtime_admission
 
     async def invoke(self, invocation: WorkflowRunInvocation) -> WorkflowRunInvocationResult:
-        slot = getattr(self.runtime_admission, "external_invocation_slot", None)
-        if callable(slot):
-            with slot(invocation) as decision:
-                admission_failure = self._admission_decision_failure(decision)
-                if admission_failure is not None:
-                    return admission_failure
-                return await self._invoke_admitted(invocation)
+        acquire = getattr(self.runtime_admission, "acquire_external_invocation", None)
+        release = getattr(self.runtime_admission, "release_external_invocation", None)
+        if callable(acquire) and callable(release):
+            decision = acquire(invocation)
+            admission_failure = self._admission_decision_failure(decision)
+            if admission_failure is not None:
+                return admission_failure
+
+            release_on_return = True
+            try:
+                result, completion = await self._invoke_admitted(invocation)
+                release_on_return = not self._release_on_completion(completion, release)
+                return result
+            finally:
+                if release_on_return:
+                    release()
 
         admission_failure = self._check_admission_failure(invocation)
         if admission_failure is not None:
             return admission_failure
 
-        return await self._invoke_admitted(invocation)
+        result, _completion = await self._invoke_admitted(invocation)
+        return result
 
     async def _invoke_admitted(
         self, invocation: WorkflowRunInvocation
-    ) -> WorkflowRunInvocationResult:
+    ) -> tuple[WorkflowRunInvocationResult, Any | None]:
         try:
-            resolved_snapshot = self.execution_service.resolve_workflow_run_snapshot(
-                invocation.workflow_id, branch=invocation.branch
-            )
-            prepared_inputs = self.execution_service.prepare_run_inputs_from_snapshot(
-                resolved_snapshot,
-                invocation.inputs,
+            resolved_snapshot, prepared_inputs = await asyncio.to_thread(
+                self._resolve_and_prepare, invocation
             )
             workflow_snapshot = resolved_snapshot.workflow
         except InputValidationError as exc:
-            return WorkflowRunInvocationResult.failure(
-                WorkflowRunInvocationFailureCode.workflow_input_validation_failed,
-                details=exc.to_dict(),
+            return (
+                WorkflowRunInvocationResult.failure(
+                    WorkflowRunInvocationFailureCode.workflow_input_validation_failed,
+                    details=exc.to_dict(),
+                ),
+                None,
             )
         except WorkflowNotFound:
-            return WorkflowRunInvocationResult.failure(
-                WorkflowRunInvocationFailureCode.workflow_not_found
+            return (
+                WorkflowRunInvocationResult.failure(
+                    WorkflowRunInvocationFailureCode.workflow_not_found
+                ),
+                None,
             )
 
         run = self.run_service.create_run(
@@ -134,33 +147,77 @@ class WorkflowRunInvoker:
         )
 
         try:
-            await self.execution_service.launch_execution_from_snapshot(
+            completion = await self.execution_service.launch_execution_from_snapshot(
                 run.id,
                 run.workflow_id,
                 prepared_inputs,
                 snapshot=resolved_snapshot,
             )
+            if isinstance(completion, asyncio.Future):
+                await completion
         except Exception as exc:
             failed_run = self.run_service.fail_run(run.id, str(exc))
-            return WorkflowRunInvocationResult.failure(
-                WorkflowRunInvocationFailureCode.execution_launch_failed,
-                run_id=run.id,
-                status=getattr(failed_run, "status", None),
+            return (
+                WorkflowRunInvocationResult.failure(
+                    WorkflowRunInvocationFailureCode.execution_launch_failed,
+                    run_id=run.id,
+                    status=getattr(failed_run, "status", None),
+                ),
+                None,
             )
 
         refreshed = self.run_service.get_run(run.id) or run
         if getattr(refreshed, "status", None) in {RunStatus.failed, RunStatus.failed.value}:
-            return WorkflowRunInvocationResult.failure(
-                WorkflowRunInvocationFailureCode.execution_launch_failed,
+            return (
+                WorkflowRunInvocationResult.failure(
+                    WorkflowRunInvocationFailureCode.execution_launch_failed,
+                    run_id=run.id,
+                    status=getattr(refreshed, "status", None),
+                ),
+                completion,
+            )
+        return (
+            WorkflowRunInvocationResult(
+                accepted=True,
                 run_id=run.id,
                 status=getattr(refreshed, "status", None),
-            )
-        return WorkflowRunInvocationResult(
-            accepted=True,
-            run_id=run.id,
-            status=getattr(refreshed, "status", None),
-            commit_sha=getattr(refreshed, "commit_sha", None),
+                commit_sha=getattr(refreshed, "commit_sha", None),
+            ),
+            completion,
         )
+
+    def _resolve_and_prepare(self, invocation: WorkflowRunInvocation) -> tuple[Any, Any]:
+        resolved_snapshot = self.execution_service.resolve_workflow_run_snapshot(
+            invocation.workflow_id, branch=invocation.branch
+        )
+        workflow_snapshot = getattr(resolved_snapshot, "workflow", None)
+        if _workflow_snapshot_is_explicitly_disabled(workflow_snapshot):
+            raise WorkflowNotFound(
+                f"Workflow {invocation.workflow_id!r} not found on {invocation.branch!r}"
+            )
+        prepared_inputs = self.execution_service.prepare_run_inputs_from_snapshot(
+            resolved_snapshot,
+            invocation.inputs,
+        )
+        return resolved_snapshot, prepared_inputs
+
+    def _release_on_completion(
+        self,
+        completion: Any,
+        release: Callable[[], None],
+    ) -> bool:
+        add_done_callback = getattr(completion, "add_done_callback", None)
+        if not callable(add_done_callback):
+            return False
+        if not getattr(completion, "release_external_invocation_on_done", False):
+            return False
+
+        done = getattr(completion, "done", None)
+        if callable(done) and done():
+            return False
+
+        add_done_callback(lambda _task: release())
+        return True
 
     def _check_admission_failure(
         self, invocation: WorkflowRunInvocation
@@ -200,3 +257,15 @@ class WorkflowRunInvoker:
             if method is not None:
                 return method(invocation)
         return True
+
+
+def _workflow_snapshot_is_explicitly_disabled(workflow_snapshot: Any) -> bool:
+    if getattr(workflow_snapshot, "enabled", True) is not False:
+        return False
+
+    fields_set = getattr(workflow_snapshot, "model_fields_set", None)
+    if fields_set is None:
+        fields_set = getattr(workflow_snapshot, "__fields_set__", None)
+    if isinstance(fields_set, set):
+        return "enabled" in fields_set
+    return True

--- a/apps/api/src/runsight_api/logic/services/workflow_run_invoker.py
+++ b/apps/api/src/runsight_api/logic/services/workflow_run_invoker.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
 import copy
-from contextlib import contextmanager
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Iterator, Literal, Mapping
+from typing import Any, Literal, Mapping
 
 from ...domain.entities.run import RunStatus, validate_source_metadata
 from ...domain.errors import InputValidationError, WorkflowNotFound
@@ -89,30 +88,15 @@ class WorkflowRunInvoker:
         if admission_failure is not None:
             return admission_failure
 
-        resolved_snapshot = None
         try:
-            resolve_snapshot = getattr(
-                self.execution_service, "resolve_workflow_run_snapshot", None
+            resolved_snapshot = self.execution_service.resolve_workflow_run_snapshot(
+                invocation.workflow_id, branch=invocation.branch
             )
-            if callable(resolve_snapshot):
-                resolved_snapshot = resolve_snapshot(
-                    invocation.workflow_id, branch=invocation.branch
-                )
-                prepared_inputs = self.execution_service.prepare_run_inputs_from_snapshot(
-                    resolved_snapshot,
-                    invocation.inputs,
-                )
-                workflow_snapshot = resolved_snapshot.workflow
-            else:
-                prepared_inputs = self.execution_service.prepare_run_inputs(
-                    invocation.workflow_id,
-                    invocation.inputs,
-                    branch=invocation.branch,
-                )
-                workflow_snapshot = self.execution_service.workflow_snapshot_for_run(
-                    invocation.workflow_id,
-                    branch=invocation.branch,
-                )
+            prepared_inputs = self.execution_service.prepare_run_inputs_from_snapshot(
+                resolved_snapshot,
+                invocation.inputs,
+            )
+            workflow_snapshot = resolved_snapshot.workflow
         except InputValidationError as exc:
             return WorkflowRunInvocationResult.failure(
                 WorkflowRunInvocationFailureCode.workflow_input_validation_failed,
@@ -134,24 +118,12 @@ class WorkflowRunInvoker:
         )
 
         try:
-            with self._temporary_run_update_sink():
-                launch_from_snapshot = getattr(
-                    self.execution_service, "launch_execution_from_snapshot", None
-                )
-                if resolved_snapshot is not None and callable(launch_from_snapshot):
-                    await launch_from_snapshot(
-                        run.id,
-                        run.workflow_id,
-                        prepared_inputs,
-                        snapshot=resolved_snapshot,
-                    )
-                else:
-                    await self.execution_service.launch_execution(
-                        run.id,
-                        run.workflow_id,
-                        prepared_inputs,
-                        branch=invocation.branch,
-                    )
+            await self.execution_service.launch_execution_from_snapshot(
+                run.id,
+                run.workflow_id,
+                prepared_inputs,
+                snapshot=resolved_snapshot,
+            )
         except Exception as exc:
             failed_run = self.run_service.fail_run(run.id, str(exc))
             return WorkflowRunInvocationResult.failure(
@@ -200,21 +172,3 @@ class WorkflowRunInvoker:
             if method is not None:
                 return method(invocation)
         return True
-
-    @contextmanager
-    def _temporary_run_update_sink(self) -> Iterator[None]:
-        execution_run_service = getattr(self.execution_service, "run_service", None)
-        if execution_run_service is not self.run_service or hasattr(self.run_service, "run_repo"):
-            yield
-            return
-
-        self.run_service.run_repo = _RunUpdateSink()
-        try:
-            yield
-        finally:
-            del self.run_service.run_repo
-
-
-class _RunUpdateSink:
-    def update_run(self, run: Any) -> Any:
-        return run

--- a/apps/api/src/runsight_api/logic/services/workflow_run_invoker.py
+++ b/apps/api/src/runsight_api/logic/services/workflow_run_invoker.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import copy
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Iterator, Literal, Mapping
+
+from ...domain.entities.run import RunStatus, validate_source_metadata
+from ...domain.errors import InputValidationError, WorkflowNotFound
+
+DIRECT_API_BRANCH = "main"
+
+
+class WorkflowRunInvocationFailureCode(str, Enum):
+    runtime_unavailable = "runtime_unavailable"
+    admission_saturated = "admission_saturated"
+    workflow_input_validation_failed = "workflow_input_validation_failed"
+    workflow_not_found = "workflow_not_found"
+    execution_launch_failed = "execution_launch_failed"
+
+
+@dataclass(frozen=True, slots=True)
+class WorkflowRunInvocation:
+    workflow_id: str
+    caller: Literal["api"]
+    source: Literal["api"]
+    inputs: dict[str, Any]
+    branch: Literal["main"] = DIRECT_API_BRANCH
+    commit_sha: None = None
+    source_correlation_id: str | None = None
+    source_metadata: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def direct_api(
+        cls,
+        *,
+        workflow_id: str,
+        inputs: Mapping[str, Any] | None,
+        source_correlation_id: str | None = None,
+        source_metadata: Mapping[str, Any] | None = None,
+    ) -> WorkflowRunInvocation:
+        safe_metadata = validate_source_metadata(dict(source_metadata or {}))
+        return cls(
+            workflow_id=workflow_id,
+            caller="api",
+            source="api",
+            inputs=dict(inputs or {}),
+            source_correlation_id=source_correlation_id,
+            source_metadata=copy.deepcopy(safe_metadata),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class WorkflowRunInvocationResult:
+    accepted: bool
+    run_id: str | None = None
+    status: RunStatus | str | None = None
+    failure_code: WorkflowRunInvocationFailureCode | str | None = None
+    details: dict[str, Any] | None = None
+    commit_sha: str | None = None
+
+    @classmethod
+    def failure(
+        cls,
+        failure_code: WorkflowRunInvocationFailureCode | str,
+        *,
+        run_id: str | None = None,
+        status: RunStatus | str | None = None,
+        details: dict[str, Any] | None = None,
+    ) -> WorkflowRunInvocationResult:
+        return cls(
+            accepted=False,
+            run_id=run_id,
+            status=status,
+            failure_code=failure_code,
+            details=details,
+        )
+
+
+class WorkflowRunInvoker:
+    def __init__(self, *, run_service: Any, execution_service: Any, runtime_admission: Any):
+        self.run_service = run_service
+        self.execution_service = execution_service
+        self.runtime_admission = runtime_admission
+
+    async def invoke(self, invocation: WorkflowRunInvocation) -> WorkflowRunInvocationResult:
+        admission_failure = self._admission_failure(invocation)
+        if admission_failure is not None:
+            return admission_failure
+
+        try:
+            prepared_inputs = self.execution_service.prepare_run_inputs(
+                invocation.workflow_id,
+                invocation.inputs,
+                branch=invocation.branch,
+            )
+            workflow_snapshot = self.execution_service.workflow_snapshot_for_run(
+                invocation.workflow_id,
+                branch=invocation.branch,
+            )
+        except InputValidationError as exc:
+            return WorkflowRunInvocationResult.failure(
+                WorkflowRunInvocationFailureCode.workflow_input_validation_failed,
+                details=exc.to_dict(),
+            )
+        except WorkflowNotFound:
+            return WorkflowRunInvocationResult.failure(
+                WorkflowRunInvocationFailureCode.workflow_not_found
+            )
+
+        run = self.run_service.create_run(
+            invocation.workflow_id,
+            prepared_inputs,
+            branch=invocation.branch,
+            source=invocation.source,
+            source_correlation_id=invocation.source_correlation_id,
+            source_metadata=invocation.source_metadata,
+            workflow_snapshot=workflow_snapshot,
+        )
+
+        try:
+            with self._temporary_run_update_sink():
+                await self.execution_service.launch_execution(
+                    run.id,
+                    run.workflow_id,
+                    prepared_inputs,
+                    branch=invocation.branch,
+                )
+        except Exception as exc:
+            failed_run = self.run_service.fail_run(run.id, str(exc))
+            return WorkflowRunInvocationResult.failure(
+                WorkflowRunInvocationFailureCode.execution_launch_failed,
+                run_id=run.id,
+                status=getattr(failed_run, "status", None),
+            )
+
+        refreshed = self.run_service.get_run(run.id) or run
+        return WorkflowRunInvocationResult(
+            accepted=True,
+            run_id=run.id,
+            status=getattr(refreshed, "status", None),
+            commit_sha=getattr(refreshed, "commit_sha", None),
+        )
+
+    def _admission_failure(
+        self, invocation: WorkflowRunInvocation
+    ) -> WorkflowRunInvocationResult | None:
+        decision = self._check_admission(invocation)
+        if decision is None or decision is True:
+            return None
+        if decision is False:
+            return WorkflowRunInvocationResult.failure(
+                WorkflowRunInvocationFailureCode.runtime_unavailable
+            )
+        allowed = getattr(decision, "allowed", True)
+        if allowed:
+            return None
+        failure_code = getattr(
+            decision,
+            "failure_code",
+            WorkflowRunInvocationFailureCode.runtime_unavailable,
+        )
+        return WorkflowRunInvocationResult.failure(failure_code)
+
+    def _check_admission(self, invocation: WorkflowRunInvocation) -> Any:
+        for method_name in ("check_external_invocation", "check", "admit"):
+            method = getattr(self.runtime_admission, method_name, None)
+            if method is not None:
+                return method(invocation)
+        return True
+
+    @contextmanager
+    def _temporary_run_update_sink(self) -> Iterator[None]:
+        execution_run_service = getattr(self.execution_service, "run_service", None)
+        if execution_run_service is not self.run_service or hasattr(self.run_service, "run_repo"):
+            yield
+            return
+
+        self.run_service.run_repo = _RunUpdateSink()
+        try:
+            yield
+        finally:
+            del self.run_service.run_repo
+
+
+class _RunUpdateSink:
+    def update_run(self, run: Any) -> Any:
+        return run

--- a/apps/api/src/runsight_api/main.py
+++ b/apps/api/src/runsight_api/main.py
@@ -105,6 +105,7 @@ def _ensure_sqlite_columns(engine) -> None:
     }
 
     with engine.begin() as conn:
+        table_columns: dict[str, set[str]] = {}
         for table_name, columns in additive_columns.items():
             existing = {
                 row[1]
@@ -114,15 +115,23 @@ def _ensure_sqlite_columns(engine) -> None:
                 if column_name in existing:
                     continue
                 conn.execute(text(f"ALTER TABLE {table_name} ADD COLUMN {column_name} {ddl}"))
-        conn.execute(
-            text("CREATE INDEX IF NOT EXISTS ix_run_source_created_at ON run (source, created_at)")
-        )
-        conn.execute(
-            text(
-                "CREATE INDEX IF NOT EXISTS ix_run_workflow_source_created_at "
-                "ON run (workflow_id, source, created_at)"
+                existing.add(column_name)
+            table_columns[table_name] = existing
+
+        run_columns = table_columns.get("run", set())
+        if {"source", "created_at"}.issubset(run_columns):
+            conn.execute(
+                text(
+                    "CREATE INDEX IF NOT EXISTS ix_run_source_created_at ON run (source, created_at)"
+                )
             )
-        )
+        if {"workflow_id", "source", "created_at"}.issubset(run_columns):
+            conn.execute(
+                text(
+                    "CREATE INDEX IF NOT EXISTS ix_run_workflow_source_created_at "
+                    "ON run (workflow_id, source, created_at)"
+                )
+            )
 
 
 def _build_alembic_config() -> AlembicConfig:

--- a/apps/api/src/runsight_api/main.py
+++ b/apps/api/src/runsight_api/main.py
@@ -73,6 +73,8 @@ def _ensure_sqlite_columns(engine) -> None:
             "error_traceback": "VARCHAR",
             "source": "VARCHAR NOT NULL DEFAULT 'manual'",
             "commit_sha": "VARCHAR",
+            "source_correlation_id": "VARCHAR",
+            "source_metadata": "JSON",
             "parent_run_id": "TEXT",
             "parent_node_id": "TEXT",
             "root_run_id": "TEXT",
@@ -106,6 +108,15 @@ def _ensure_sqlite_columns(engine) -> None:
                 if column_name in existing:
                     continue
                 conn.execute(text(f"ALTER TABLE {table_name} ADD COLUMN {column_name} {ddl}"))
+        conn.execute(
+            text("CREATE INDEX IF NOT EXISTS ix_run_source_created_at ON run (source, created_at)")
+        )
+        conn.execute(
+            text(
+                "CREATE INDEX IF NOT EXISTS ix_run_workflow_source_created_at "
+                "ON run (workflow_id, source, created_at)"
+            )
+        )
 
 
 def _build_alembic_config() -> AlembicConfig:

--- a/apps/api/src/runsight_api/main.py
+++ b/apps/api/src/runsight_api/main.py
@@ -26,7 +26,12 @@ from .data.repositories.run_repo import RunRepository
 from .domain.errors import RunsightError
 from .logic.services.git_service import GitService
 from .logic.services.execution_service import ExecutionService
+from .logic.services.trigger_runtime import (
+    ExternalInvocationAdmission,
+    TriggerRuntimeConfig,
+)
 from .transport.middleware.access_log import AccessLogMiddleware
+from .transport.middleware.body_limit import BodySizeLimitMiddleware
 from .transport.middleware.error_handler import (
     global_exception_handler,
     request_validation_exception_handler,
@@ -54,6 +59,7 @@ def _recover_stale_runs(engine):
             workflow_repo=None,
             provider_repo=None,
             engine=engine,
+            max_concurrent_runs=app_settings.max_concurrent_runs,
         ).fail_ghost_runs()
 
 
@@ -142,11 +148,15 @@ async def lifespan(app: FastAPI):
     settings_repo = FileSystemSettingsRepo(base_path=app_settings.base_path)
     secrets = SecretsEnvLoader(base_path=app_settings.base_path)
     git_service = GitService(app_settings.base_path)
+    trigger_runtime_config = TriggerRuntimeConfig.from_settings(app_settings)
+    app.state.trigger_runtime_config = trigger_runtime_config
+    app.state.external_invocation_admission = ExternalInvocationAdmission(trigger_runtime_config)
     app.state.execution_service = ExecutionService(
         run_repo,
         workflow_repo,
         provider_repo,
         engine=engine,
+        max_concurrent_runs=trigger_runtime_config.max_concurrent_runs,
         secrets=secrets,
         settings_repo=settings_repo,
         git_service=git_service,
@@ -171,6 +181,10 @@ def create_app() -> FastAPI:
     )
 
     # Middleware
+    app.add_middleware(
+        BodySizeLimitMiddleware,
+        max_body_bytes=app_settings.external_invocation_body_limit_bytes,
+    )
     app.add_middleware(AccessLogMiddleware)
     app.add_middleware(RequestIdMiddleware)
     app.add_exception_handler(RunsightError, global_exception_handler)
@@ -235,4 +249,4 @@ app = create_app()
 if __name__ == "__main__":
     import uvicorn
 
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+    uvicorn.run(app, host=app_settings.host, port=app_settings.port)

--- a/apps/api/src/runsight_api/transport/deps.py
+++ b/apps/api/src/runsight_api/transport/deps.py
@@ -14,6 +14,7 @@ from ..data.filesystem.workflow_repo import WorkflowRepository
 from ..data.repositories.run_repo import RunRepository
 from ..data.repositories.run_read_model import RunReadModel
 from ..logic.services.eval_service import EvalService
+from ..logic.services.api_run_service import ApiRunService
 from ..logic.services.execution_service import ExecutionService
 from ..logic.services.git_service import GitService
 from ..logic.services.model_service import ModelService
@@ -119,6 +120,18 @@ def get_external_invocation_admission(request: Request) -> ExternalInvocationAdm
         return request.app.state.external_invocation_admission
     except AttributeError:
         return ExternalInvocationAdmission(get_trigger_runtime_config(request))
+
+
+def get_api_run_service(
+    run_service: RunService = Depends(get_run_service),
+    execution_service: Optional[ExecutionService] = Depends(get_execution_service),
+    runtime_admission: ExternalInvocationAdmission = Depends(get_external_invocation_admission),
+) -> ApiRunService:
+    return ApiRunService(
+        run_service=run_service,
+        execution_service=execution_service,
+        runtime_admission=runtime_admission,
+    )
 
 
 def get_soul_service(

--- a/apps/api/src/runsight_api/transport/deps.py
+++ b/apps/api/src/runsight_api/transport/deps.py
@@ -21,6 +21,7 @@ from ..logic.services.provider_service import ProviderService
 from ..logic.services.run_service import RunService
 from ..logic.services.settings_service import SettingsService
 from ..logic.services.soul_service import SoulService
+from ..logic.services.trigger_runtime import ExternalInvocationAdmission, TriggerRuntimeConfig
 from ..logic.services.workflow_service import WorkflowService
 
 
@@ -104,6 +105,20 @@ def get_execution_service(
         return request.app.state.execution_service
     except AttributeError:
         return None
+
+
+def get_trigger_runtime_config(request: Request) -> TriggerRuntimeConfig:
+    try:
+        return request.app.state.trigger_runtime_config
+    except AttributeError:
+        return TriggerRuntimeConfig.from_settings(settings)
+
+
+def get_external_invocation_admission(request: Request) -> ExternalInvocationAdmission:
+    try:
+        return request.app.state.external_invocation_admission
+    except AttributeError:
+        return ExternalInvocationAdmission(get_trigger_runtime_config(request))
 
 
 def get_soul_service(

--- a/apps/api/src/runsight_api/transport/middleware/body_limit.py
+++ b/apps/api/src/runsight_api/transport/middleware/body_limit.py
@@ -14,6 +14,10 @@ class BodySizeLimitMiddleware:
             await self.app(scope, receive, send)
             return
 
+        if not _is_direct_api_invocation_request(scope):
+            await self.app(scope, receive, send)
+            return
+
         content_length = _content_length(scope.get("headers", []))
         if content_length is not None and content_length > self.max_body_bytes:
             await _body_too_large_response()(scope, receive, send)
@@ -65,6 +69,13 @@ def _content_length(headers: list[tuple[bytes, bytes]]) -> int | None:
         except ValueError:
             return None
     return None
+
+
+def _is_direct_api_invocation_request(scope: Scope) -> bool:
+    if scope.get("method") != "POST":
+        return False
+    parts = str(scope.get("path", "")).strip("/").split("/")
+    return len(parts) == 4 and parts[0] == "api" and parts[1] == "workflows" and parts[3] == "runs"
 
 
 def _body_too_large_response() -> JSONResponse:

--- a/apps/api/src/runsight_api/transport/middleware/body_limit.py
+++ b/apps/api/src/runsight_api/transport/middleware/body_limit.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from starlette.responses import JSONResponse
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+
+class BodySizeLimitMiddleware:
+    def __init__(self, app: ASGIApp, *, max_body_bytes: int) -> None:
+        self.app = app
+        self.max_body_bytes = max_body_bytes
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        content_length = _content_length(scope.get("headers", []))
+        if content_length is not None and content_length > self.max_body_bytes:
+            await _body_too_large_response()(scope, receive, send)
+            return
+
+        limited_receive = _LimitedReceive(
+            receive,
+            max_body_bytes=self.max_body_bytes,
+        )
+        try:
+            await self.app(scope, limited_receive, send)
+        except _BodyTooLarge:
+            await _body_too_large_response()(scope, receive, send)
+
+
+class _BodyTooLarge(Exception):
+    pass
+
+
+class _LimitedReceive:
+    def __init__(self, receive: Receive, *, max_body_bytes: int) -> None:
+        self.receive = receive
+        self.max_body_bytes = max_body_bytes
+        self.bytes_seen = 0
+        self.rejected = False
+
+    async def __call__(self) -> Message:
+        if self.rejected:
+            return {"type": "http.disconnect"}
+
+        message = await self.receive()
+        if message["type"] != "http.request":
+            return message
+
+        body = message.get("body", b"")
+        self.bytes_seen += len(body)
+        if self.bytes_seen > self.max_body_bytes:
+            self.rejected = True
+            raise _BodyTooLarge()
+        return message
+
+
+def _content_length(headers: list[tuple[bytes, bytes]]) -> int | None:
+    for name, value in headers:
+        if name.lower() != b"content-length":
+            continue
+        try:
+            return int(value.decode("ascii"))
+        except ValueError:
+            return None
+    return None
+
+
+def _body_too_large_response() -> JSONResponse:
+    return JSONResponse(
+        status_code=413,
+        content={
+            "error": "Request body too large",
+            "error_code": "REQUEST_BODY_TOO_LARGE",
+            "status_code": 413,
+        },
+    )

--- a/apps/api/src/runsight_api/transport/middleware/error_handler.py
+++ b/apps/api/src/runsight_api/transport/middleware/error_handler.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from typing import Any
 
 from fastapi import Request
@@ -12,6 +13,8 @@ from ...core.context import request_id as _request_id_var
 from ...domain.errors import RunsightError
 
 logger = logging.getLogger(__name__)
+
+_DIRECT_API_RUN_PATH = re.compile(r"^/api/workflows/([^/]+)/runs$")
 
 
 async def global_exception_handler(request: Request, exc: Exception) -> JSONResponse:
@@ -72,11 +75,15 @@ async def request_validation_exception_handler(
     request: Request,
     exc: RequestValidationError,
 ) -> JSONResponse:
-    if request.method != "POST" or request.url.path != "/api/runs":
+    workflow_id: str | None = None
+    if request.method == "POST" and request.url.path == "/api/runs":
+        body_value = getattr(exc, "body", None)
+        workflow_id = body_value.get("workflow_id") if isinstance(body_value, dict) else None
+    elif request.method == "POST" and (match := _DIRECT_API_RUN_PATH.match(request.url.path)):
+        workflow_id = match.group(1)
+    else:
         return await fastapi_validation_handler(request, exc)
 
-    body_value = getattr(exc, "body", None)
-    workflow_id = body_value.get("workflow_id") if isinstance(body_value, dict) else None
     fields = [_workflow_request_field_error(error) for error in exc.errors()]
     body: dict[str, Any] = {
         "error": "Workflow input validation failed",

--- a/apps/api/src/runsight_api/transport/routers/dashboard.py
+++ b/apps/api/src/runsight_api/transport/routers/dashboard.py
@@ -10,7 +10,7 @@ from ..schemas.dashboard import AttentionItemsResponse, DashboardKPIsResponse
 router = APIRouter(prefix="/dashboard", tags=["Dashboard"])
 
 PERIOD_HOURS = 24
-PRODUCTION_SOURCES = {"manual", "webhook", "schedule"}
+PRODUCTION_SOURCES = {"manual", "api", "webhook", "schedule"}
 
 
 def _is_production_main_run(run) -> bool:

--- a/apps/api/src/runsight_api/transport/routers/runs.py
+++ b/apps/api/src/runsight_api/transport/routers/runs.py
@@ -265,6 +265,26 @@ async def create_run(
     execution_service: Optional[ExecutionService] = Depends(get_execution_service),
 ):
     source = body.source or "manual"
+    if source == "api":
+        raise InputValidationError(
+            "Workflow input validation failed",
+            error_code="WORKFLOW_INPUT_VALIDATION_ERROR",
+            status_code=422,
+            details={
+                "kind": "workflow_input_validation",
+                "workflow_id": body.workflow_id,
+                "fields": [
+                    {
+                        "field": "source",
+                        "code": "reserved",
+                        "message": "The api source is reserved for Direct API invocations.",
+                        "input_path": ["body", "source"],
+                        "expected_type": None,
+                        "actual_type": "string",
+                    }
+                ],
+            },
+        )
     branch = body.branch
     persisted_branch = "main" if branch is None else branch
     if execution_service is None:

--- a/apps/api/src/runsight_api/transport/routers/runs.py
+++ b/apps/api/src/runsight_api/transport/routers/runs.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Optional
+from typing import Any, List, Optional
 
 from fastapi import APIRouter, Depends, Query
 
@@ -36,6 +36,78 @@ from ..schemas.runs import (
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/runs", tags=["Runs"])
+
+_DROP_SOURCE_METADATA_VALUE = object()
+
+
+def _is_unsafe_source_metadata_response_key(key: str) -> bool:
+    normalized = key.lower().replace("-", "_").replace(" ", "_")
+    compact = "".join(part for part in normalized if part.isalnum())
+    segments = {segment for segment in normalized.split("_") if segment}
+
+    if any(
+        marker in compact
+        for marker in (
+            "apikey",
+            "authorization",
+            "authentication",
+            "idempotency",
+            "password",
+            "rawbody",
+            "rawinput",
+            "rawinputs",
+            "secret",
+            "token",
+            "workflowinputs",
+        )
+    ):
+        return True
+    return bool(
+        segments
+        & {
+            "auth",
+            "authorization",
+            "authentication",
+            "body",
+            "cookie",
+            "cookies",
+            "header",
+            "headers",
+            "input",
+            "inputs",
+            "password",
+            "raw",
+            "secret",
+            "token",
+        }
+    )
+
+
+def _sanitize_source_metadata_response_value(value: Any) -> Any:
+    if isinstance(value, dict):
+        sanitized: dict[str, Any] = {}
+        for key, nested in value.items():
+            if not isinstance(key, str) or _is_unsafe_source_metadata_response_key(key):
+                continue
+            clean_nested = _sanitize_source_metadata_response_value(nested)
+            if clean_nested is _DROP_SOURCE_METADATA_VALUE or clean_nested in ({}, []):
+                continue
+            sanitized[key] = clean_nested
+        return sanitized
+
+    if isinstance(value, list):
+        sanitized_items = []
+        for item in value:
+            clean_item = _sanitize_source_metadata_response_value(item)
+            if clean_item is _DROP_SOURCE_METADATA_VALUE or clean_item in ({}, []):
+                continue
+            sanitized_items.append(clean_item)
+        return sanitized_items
+
+    if value is None or isinstance(value, str | int | float | bool):
+        return value
+
+    return _DROP_SOURCE_METADATA_VALUE
 
 
 def _run_response_field(run, field: str, default):
@@ -129,7 +201,7 @@ def _run_snapshot_field(run, field: str) -> Optional[dict]:
 
 def _run_metadata_field(run) -> dict:
     value = getattr(run, "source_metadata", None)
-    return value if isinstance(value, dict) else {}
+    return _sanitize_source_metadata_response_value(value) if isinstance(value, dict) else {}
 
 
 def _build_run_response(

--- a/apps/api/src/runsight_api/transport/routers/runs.py
+++ b/apps/api/src/runsight_api/transport/routers/runs.py
@@ -43,7 +43,7 @@ def _run_response_field(run, field: str, default):
     value = getattr(run, field, default)
     if field == "source":
         return value if isinstance(value, str) else default
-    if field == "commit_sha":
+    if field in {"commit_sha", "source_correlation_id"}:
         return value if value is None or isinstance(value, str) else None
     return value
 
@@ -127,6 +127,11 @@ def _run_snapshot_field(run, field: str) -> Optional[dict]:
     return value if isinstance(value, dict) else None
 
 
+def _run_metadata_field(run) -> dict:
+    value = getattr(run, "source_metadata", None)
+    return value if isinstance(value, dict) else {}
+
+
 def _build_run_response(
     run,
     *,
@@ -152,6 +157,8 @@ def _build_run_response(
         branch=_run_branch_field(run),
         source=_run_response_field(run, "source", "manual"),
         commit_sha=_run_response_field(run, "commit_sha", None),
+        source_correlation_id=_run_response_field(run, "source_correlation_id", None),
+        source_metadata=_run_metadata_field(run),
         run_number=_run_metric_field(run, "run_number"),
         eval_pass_pct=_run_metric_field(run, "eval_pass_pct"),
         eval_score_avg=eval_score_avg,

--- a/apps/api/src/runsight_api/transport/routers/workflows.py
+++ b/apps/api/src/runsight_api/transport/routers/workflows.py
@@ -9,6 +9,7 @@ from ...logic.services.workflow_service import WorkflowService
 from ..deps import get_api_run_service, get_eval_service, get_workflow_service
 from ..schemas.runs import (
     DirectApiRunCreate,
+    ErrorResponse,
     NodeSummary,
     RunResponse,
     WorkflowInputValidationErrorResponse,
@@ -119,10 +120,14 @@ async def patch_workflow_enabled(
     "/{workflow_id}/runs",
     response_model=RunResponse,
     responses={
-        404: {"description": "Workflow not found"},
+        404: {"model": ErrorResponse, "description": "Workflow not found"},
         422: {"model": WorkflowInputValidationErrorResponse},
-        429: {"description": "External invocation admission is saturated"},
-        503: {"description": "Execution runtime is unavailable"},
+        429: {
+            "model": ErrorResponse,
+            "description": "External invocation admission is saturated",
+        },
+        503: {"model": ErrorResponse, "description": "Execution runtime is unavailable"},
+        413: {"model": ErrorResponse, "description": "Request body too large"},
     },
 )
 async def create_direct_api_run(

--- a/apps/api/src/runsight_api/transport/routers/workflows.py
+++ b/apps/api/src/runsight_api/transport/routers/workflows.py
@@ -1,12 +1,19 @@
 from typing import Optional
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Request
 from runsight_core.identity import EntityKind, EntityRef
 
 from ...logic.services.eval_service import EvalService
+from ...logic.services.api_run_service import ApiRunService
 from ...logic.services.workflow_service import WorkflowService
-from ..deps import get_eval_service, get_workflow_service
-from ..schemas.runs import WorkflowInputValidationErrorResponse
+from ..deps import get_api_run_service, get_eval_service, get_workflow_service
+from ..schemas.runs import (
+    DirectApiRunCreate,
+    NodeSummary,
+    RunResponse,
+    WorkflowInputValidationErrorResponse,
+)
+from .runs import _build_run_response, _run_metric_field
 from ..schemas.workflows import (
     WorkflowCommitCreate,
     WorkflowCommitResponse,
@@ -26,6 +33,10 @@ router = APIRouter(prefix="/workflows", tags=["Workflows"])
 
 def _workflow_ref(workflow_id: str) -> str:
     return str(EntityRef(EntityKind.WORKFLOW, workflow_id))
+
+
+def _direct_api_source_correlation_id(request: Request) -> str | None:
+    return request.headers.get("x-request-id") or request.headers.get("x-correlation-id")
 
 
 @router.get("", response_model=WorkflowListResponse)
@@ -102,6 +113,42 @@ async def patch_workflow_enabled(
 ):
     w = service.set_enabled(id, body.enabled)
     return WorkflowResponse(**w.model_dump())
+
+
+@router.post(
+    "/{workflow_id}/runs",
+    response_model=RunResponse,
+    responses={
+        404: {"description": "Workflow not found"},
+        422: {"model": WorkflowInputValidationErrorResponse},
+        429: {"description": "External invocation admission is saturated"},
+        503: {"description": "Execution runtime is unavailable"},
+    },
+)
+async def create_direct_api_run(
+    workflow_id: str,
+    body: DirectApiRunCreate,
+    request: Request,
+    service: ApiRunService = Depends(get_api_run_service),
+):
+    run = await service.create_direct_api_run(
+        workflow_id=workflow_id,
+        inputs=body.inputs,
+        source_correlation_id=_direct_api_source_correlation_id(request),
+        source_metadata={
+            "entry_path": "direct_api",
+            "request_path": request.url.path,
+        },
+    )
+    return _build_run_response(
+        run,
+        total_cost_usd=run.total_cost_usd,
+        total_tokens=run.total_tokens,
+        node_summary=NodeSummary(total=0, completed=0, running=0, pending=0, failed=0),
+        eval_score_avg=_run_metric_field(run, "eval_score_avg"),
+        regression_count=_run_metric_field(run, "regression_count"),
+        regression_types=[],
+    )
 
 
 @router.get("/{id}/regressions", response_model=WorkflowRegressionsResponse)

--- a/apps/api/src/runsight_api/transport/schemas/runs.py
+++ b/apps/api/src/runsight_api/transport/schemas/runs.py
@@ -31,6 +31,13 @@ class WorkflowInputValidationErrorResponse(BaseModel):
     details: WorkflowInputValidationErrorDetails
 
 
+class ErrorResponse(BaseModel):
+    error: str
+    error_code: str
+    status_code: int
+    details: Optional[Dict[str, Any]] = None
+
+
 class RunCreate(BaseModel):
     model_config = ConfigDict(extra="forbid")
 

--- a/apps/api/src/runsight_api/transport/schemas/runs.py
+++ b/apps/api/src/runsight_api/transport/schemas/runs.py
@@ -40,6 +40,12 @@ class RunCreate(BaseModel):
     branch: Optional[str] = Field(default=None, min_length=1)
 
 
+class DirectApiRunCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    inputs: Dict[str, Any]
+
+
 class NodeSummary(BaseModel):
     total: int
     completed: int

--- a/apps/api/src/runsight_api/transport/schemas/runs.py
+++ b/apps/api/src/runsight_api/transport/schemas/runs.py
@@ -63,6 +63,8 @@ class RunResponse(BaseModel):
     branch: str
     source: str = "manual"
     commit_sha: Optional[str] = None
+    source_correlation_id: Optional[str] = None
+    source_metadata: Dict[str, Any] = Field(default_factory=dict)
     run_number: Optional[int] = None
     eval_pass_pct: Optional[float] = None
     eval_score_avg: Optional[float] = None

--- a/apps/api/tests/data/test_run822_workflow_repo_identity.py
+++ b/apps/api/tests/data/test_run822_workflow_repo_identity.py
@@ -76,6 +76,13 @@ def test_update_rejects_workflow_id_stem_mismatch(tmp_path) -> None:
         )
 
 
+def test_build_entity_from_yaml_reports_snapshot_id_mismatch_as_validation_error(tmp_path) -> None:
+    repo = WorkflowRepository(base_path=str(tmp_path))
+
+    with pytest.raises(InputValidationError, match="embedded id"):
+        repo.build_entity_from_yaml("legacy-workflow", _workflow_fixture_text())
+
+
 def test_update_keeps_yaml_and_canvas_persistence_in_separate_workflow_contract_files(
     tmp_path,
 ) -> None:

--- a/apps/api/tests/data/test_run930_run_provenance_read_model.py
+++ b/apps/api/tests/data/test_run930_run_provenance_read_model.py
@@ -1,0 +1,114 @@
+"""RED tests for RUN-930 run provenance in read models."""
+
+from __future__ import annotations
+
+import pytest
+from sqlmodel import Session, SQLModel, create_engine
+
+from runsight_api.domain.entities.run import Run
+
+COMMITTED_MAIN_SHA = "abc123def4567890abc123def4567890abc123de"
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+
+
+def _seed_run(
+    session: Session,
+    run_id: str,
+    *,
+    workflow_id: str = "wf-930",
+    workflow_name: str = "Direct API Workflow",
+    created_at: float,
+    source: str = "manual",
+    branch: str = "main",
+    commit_sha: str | None = None,
+    source_correlation_id: str | None = None,
+    source_metadata: dict[str, object] | None = None,
+) -> None:
+    session.add(
+        Run(
+            id=run_id,
+            workflow_id=workflow_id,
+            workflow_name=workflow_name,
+            task_json="{}",
+            source=source,
+            branch=branch,
+            commit_sha=commit_sha,
+            source_correlation_id=source_correlation_id,
+            source_metadata=source_metadata,
+            created_at=created_at,
+            updated_at=created_at,
+        )
+    )
+
+
+class TestRun930RunReadModelProvenance:
+    def test_list_runs_paginated_preserves_api_provenance_and_old_run_defaults(
+        self,
+        db_session: Session,
+    ) -> None:
+        """Read models should distinguish API runs while keeping old rows readable."""
+        from runsight_api.data.repositories.run_read_model import RunReadModel
+
+        _seed_run(
+            db_session,
+            "run-manual-old",
+            created_at=100.0,
+            source="legacy-runner",
+            branch="main",
+        )
+        _seed_run(
+            db_session,
+            "run-simulation",
+            created_at=200.0,
+            source="simulation",
+            branch="sim/run-930",
+        )
+        _seed_run(
+            db_session,
+            "run-api",
+            created_at=300.0,
+            source="api",
+            branch="main",
+            commit_sha=COMMITTED_MAIN_SHA,
+            source_correlation_id="corr-930",
+            source_metadata={
+                "entry_path": "direct_api",
+                "client_request_id": "req-930",
+            },
+        )
+        db_session.commit()
+
+        read_model = RunReadModel(db_session)
+        api_items, api_total = read_model.list_runs_paginated(
+            offset=0,
+            limit=10,
+            source=["api"],
+        )
+        all_items, all_total = read_model.list_runs_paginated(offset=0, limit=10)
+
+        assert api_total == 1
+        assert [run.id for run in api_items] == ["run-api"]
+        assert api_items[0].source == "api"
+        assert api_items[0].branch == "main"
+        assert api_items[0].commit_sha == COMMITTED_MAIN_SHA
+        assert api_items[0].source_correlation_id == "corr-930"
+        assert api_items[0].source_metadata == {
+            "entry_path": "direct_api",
+            "client_request_id": "req-930",
+        }
+
+        assert all_total == 3
+        old_run = next(run for run in all_items if run.id == "run-manual-old")
+        assert old_run.source == "legacy-runner"
+        assert old_run.source_correlation_id is None
+        assert old_run.source_metadata == {}
+
+        simulation_run = next(run for run in all_items if run.id == "run-simulation")
+        assert simulation_run.source == "simulation"

--- a/apps/api/tests/data/test_run934_api_provenance_read_model.py
+++ b/apps/api/tests/data/test_run934_api_provenance_read_model.py
@@ -1,0 +1,75 @@
+"""RED tests for RUN-934 API source treatment in read-model semantics."""
+
+from __future__ import annotations
+
+import pytest
+from sqlmodel import Session, SQLModel, create_engine
+
+from runsight_api.domain.entities.run import Run, RunNode, RunStatus
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+
+
+def _seed_run(
+    session: Session,
+    run_id: str,
+    *,
+    source: str,
+    created_at: float,
+    eval_passed: bool,
+    total_cost_usd: float = 1.0,
+) -> None:
+    session.add(
+        Run(
+            id=run_id,
+            workflow_id="wf_run934",
+            workflow_name="RUN-934 Workflow",
+            status=RunStatus.completed,
+            task_json="{}",
+            source=source,
+            branch="main" if source != "simulation" else "sim/run-934",
+            created_at=created_at,
+            updated_at=created_at,
+            total_cost_usd=total_cost_usd,
+        )
+    )
+    session.add(
+        RunNode(
+            id=f"{run_id}:node",
+            run_id=run_id,
+            node_id="node",
+            block_type="llm",
+            status="completed",
+            eval_passed=eval_passed,
+            cost_usd=total_cost_usd,
+            tokens={"total": 10},
+        )
+    )
+
+
+def test_api_runs_are_production_runs_for_workflow_health_metrics(db_session: Session) -> None:
+    from runsight_api.data.repositories.run_read_model import RunReadModel
+
+    _seed_run(db_session, "run_934_manual", source="manual", created_at=100.0, eval_passed=True)
+    _seed_run(db_session, "run_934_api", source="api", created_at=200.0, eval_passed=False)
+    _seed_run(
+        db_session,
+        "run_934_simulation",
+        source="simulation",
+        created_at=300.0,
+        eval_passed=False,
+        total_cost_usd=99.0,
+    )
+    db_session.commit()
+
+    metrics = RunReadModel(db_session).get_workflow_health_metrics(["wf_run934"])
+
+    assert metrics["wf_run934"]["run_count"] == 2
+    assert metrics["wf_run934"]["eval_pass_pct"] == 50.0
+    assert metrics["wf_run934"]["total_cost_usd"] == 2.0

--- a/apps/api/tests/domain/test_run663_entity_fields.py
+++ b/apps/api/tests/domain/test_run663_entity_fields.py
@@ -175,6 +175,50 @@ class TestSqliteBackfillColumns:
                 "Expected _ensure_sqlite_columns to leave branch out of legacy run table backfill"
             )
 
+    def test_ensure_sqlite_columns_creates_source_indexes_when_created_at_exists(
+        self, tmp_path
+    ) -> None:
+        """Backfill must create source indexes when legacy SQLite tables support them."""
+        from sqlalchemy import create_engine
+
+        from runsight_api.main import _ensure_sqlite_columns
+
+        db_path = tmp_path / "run663_legacy_with_created_at.sqlite"
+        engine = create_engine(f"sqlite:///{db_path}")
+        with engine.begin() as conn:
+            conn.exec_driver_sql(
+                """
+                CREATE TABLE run (
+                    id TEXT PRIMARY KEY,
+                    workflow_id TEXT NOT NULL,
+                    workflow_name TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    task_json TEXT NOT NULL,
+                    created_at FLOAT NOT NULL
+                )
+                """
+            )
+            conn.exec_driver_sql(
+                """
+                CREATE TABLE runnode (
+                    id TEXT PRIMARY KEY,
+                    run_id TEXT NOT NULL,
+                    node_id TEXT NOT NULL,
+                    block_type TEXT NOT NULL,
+                    status TEXT NOT NULL
+                )
+                """
+            )
+
+        _ensure_sqlite_columns(engine)
+
+        with engine.begin() as conn:
+            index_names = {
+                row[1] for row in conn.exec_driver_sql("PRAGMA index_list(run)").fetchall()
+            }
+            assert "ix_run_source_created_at" in index_names
+            assert "ix_run_workflow_source_created_at" in index_names
+
 
 class TestAlembicMigrationAddsRunWarningsJson:
     """A migration must add and drop run.warnings_json for non-SQLite DBs."""

--- a/apps/api/tests/domain/test_run930_run_provenance_foundation.py
+++ b/apps/api/tests/domain/test_run930_run_provenance_foundation.py
@@ -42,6 +42,31 @@ def _migration_sources() -> list[tuple[Path, str]]:
     ]
 
 
+def _deferred_persistence_hits(names: set[str]) -> list[str]:
+    """Find deferred persistence names while allowing existing token metrics."""
+    allowed_token_metrics = {"tokens", "total_tokens"}
+    deferred_terms = (
+        "webhook",
+        "schedule",
+        "scheduler",
+        "trigger",
+        "delivery",
+        "idempotency",
+    )
+    hits = []
+    for name in sorted(names):
+        lowered = name.lower()
+        if any(term in lowered for term in deferred_terms):
+            hits.append(name)
+        elif "token" in lowered and lowered not in allowed_token_metrics:
+            hits.append(name)
+    return hits
+
+
+def _migration_identifiers(source: str) -> set[str]:
+    return set(re.findall(r"[A-Za-z_][A-Za-z0-9_]*", source))
+
+
 def _mock_run(
     run_id: str,
     *,
@@ -80,9 +105,10 @@ def _mock_node(
 class TestRun930AlembicMigrationContract:
     def test_migration_adds_direct_api_provenance_columns_and_indexes_only(self) -> None:
         """RUN-930 must add direct API provenance without deferred trigger/idempotency storage."""
+        all_migration_sources = _migration_sources()
         provenance_migrations = [
             (path, source)
-            for path, source in _migration_sources()
+            for path, source in all_migration_sources
             if "source_metadata" in source or "source_correlation_id" in source
         ]
         assert provenance_migrations, "Expected a RUN-930 migration for direct API provenance"
@@ -103,36 +129,34 @@ class TestRun930AlembicMigrationContract:
             normalized,
         ), "Expected an index over (workflow_id, source, created_at)"
 
-        forbidden_terms = {
-            "idempotency_key",
-            "webhook",
-            "schedule",
-            "scheduler",
-            "trigger",
-            "delivery",
-            "token",
-        }
-        found = {term for term in forbidden_terms if term in combined.lower()}
-        assert not found, (
-            f"RUN-930 migration must not include deferred persistence: {sorted(found)}"
+        all_migration_identifiers = set()
+        for _, source in all_migration_sources:
+            all_migration_identifiers.update(_migration_identifiers(source))
+        deferred_hits = _deferred_persistence_hits(all_migration_identifiers)
+        assert deferred_hits == [], (
+            "RUN-930 migration surface must not include deferred persistence identifiers: "
+            f"{deferred_hits}"
         )
 
 
-class TestRun930NoIdempotencyPersistenceSurface:
-    def test_run_model_table_and_response_fields_do_not_expose_idempotency(self) -> None:
-        """RUN-930 must leave no idempotency persistence or serialization surface."""
+class TestRun930PersistenceSurfaceContract:
+    def test_provenance_fields_exist_without_deferred_persistence_surfaces(self) -> None:
+        """RUN-930 provenance must exist without webhook/schedule/idempotency persistence."""
         from runsight_api.domain.entities.run import Run
         from runsight_api.transport.schemas.runs import RunResponse
 
         run_model_fields = set(Run.model_fields)
         run_table_columns = {column.name for column in Run.__table__.columns}
         response_fields = set(RunResponse.model_fields)
-        all_field_names = run_model_fields | run_table_columns | response_fields
 
-        idempotency_fields = sorted(
-            field_name for field_name in all_field_names if "idempotency" in field_name.lower()
-        )
-        assert idempotency_fields == []
+        required_provenance_fields = {"source_metadata", "source_correlation_id"}
+        assert required_provenance_fields.issubset(run_model_fields)
+        assert required_provenance_fields.issubset(run_table_columns)
+        assert required_provenance_fields.issubset(response_fields)
+
+        all_surface_names = run_model_fields | run_table_columns | response_fields
+        deferred_hits = _deferred_persistence_hits(all_surface_names)
+        assert deferred_hits == []
 
 
 class TestRun930RunEntityProvenance:

--- a/apps/api/tests/domain/test_run930_run_provenance_foundation.py
+++ b/apps/api/tests/domain/test_run930_run_provenance_foundation.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import re
 from pathlib import Path
+from unittest.mock import Mock
 
 import pytest
 from pydantic import ValidationError
@@ -39,6 +40,41 @@ def _migration_sources() -> list[tuple[Path, str]]:
         for path in sorted(_versions_dir().glob("*.py"))
         if path.name != "__init__.py"
     ]
+
+
+def _mock_run(
+    run_id: str,
+    *,
+    source: str,
+    branch: str = "main",
+    created_at: float,
+):
+    run = Mock()
+    run.id = run_id
+    run.workflow_id = "wf-930"
+    run.workflow_name = "Direct API Workflow"
+    run.source = source
+    run.branch = branch
+    run.created_at = created_at
+    return run
+
+
+def _mock_node(
+    run_id: str,
+    *,
+    eval_passed: bool,
+):
+    node = Mock()
+    node.node_id = "shared_node"
+    node.run_id = run_id
+    node.soul_id = "researcher"
+    node.soul_version = "sha256:run930"
+    node.eval_score = 0.9
+    node.eval_passed = eval_passed
+    node.cost_usd = 0.01
+    node.tokens = {"prompt": 100, "completion": 50, "total": 150}
+    node.created_at = 100.0
+    return node
 
 
 class TestRun930AlembicMigrationContract:
@@ -80,6 +116,23 @@ class TestRun930AlembicMigrationContract:
         assert not found, (
             f"RUN-930 migration must not include deferred persistence: {sorted(found)}"
         )
+
+
+class TestRun930NoIdempotencyPersistenceSurface:
+    def test_run_model_table_and_response_fields_do_not_expose_idempotency(self) -> None:
+        """RUN-930 must leave no idempotency persistence or serialization surface."""
+        from runsight_api.domain.entities.run import Run
+        from runsight_api.transport.schemas.runs import RunResponse
+
+        run_model_fields = set(Run.model_fields)
+        run_table_columns = {column.name for column in Run.__table__.columns}
+        response_fields = set(RunResponse.model_fields)
+        all_field_names = run_model_fields | run_table_columns | response_fields
+
+        idempotency_fields = sorted(
+            field_name for field_name in all_field_names if "idempotency" in field_name.lower()
+        )
+        assert idempotency_fields == []
 
 
 class TestRun930RunEntityProvenance:
@@ -198,3 +251,51 @@ class TestRun930RunResponseProvenance:
             "client_request_id": "req-930",
         }
         assert "idempotency" not in serialized.lower()
+
+
+class TestRun930ProductionSourceSemantics:
+    def test_api_main_run_is_production_baseline_and_simulation_between_runs_is_not(self) -> None:
+        """Downstream regression logic must include API production runs and exclude simulations."""
+        from runsight_api.logic.services.eval_service import EvalService
+
+        repo = Mock()
+        manual_baseline = _mock_run(
+            "run-manual-pass",
+            source="manual",
+            created_at=100.0,
+        )
+        api_baseline = _mock_run(
+            "run-api-fail",
+            source="api",
+            created_at=200.0,
+        )
+        simulation_between = _mock_run(
+            "run-simulation-pass",
+            source="simulation",
+            branch="sim/run-930",
+            created_at=300.0,
+        )
+        current_manual = _mock_run(
+            "run-manual-current-fail",
+            source="manual",
+            created_at=400.0,
+        )
+
+        nodes_by_run = {
+            "run-manual-pass": [_mock_node("run-manual-pass", eval_passed=True)],
+            "run-api-fail": [_mock_node("run-api-fail", eval_passed=False)],
+            "run-simulation-pass": [_mock_node("run-simulation-pass", eval_passed=True)],
+            "run-manual-current-fail": [_mock_node("run-manual-current-fail", eval_passed=False)],
+        }
+        repo.get_run.return_value = current_manual
+        repo.list_runs.return_value = [
+            current_manual,
+            simulation_between,
+            api_baseline,
+            manual_baseline,
+        ]
+        repo.list_nodes_for_run.side_effect = lambda run_id: nodes_by_run[run_id]
+
+        result = EvalService(repo).get_run_regressions("run-manual-current-fail")
+
+        assert result == {"count": 0, "issues": []}

--- a/apps/api/tests/domain/test_run930_run_provenance_foundation.py
+++ b/apps/api/tests/domain/test_run930_run_provenance_foundation.py
@@ -1,0 +1,200 @@
+"""RED tests for RUN-930 direct API run provenance foundation."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+from sqlmodel import Session, SQLModel, create_engine
+
+COMMITTED_MAIN_SHA = "abc123def4567890abc123def4567890abc123de"
+
+
+def _make_run(**overrides):
+    from runsight_api.domain.entities.run import Run
+
+    values = {
+        "id": "run-930-provenance",
+        "workflow_id": "wf-930",
+        "workflow_name": "Direct API Workflow",
+        "task_json": "{}",
+        "branch": "main",
+        "source": "api",
+        "commit_sha": COMMITTED_MAIN_SHA,
+    }
+    values.update(overrides)
+    return Run(**values)
+
+
+def _versions_dir() -> Path:
+    return Path(__file__).resolve().parents[2] / "src" / "runsight_api" / "alembic" / "versions"
+
+
+def _migration_sources() -> list[tuple[Path, str]]:
+    return [
+        (path, path.read_text())
+        for path in sorted(_versions_dir().glob("*.py"))
+        if path.name != "__init__.py"
+    ]
+
+
+class TestRun930AlembicMigrationContract:
+    def test_migration_adds_direct_api_provenance_columns_and_indexes_only(self) -> None:
+        """RUN-930 must add direct API provenance without deferred trigger/idempotency storage."""
+        provenance_migrations = [
+            (path, source)
+            for path, source in _migration_sources()
+            if "source_metadata" in source or "source_correlation_id" in source
+        ]
+        assert provenance_migrations, "Expected a RUN-930 migration for direct API provenance"
+
+        combined = "\n".join(source for _, source in provenance_migrations)
+        assert "source_metadata" in combined
+        assert "source_correlation_id" in combined
+        assert re.search(r"source_metadata.+JSON|JSON.+source_metadata", combined, re.DOTALL)
+        assert "nullable=True" in combined
+
+        normalized = re.sub(r"\s+", "", combined)
+        assert re.search(
+            r"create_index\([^)]*\[.*['\"]source['\"].*['\"]created_at['\"].*\]",
+            normalized,
+        ), "Expected an index over (source, created_at)"
+        assert re.search(
+            r"create_index\([^)]*\[.*['\"]workflow_id['\"].*['\"]source['\"].*['\"]created_at['\"].*\]",
+            normalized,
+        ), "Expected an index over (workflow_id, source, created_at)"
+
+        forbidden_terms = {
+            "idempotency_key",
+            "webhook",
+            "schedule",
+            "scheduler",
+            "trigger",
+            "delivery",
+            "token",
+        }
+        found = {term for term in forbidden_terms if term in combined.lower()}
+        assert not found, (
+            f"RUN-930 migration must not include deferred persistence: {sorted(found)}"
+        )
+
+
+class TestRun930RunEntityProvenance:
+    def test_api_run_persists_committed_main_identity_and_safe_metadata(self) -> None:
+        """API runs should round-trip source='api', committed main identity, and safe provenance."""
+        engine = create_engine("sqlite:///:memory:")
+        SQLModel.metadata.create_all(engine)
+        safe_metadata = {
+            "entry_path": "direct_api",
+            "request_path": "/api/workflows/wf-930/invocations",
+            "client_request_id": "req-930",
+        }
+
+        with Session(engine) as session:
+            session.add(
+                _make_run(
+                    id="run-930-api",
+                    source_metadata=safe_metadata,
+                    source_correlation_id="corr-930",
+                )
+            )
+            session.commit()
+
+        with Session(engine) as session:
+            from runsight_api.domain.entities.run import Run
+
+            loaded = session.get(Run, "run-930-api")
+
+        assert loaded is not None
+        assert loaded.source == "api"
+        assert loaded.branch == "main"
+        assert loaded.commit_sha == COMMITTED_MAIN_SHA
+        assert loaded.source_correlation_id == "corr-930"
+        assert loaded.source_metadata == safe_metadata
+
+    @pytest.mark.parametrize(
+        "unsafe_metadata",
+        [
+            {"headers": {"authorization": "Bearer secret"}},
+            {"authorization": "Bearer secret"},
+            {"raw_body": {"inputs": {"api_token": "secret"}}},
+            {"inputs": {"api_token": "secret"}},
+            {"idempotency_key": "deferred-until-later-slice"},
+        ],
+    )
+    def test_source_metadata_rejects_sensitive_or_deferred_payload_keys(
+        self,
+        unsafe_metadata: dict[str, object],
+    ) -> None:
+        """Provenance metadata must not persist raw request data or idempotency placeholders."""
+        with pytest.raises(ValidationError):
+            _make_run(source_metadata=unsafe_metadata)
+
+    def test_source_metadata_rejects_oversized_payload(self) -> None:
+        """The JSON provenance payload should have an intentional size boundary."""
+        with pytest.raises(ValidationError):
+            _make_run(source_metadata={"client_context": "x" * 8192})
+
+
+class TestRun930RunResponseProvenance:
+    def test_old_run_response_defaults_provenance_safely_and_preserves_unknown_source(self) -> None:
+        """Old rows with missing provenance and unknown source strings must serialize safely."""
+        from runsight_api.transport.schemas.runs import RunResponse
+
+        response = RunResponse(
+            id="run-legacy",
+            workflow_id="wf-legacy",
+            workflow_name="Legacy",
+            status="completed",
+            started_at=None,
+            completed_at=None,
+            duration_seconds=None,
+            total_cost_usd=0.0,
+            total_tokens=0,
+            created_at=1711699200.0,
+            branch="main",
+            source="legacy-runner",
+            commit_sha=None,
+        )
+
+        assert response.source == "legacy-runner"
+        assert response.source_correlation_id is None
+        assert response.source_metadata == {}
+
+    def test_api_run_response_exposes_safe_provenance_without_idempotency(self) -> None:
+        """Direct API responses may expose safe provenance but must not expose idempotency state."""
+        from runsight_api.transport.schemas.runs import RunResponse
+
+        response = RunResponse(
+            id="run-api",
+            workflow_id="wf-930",
+            workflow_name="Direct API Workflow",
+            status="pending",
+            started_at=None,
+            completed_at=None,
+            duration_seconds=None,
+            total_cost_usd=0.0,
+            total_tokens=0,
+            created_at=1711699300.0,
+            branch="main",
+            source="api",
+            commit_sha=COMMITTED_MAIN_SHA,
+            source_correlation_id="corr-930",
+            source_metadata={"entry_path": "direct_api", "client_request_id": "req-930"},
+        )
+
+        payload = response.model_dump()
+        serialized = json.dumps(payload, sort_keys=True)
+
+        assert payload["source"] == "api"
+        assert payload["branch"] == "main"
+        assert payload["commit_sha"] == COMMITTED_MAIN_SHA
+        assert payload["source_correlation_id"] == "corr-930"
+        assert payload["source_metadata"] == {
+            "entry_path": "direct_api",
+            "client_request_id": "req-930",
+        }
+        assert "idempotency" not in serialized.lower()

--- a/apps/api/tests/logic/test_run931_workflow_run_invoker.py
+++ b/apps/api/tests/logic/test_run931_workflow_run_invoker.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import time
 from dataclasses import dataclass
 from typing import Any
 from unittest.mock import Mock
@@ -333,6 +335,24 @@ class _RecordingRunService:
         return self.created_run
 
 
+class _BlockingPreRunExecutionService(_RecordingExecutionService):
+    def __init__(self, *, delay_seconds: float, prepared: Any, committed_workflow: WorkflowEntity):
+        super().__init__(prepared=prepared, committed_workflow=committed_workflow)
+        self.delay_seconds = delay_seconds
+
+    def resolve_workflow_run_snapshot(
+        self, workflow_id: str, *, branch: str
+    ) -> _ResolvedWorkflowSnapshot:
+        time.sleep(self.delay_seconds)
+        return super().resolve_workflow_run_snapshot(workflow_id, branch=branch)
+
+    def prepare_run_inputs_from_snapshot(
+        self, snapshot: _ResolvedWorkflowSnapshot, inputs: dict[str, Any]
+    ):
+        time.sleep(self.delay_seconds)
+        return super().prepare_run_inputs_from_snapshot(snapshot, inputs)
+
+
 class TestWorkflowRunInvocationDirectApiContract:
     def test_direct_api_factory_owns_api_source_and_saved_main_policy(self) -> None:
         invocation = _direct_api_invocation()
@@ -626,3 +646,36 @@ class TestWorkflowRunInvokerDirectApiLaunch:
             {"run_id": "run_run931_created", "error": "snapshot graph failed"}
         ]
         assert _value(run_service.created_run.status) == "failed"
+
+    @pytest.mark.asyncio
+    async def test_direct_api_pre_run_snapshot_work_does_not_block_event_loop(self) -> None:
+        WorkflowRunInvoker, _ = _invoker_contract()
+        main_yaml = _main_workflow_yaml()
+        committed_workflow = _workflow_entity(main_yaml, name="Committed Main Workflow")
+        prepared = _prepared_inputs(main_yaml, {"query": "from api"})
+        run_service = _RecordingRunService()
+        execution = _BlockingPreRunExecutionService(
+            delay_seconds=0.12,
+            prepared=prepared,
+            committed_workflow=committed_workflow,
+        )
+        invoker = WorkflowRunInvoker(
+            run_service=run_service,
+            execution_service=execution,
+            runtime_admission=_RuntimeAdmission(),
+        )
+        start = time.perf_counter()
+        progress_at: list[float] = []
+
+        async def record_event_loop_progress() -> None:
+            await asyncio.sleep(0.01)
+            progress_at.append(time.perf_counter() - start)
+
+        invoke_task = asyncio.create_task(invoker.invoke(_direct_api_invocation()))
+        progress_task = asyncio.create_task(record_event_loop_progress())
+
+        await asyncio.gather(invoke_task, progress_task)
+
+        assert progress_at
+        assert progress_at[0] < 0.08
+        assert _field(invoke_task.result(), "accepted") is True

--- a/apps/api/tests/logic/test_run931_workflow_run_invoker.py
+++ b/apps/api/tests/logic/test_run931_workflow_run_invoker.py
@@ -162,6 +162,14 @@ class _AdmissionDecision:
     reason: str | None = None
 
 
+@dataclass(frozen=True)
+class _ResolvedWorkflowSnapshot:
+    workflow_id: str
+    branch: str
+    workflow: WorkflowEntity | None
+    commit_sha: str
+
+
 class _RuntimeAdmission:
     def __init__(self, *, enabled: bool = True, saturated: bool = False) -> None:
         self.enabled = enabled
@@ -218,31 +226,43 @@ class _RecordingExecutionService:
         self.launch_calls: list[dict[str, Any]] = []
         self.snapshot_calls: list[dict[str, Any]] = []
 
-    def prepare_run_inputs(self, workflow_id: str, inputs: dict[str, Any], *, branch: str | None):
-        self.prepare_calls.append({"workflow_id": workflow_id, "inputs": inputs, "branch": branch})
+    def resolve_workflow_run_snapshot(
+        self, workflow_id: str, *, branch: str
+    ) -> _ResolvedWorkflowSnapshot:
+        self.snapshot_calls.append({"workflow_id": workflow_id, "branch": branch})
+        if self.committed_workflow is None and self.prepare_error is None:
+            raise WorkflowNotFound(f"Workflow {workflow_id!r} not found on {branch!r}")
+        return _ResolvedWorkflowSnapshot(
+            workflow_id=workflow_id,
+            branch=branch,
+            workflow=self.committed_workflow,
+            commit_sha=self.commit_sha,
+        )
+
+    def prepare_run_inputs_from_snapshot(
+        self, snapshot: _ResolvedWorkflowSnapshot, inputs: dict[str, Any]
+    ):
+        self.prepare_calls.append(
+            {"workflow_id": snapshot.workflow_id, "inputs": inputs, "branch": snapshot.branch}
+        )
         if self.prepare_error is not None:
             raise self.prepare_error
         return self.prepared
 
-    def workflow_snapshot_for_run(self, workflow_id: str, *, branch: str) -> WorkflowEntity:
-        self.snapshot_calls.append({"workflow_id": workflow_id, "branch": branch})
-        if self.committed_workflow is None:
-            raise WorkflowNotFound(f"Workflow {workflow_id!r} not found on {branch!r}")
-        return self.committed_workflow
-
-    async def launch_execution(
+    async def launch_execution_from_snapshot(
         self,
         run_id: str,
         workflow_id: str,
         inputs: Any,
-        branch: str | None = None,
+        *,
+        snapshot: _ResolvedWorkflowSnapshot,
     ) -> None:
         self.launch_calls.append(
             {
                 "run_id": run_id,
                 "workflow_id": workflow_id,
                 "inputs": inputs,
-                "branch": branch,
+                "branch": snapshot.branch,
             }
         )
         if self.launch_error is not None:
@@ -250,7 +270,9 @@ class _RecordingExecutionService:
         if self.run_service is not None:
             run = self.run_service.get_run(run_id)
             run.commit_sha = self.commit_sha
-            self.run_service.run_repo.update_run(run)
+            run_repo = getattr(self.run_service, "run_repo", None)
+            if run_repo is not None:
+                run_repo.update_run(run)
 
 
 class _RecordingRunService:

--- a/apps/api/tests/logic/test_run931_workflow_run_invoker.py
+++ b/apps/api/tests/logic/test_run931_workflow_run_invoker.py
@@ -1,0 +1,606 @@
+"""RED tests for RUN-931: WorkflowRunInvoker direct API invocation boundary."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+from sqlalchemy.pool import StaticPool
+from sqlmodel import SQLModel, Session, create_engine, select
+
+from runsight_api.data.repositories.run_repo import RunRepository
+from runsight_api.domain.entities.run import Run, RunStatus
+from runsight_api.domain.errors import InputValidationError, WorkflowNotFound
+from runsight_api.domain.value_objects import WorkflowEntity
+from runsight_api.logic.services.execution_service import (
+    _prepare_run_inputs_from_schema,
+    _workflow_input_schema_from_yaml,
+)
+from runsight_api.logic.services.run_service import RunService
+
+
+WORKFLOW_ID = "run931_direct_api"
+COMMITTED_MAIN_SHA = "931" * 13 + "9"
+
+
+def _invoker_contract():
+    from runsight_api.logic.services.workflow_run_invoker import (
+        WorkflowRunInvocation,
+        WorkflowRunInvoker,
+    )
+
+    return WorkflowRunInvoker, WorkflowRunInvocation
+
+
+def _db_engine():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SQLModel.metadata.create_all(engine)
+    return engine
+
+
+def _main_workflow_yaml(*, name: str = "Committed Main Workflow") -> str:
+    return f"""
+id: {WORKFLOW_ID}
+kind: workflow
+version: "1.0"
+inputs:
+  query:
+    type: string
+  max_results:
+    type: number
+    required: false
+    default: 10
+workflow:
+  name: {name}
+  entry: start
+  transitions:
+    - from: start
+      to: null
+blocks:
+  start:
+    type: code
+    code: |
+      def main(data):
+          return {{"ok": True}}
+"""
+
+
+def _dirty_workflow_yaml() -> str:
+    return f"""
+id: {WORKFLOW_ID}
+kind: workflow
+version: "1.0"
+inputs:
+  query:
+    type: string
+  debug:
+    type: boolean
+    required: false
+    default: true
+workflow:
+  name: Dirty Live Workflow
+  entry: start
+  transitions:
+    - from: start
+      to: null
+blocks:
+  start:
+    type: code
+    code: |
+      def main(data):
+          return {{"dirty": True}}
+"""
+
+
+def _workflow_entity(
+    yaml_text: str,
+    *,
+    name: str,
+    warnings: list[dict[str, str]] | None = None,
+) -> WorkflowEntity:
+    return WorkflowEntity(
+        kind="workflow",
+        id=WORKFLOW_ID,
+        name=name,
+        yaml=yaml_text,
+        valid=True,
+        validation_error=None,
+        warnings=warnings or [],
+    )
+
+
+def _prepared_inputs(yaml_text: str, inputs: dict[str, object]):
+    return _prepare_run_inputs_from_schema(
+        WORKFLOW_ID,
+        _workflow_input_schema_from_yaml(WORKFLOW_ID, yaml_text),
+        inputs,
+    )
+
+
+def _field(result: Any, name: str) -> Any:
+    if isinstance(result, dict):
+        return result.get(name)
+    return getattr(result, name)
+
+
+def _value(value: Any) -> Any:
+    return getattr(value, "value", value)
+
+
+def _assert_failure_result(result: Any, *, code: str, run_id: str | None = None) -> None:
+    assert _field(result, "accepted") is False
+    assert _value(_field(result, "failure_code")) == code
+    assert _field(result, "run_id") == run_id
+
+
+def _direct_api_invocation(**overrides: Any):
+    _, WorkflowRunInvocation = _invoker_contract()
+    payload = {
+        "workflow_id": WORKFLOW_ID,
+        "inputs": {"query": "from api"},
+        "source_correlation_id": "corr-run-931",
+        "source_metadata": {
+            "entry_path": "direct_api",
+            "request_path": f"/api/workflows/{WORKFLOW_ID}/invocations",
+            "client_request_id": "req-run-931",
+        },
+    }
+    payload.update(overrides)
+    return WorkflowRunInvocation.direct_api(**payload)
+
+
+@dataclass(frozen=True)
+class _AdmissionDecision:
+    allowed: bool
+    failure_code: str | None = None
+    reason: str | None = None
+
+
+class _RuntimeAdmission:
+    def __init__(self, *, enabled: bool = True, saturated: bool = False) -> None:
+        self.enabled = enabled
+        self.saturated = saturated
+        self.calls: list[Any] = []
+
+    def check_external_invocation(self, invocation: Any) -> _AdmissionDecision:
+        self.calls.append(invocation)
+        if not self.enabled:
+            return _AdmissionDecision(False, "runtime_unavailable", "External invocation disabled")
+        if self.saturated:
+            return _AdmissionDecision(False, "admission_saturated", "Runtime admission saturated")
+        return _AdmissionDecision(True)
+
+    def check(self, invocation: Any) -> _AdmissionDecision:
+        return self.check_external_invocation(invocation)
+
+    def admit(self, invocation: Any) -> _AdmissionDecision:
+        return self.check_external_invocation(invocation)
+
+
+class _NoCallExecutionService:
+    def __init__(self) -> None:
+        self.prepare_calls: list[Any] = []
+        self.launch_calls: list[Any] = []
+
+    def prepare_run_inputs(self, *args: Any, **kwargs: Any) -> None:
+        self.prepare_calls.append((args, kwargs))
+        raise AssertionError("pre-run admission failure must not validate inputs")
+
+    async def launch_execution(self, *args: Any, **kwargs: Any) -> None:
+        self.launch_calls.append((args, kwargs))
+        raise AssertionError("pre-run admission failure must not launch execution")
+
+
+class _RecordingExecutionService:
+    def __init__(
+        self,
+        *,
+        prepared: Any | None = None,
+        prepare_error: Exception | None = None,
+        launch_error: Exception | None = None,
+        committed_workflow: WorkflowEntity | None = None,
+        commit_sha: str = COMMITTED_MAIN_SHA,
+        run_service: Any | None = None,
+    ) -> None:
+        self.prepared = prepared
+        self.prepare_error = prepare_error
+        self.launch_error = launch_error
+        self.committed_workflow = committed_workflow
+        self.commit_sha = commit_sha
+        self.run_service = run_service
+        self.prepare_calls: list[dict[str, Any]] = []
+        self.launch_calls: list[dict[str, Any]] = []
+        self.snapshot_calls: list[dict[str, Any]] = []
+
+    def prepare_run_inputs(self, workflow_id: str, inputs: dict[str, Any], *, branch: str | None):
+        self.prepare_calls.append({"workflow_id": workflow_id, "inputs": inputs, "branch": branch})
+        if self.prepare_error is not None:
+            raise self.prepare_error
+        return self.prepared
+
+    def workflow_snapshot_for_run(self, workflow_id: str, *, branch: str) -> WorkflowEntity:
+        self.snapshot_calls.append({"workflow_id": workflow_id, "branch": branch})
+        if self.committed_workflow is None:
+            raise WorkflowNotFound(f"Workflow {workflow_id!r} not found on {branch!r}")
+        return self.committed_workflow
+
+    async def launch_execution(
+        self,
+        run_id: str,
+        workflow_id: str,
+        inputs: Any,
+        branch: str | None = None,
+    ) -> None:
+        self.launch_calls.append(
+            {
+                "run_id": run_id,
+                "workflow_id": workflow_id,
+                "inputs": inputs,
+                "branch": branch,
+            }
+        )
+        if self.launch_error is not None:
+            raise self.launch_error
+        if self.run_service is not None:
+            run = self.run_service.get_run(run_id)
+            run.commit_sha = self.commit_sha
+            self.run_service.run_repo.update_run(run)
+
+
+class _RecordingRunService:
+    def __init__(self) -> None:
+        self.create_calls: list[dict[str, Any]] = []
+        self.fail_calls: list[dict[str, Any]] = []
+        self.created_run: Any | None = None
+
+    def create_run(
+        self,
+        workflow_id: str,
+        inputs: Any,
+        *,
+        branch: str,
+        source: str,
+        source_correlation_id: str | None = None,
+        source_metadata: dict[str, Any] | None = None,
+        workflow_snapshot: WorkflowEntity | None = None,
+    ):
+        self.create_calls.append(
+            {
+                "workflow_id": workflow_id,
+                "inputs": inputs,
+                "branch": branch,
+                "source": source,
+                "source_correlation_id": source_correlation_id,
+                "source_metadata": source_metadata,
+                "workflow_snapshot": workflow_snapshot,
+            }
+        )
+        self.created_run = Mock()
+        self.created_run.id = "run_run931_created"
+        self.created_run.workflow_id = workflow_id
+        self.created_run.workflow_name = (
+            workflow_snapshot.name if workflow_snapshot is not None else workflow_id
+        )
+        self.created_run.status = RunStatus.pending
+        self.created_run.branch = branch
+        self.created_run.source = source
+        self.created_run.commit_sha = None
+        self.created_run.source_correlation_id = source_correlation_id
+        self.created_run.source_metadata = source_metadata or {}
+        return self.created_run
+
+    def get_run(self, run_id: str):
+        assert self.created_run is not None
+        assert self.created_run.id == run_id
+        return self.created_run
+
+    def refresh_run(self, run: Any):
+        return run
+
+    def fail_run(self, run_id: str, error: str):
+        self.fail_calls.append({"run_id": run_id, "error": error})
+        assert self.created_run is not None
+        self.created_run.status = RunStatus.failed
+        self.created_run.error = error
+        return self.created_run
+
+
+class TestWorkflowRunInvocationDirectApiContract:
+    def test_direct_api_factory_owns_api_source_and_saved_main_policy(self) -> None:
+        invocation = _direct_api_invocation()
+
+        assert invocation.workflow_id == WORKFLOW_ID
+        assert _value(invocation.caller) == "api"
+        assert _value(invocation.source) == "api"
+        assert invocation.inputs == {"query": "from api"}
+        assert invocation.source_correlation_id == "corr-run-931"
+        assert invocation.source_metadata["entry_path"] == "direct_api"
+        assert _value(getattr(invocation, "branch", "main")) == "main"
+        assert getattr(invocation, "commit_sha", None) is None
+
+    @pytest.mark.parametrize(
+        "privileged_fields",
+        [
+            {"caller": "manual"},
+            {"source": "manual"},
+            {"branch": "feature/dirty"},
+            {"commit_sha": "caller-selected-sha"},
+            {"debug": True},
+            {"simulation": True},
+            {"idempotency_key": "deferred-by-run-85"},
+            {"trigger_id": "trigger-931"},
+            {"delivery_id": "delivery-931"},
+            {"source_metadata": {"idempotency_key": "deferred-by-run-85"}},
+        ],
+    )
+    def test_direct_api_factory_rejects_external_privileged_fields(
+        self, privileged_fields: dict[str, object]
+    ) -> None:
+        _, WorkflowRunInvocation = _invoker_contract()
+
+        with pytest.raises((TypeError, ValueError)):
+            WorkflowRunInvocation.direct_api(
+                workflow_id=WORKFLOW_ID,
+                inputs={"query": "from api"},
+                **privileged_fields,
+            )
+
+
+class TestWorkflowRunInvokerPreRunFailures:
+    @pytest.mark.asyncio
+    async def test_runtime_disabled_returns_typed_result_before_validation_or_run_creation(
+        self,
+    ) -> None:
+        WorkflowRunInvoker, _ = _invoker_contract()
+        execution = _NoCallExecutionService()
+        run_service = _RecordingRunService()
+        admission = _RuntimeAdmission(enabled=False)
+        invoker = WorkflowRunInvoker(
+            run_service=run_service,
+            execution_service=execution,
+            runtime_admission=admission,
+        )
+
+        result = await invoker.invoke(_direct_api_invocation())
+
+        _assert_failure_result(result, code="runtime_unavailable")
+        assert admission.calls
+        assert execution.prepare_calls == []
+        assert execution.launch_calls == []
+        assert run_service.create_calls == []
+
+    @pytest.mark.asyncio
+    async def test_admission_saturated_returns_typed_result_before_run_creation(self) -> None:
+        WorkflowRunInvoker, _ = _invoker_contract()
+        execution = _NoCallExecutionService()
+        run_service = _RecordingRunService()
+        admission = _RuntimeAdmission(saturated=True)
+        invoker = WorkflowRunInvoker(
+            run_service=run_service,
+            execution_service=execution,
+            runtime_admission=admission,
+        )
+
+        result = await invoker.invoke(_direct_api_invocation())
+
+        _assert_failure_result(result, code="admission_saturated")
+        assert admission.calls
+        assert execution.prepare_calls == []
+        assert execution.launch_calls == []
+        assert run_service.create_calls == []
+
+    @pytest.mark.asyncio
+    async def test_canonical_input_validation_failure_returns_typed_result_without_run(
+        self,
+    ) -> None:
+        WorkflowRunInvoker, _ = _invoker_contract()
+        validation_error = InputValidationError(
+            "Workflow input validation failed",
+            error_code="WORKFLOW_INPUT_VALIDATION_ERROR",
+            status_code=422,
+            details={
+                "kind": "workflow_input_validation",
+                "workflow_id": WORKFLOW_ID,
+                "fields": [{"field": "query", "code": "required"}],
+            },
+        )
+        execution = _RecordingExecutionService(prepare_error=validation_error)
+        run_service = _RecordingRunService()
+        invoker = WorkflowRunInvoker(
+            run_service=run_service,
+            execution_service=execution,
+            runtime_admission=_RuntimeAdmission(),
+        )
+
+        result = await invoker.invoke(_direct_api_invocation(inputs={}))
+
+        _assert_failure_result(result, code="workflow_input_validation_failed")
+        assert execution.prepare_calls == [
+            {"workflow_id": WORKFLOW_ID, "inputs": {}, "branch": "main"}
+        ]
+        assert execution.launch_calls == []
+        assert run_service.create_calls == []
+        assert _field(result, "details") == validation_error.to_dict()
+
+    @pytest.mark.asyncio
+    async def test_workflow_missing_on_main_returns_typed_result_without_run(self) -> None:
+        WorkflowRunInvoker, _ = _invoker_contract()
+        missing_error = WorkflowNotFound(f"Workflow {WORKFLOW_ID!r} not found on main")
+        execution = _RecordingExecutionService(prepare_error=missing_error)
+        run_service = _RecordingRunService()
+        invoker = WorkflowRunInvoker(
+            run_service=run_service,
+            execution_service=execution,
+            runtime_admission=_RuntimeAdmission(),
+        )
+
+        result = await invoker.invoke(_direct_api_invocation())
+
+        _assert_failure_result(result, code="workflow_not_found")
+        assert execution.prepare_calls == [
+            {"workflow_id": WORKFLOW_ID, "inputs": {"query": "from api"}, "branch": "main"}
+        ]
+        assert execution.launch_calls == []
+        assert run_service.create_calls == []
+
+
+class TestWorkflowRunInvokerDirectApiLaunch:
+    @pytest.mark.asyncio
+    async def test_success_creates_api_run_with_provenance_and_launches_saved_main(
+        self,
+    ) -> None:
+        WorkflowRunInvoker, _ = _invoker_contract()
+        main_yaml = _main_workflow_yaml()
+        committed_workflow = _workflow_entity(
+            main_yaml,
+            name="Committed Main Workflow",
+            warnings=[{"code": "main-warning", "message": "from committed main"}],
+        )
+        prepared = _prepared_inputs(main_yaml, {"query": "from api"})
+        run_service = _RecordingRunService()
+        execution = _RecordingExecutionService(
+            prepared=prepared,
+            committed_workflow=committed_workflow,
+            run_service=run_service,
+        )
+        invoker = WorkflowRunInvoker(
+            run_service=run_service,
+            execution_service=execution,
+            runtime_admission=_RuntimeAdmission(),
+        )
+
+        result = await invoker.invoke(_direct_api_invocation())
+
+        assert _field(result, "accepted") is True
+        assert _field(result, "run_id") == "run_run931_created"
+        assert _value(_field(result, "status")) == "pending"
+        assert _field(result, "commit_sha") == COMMITTED_MAIN_SHA
+        assert run_service.create_calls == [
+            {
+                "workflow_id": WORKFLOW_ID,
+                "inputs": prepared,
+                "branch": "main",
+                "source": "api",
+                "source_correlation_id": "corr-run-931",
+                "source_metadata": {
+                    "entry_path": "direct_api",
+                    "request_path": f"/api/workflows/{WORKFLOW_ID}/invocations",
+                    "client_request_id": "req-run-931",
+                },
+                "workflow_snapshot": committed_workflow,
+            }
+        ]
+        assert execution.prepare_calls == [
+            {
+                "workflow_id": WORKFLOW_ID,
+                "inputs": {"query": "from api"},
+                "branch": "main",
+            }
+        ]
+        assert execution.launch_calls == [
+            {
+                "run_id": "run_run931_created",
+                "workflow_id": WORKFLOW_ID,
+                "inputs": prepared,
+                "branch": "main",
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_run_metadata_schema_warnings_and_execution_use_committed_main_not_dirty_live(
+        self,
+    ) -> None:
+        WorkflowRunInvoker, _ = _invoker_contract()
+        engine = _db_engine()
+        main_yaml = _main_workflow_yaml(name="Committed Main Workflow")
+        dirty_live = _workflow_entity(
+            _dirty_workflow_yaml(),
+            name="Dirty Live Workflow",
+            warnings=[{"code": "dirty-warning", "message": "from live disk"}],
+        )
+        committed_workflow = _workflow_entity(
+            main_yaml,
+            name="Committed Main Workflow",
+            warnings=[{"code": "main-warning", "message": "from committed main"}],
+        )
+        workflow_repo = Mock()
+        workflow_repo.get_by_id.return_value = dirty_live
+        workflow_repo._get_path.return_value = f"/custom/workflows/{WORKFLOW_ID}.yaml"
+
+        with Session(engine) as session:
+            run_service = RunService(RunRepository(session), workflow_repo)
+            execution = _RecordingExecutionService(
+                prepared=_prepared_inputs(main_yaml, {"query": "from api"}),
+                committed_workflow=committed_workflow,
+                run_service=run_service,
+            )
+            invoker = WorkflowRunInvoker(
+                run_service=run_service,
+                execution_service=execution,
+                runtime_admission=_RuntimeAdmission(),
+            )
+
+            result = await invoker.invoke(_direct_api_invocation())
+
+        assert _field(result, "accepted") is True
+        assert _field(result, "commit_sha") == COMMITTED_MAIN_SHA
+        assert execution.prepare_calls[0]["branch"] == "main"
+        assert execution.launch_calls[0]["branch"] == "main"
+
+        with Session(engine) as session:
+            runs = session.exec(select(Run)).all()
+
+        assert len(runs) == 1
+        run = runs[0]
+        assert run.source == "api"
+        assert run.branch == "main"
+        assert run.commit_sha == COMMITTED_MAIN_SHA
+        assert run.source_correlation_id == "corr-run-931"
+        assert run.source_metadata == {
+            "entry_path": "direct_api",
+            "request_path": f"/api/workflows/{WORKFLOW_ID}/invocations",
+            "client_request_id": "req-run-931",
+        }
+        assert run.workflow_name == "Committed Main Workflow"
+        assert run.warnings_json == [{"code": "main-warning", "message": "from committed main"}]
+        assert run.workflow_input_schema is not None
+        assert set(run.workflow_input_schema) == {"query", "max_results"}
+        assert "debug" not in run.workflow_input_schema
+
+    @pytest.mark.asyncio
+    async def test_launch_failure_after_run_creation_returns_typed_failure_with_run_id(
+        self,
+    ) -> None:
+        WorkflowRunInvoker, _ = _invoker_contract()
+        main_yaml = _main_workflow_yaml()
+        run_service = _RecordingRunService()
+        execution = _RecordingExecutionService(
+            prepared=_prepared_inputs(main_yaml, {"query": "from api"}),
+            committed_workflow=_workflow_entity(main_yaml, name="Committed Main Workflow"),
+            launch_error=RuntimeError("snapshot graph failed"),
+            run_service=run_service,
+        )
+        invoker = WorkflowRunInvoker(
+            run_service=run_service,
+            execution_service=execution,
+            runtime_admission=_RuntimeAdmission(),
+        )
+
+        result = await invoker.invoke(_direct_api_invocation())
+
+        _assert_failure_result(
+            result,
+            code="execution_launch_failed",
+            run_id="run_run931_created",
+        )
+        assert run_service.create_calls
+        assert run_service.fail_calls == [
+            {"run_id": "run_run931_created", "error": "snapshot graph failed"}
+        ]
+        assert _value(run_service.created_run.status) == "failed"

--- a/apps/api/tests/logic/test_run931_workflow_run_invoker.py
+++ b/apps/api/tests/logic/test_run931_workflow_run_invoker.py
@@ -104,6 +104,7 @@ def _workflow_entity(
     yaml_text: str,
     *,
     name: str,
+    enabled: bool = True,
     warnings: list[dict[str, str]] | None = None,
 ) -> WorkflowEntity:
     return WorkflowEntity(
@@ -111,6 +112,7 @@ def _workflow_entity(
         id=WORKFLOW_ID,
         name=name,
         yaml=yaml_text,
+        enabled=enabled,
         valid=True,
         validation_error=None,
         warnings=warnings or [],
@@ -149,7 +151,7 @@ def _direct_api_invocation(**overrides: Any):
         "source_correlation_id": "corr-run-931",
         "source_metadata": {
             "entry_path": "direct_api",
-            "request_path": f"/api/workflows/{WORKFLOW_ID}/invocations",
+            "request_path": f"/api/workflows/{WORKFLOW_ID}/runs",
             "client_request_id": "req-run-931",
         },
     }
@@ -491,6 +493,33 @@ class TestWorkflowRunInvokerPreRunFailures:
         assert execution.launch_calls == []
         assert run_service.create_calls == []
 
+    @pytest.mark.asyncio
+    async def test_workflow_omitting_enabled_on_main_returns_not_found_without_validation(
+        self,
+    ) -> None:
+        WorkflowRunInvoker, _ = _invoker_contract()
+        omitted_enabled_workflow = WorkflowEntity(
+            kind="workflow",
+            id=WORKFLOW_ID,
+            name="Omitted Enabled Main Workflow",
+            yaml=_main_workflow_yaml(name="Omitted Enabled Main Workflow"),
+        )
+        execution = _RecordingExecutionService(committed_workflow=omitted_enabled_workflow)
+        run_service = _RecordingRunService()
+        invoker = WorkflowRunInvoker(
+            run_service=run_service,
+            execution_service=execution,
+            runtime_admission=_RuntimeAdmission(),
+        )
+
+        result = await invoker.invoke(_direct_api_invocation())
+
+        _assert_failure_result(result, code="workflow_not_found")
+        assert execution.snapshot_calls == [{"workflow_id": WORKFLOW_ID, "branch": "main"}]
+        assert execution.prepare_calls == []
+        assert execution.launch_calls == []
+        assert run_service.create_calls == []
+
 
 class TestWorkflowRunInvokerDirectApiLaunch:
     @pytest.mark.asyncio
@@ -532,7 +561,7 @@ class TestWorkflowRunInvokerDirectApiLaunch:
                 "source_correlation_id": "corr-run-931",
                 "source_metadata": {
                     "entry_path": "direct_api",
-                    "request_path": f"/api/workflows/{WORKFLOW_ID}/invocations",
+                    "request_path": f"/api/workflows/{WORKFLOW_ID}/runs",
                     "client_request_id": "req-run-931",
                 },
                 "workflow_snapshot": committed_workflow,
@@ -606,7 +635,7 @@ class TestWorkflowRunInvokerDirectApiLaunch:
         assert run.source_correlation_id == "corr-run-931"
         assert run.source_metadata == {
             "entry_path": "direct_api",
-            "request_path": f"/api/workflows/{WORKFLOW_ID}/invocations",
+            "request_path": f"/api/workflows/{WORKFLOW_ID}/runs",
             "client_request_id": "req-run-931",
         }
         assert run.workflow_name == "Committed Main Workflow"

--- a/apps/api/tests/logic/test_run944_trigger_runtime_guardrails.py
+++ b/apps/api/tests/logic/test_run944_trigger_runtime_guardrails.py
@@ -159,3 +159,60 @@ def test_external_admission_uses_shared_runtime_config_primitives() -> None:
     assert decision.allowed is False
     assert decision.failure_code == "runtime_unavailable"
     assert decision.status_code == 503
+
+
+def test_external_admission_tracks_pending_capacity_and_releases() -> None:
+    from runsight_api.logic.services.trigger_runtime import (
+        ExternalInvocationAdmission,
+        TriggerRuntimeConfig,
+    )
+
+    config = TriggerRuntimeConfig(
+        external_invocation_enabled=True,
+        max_concurrent_runs=3,
+        max_pending_external_invocations=2,
+        body_limit_bytes=1_048_576,
+        public_base_url=None,
+    )
+    admission = ExternalInvocationAdmission(config)
+
+    first = admission.acquire_external_invocation(_direct_api_invocation())
+    second = admission.acquire_external_invocation(_direct_api_invocation())
+    saturated = admission.acquire_external_invocation(_direct_api_invocation())
+
+    assert first.allowed is True
+    assert second.allowed is True
+    assert saturated.allowed is False
+    assert saturated.failure_code == "admission_saturated"
+    assert saturated.status_code == 429
+    assert admission.pending_external_invocations == 2
+
+    admission.release_external_invocation()
+
+    after_release = admission.acquire_external_invocation(_direct_api_invocation())
+    assert after_release.allowed is True
+    assert admission.pending_external_invocations == 2
+
+
+def test_external_admission_respects_concurrent_run_capacity() -> None:
+    from runsight_api.logic.services.trigger_runtime import (
+        ExternalInvocationAdmission,
+        TriggerRuntimeConfig,
+    )
+
+    config = TriggerRuntimeConfig(
+        external_invocation_enabled=True,
+        max_concurrent_runs=1,
+        max_pending_external_invocations=5,
+        body_limit_bytes=1_048_576,
+        public_base_url=None,
+    )
+    admission = ExternalInvocationAdmission(config)
+
+    admitted = admission.acquire_external_invocation(_direct_api_invocation())
+    saturated = admission.acquire_external_invocation(_direct_api_invocation())
+
+    assert admitted.allowed is True
+    assert saturated.allowed is False
+    assert saturated.failure_code == "admission_saturated"
+    assert saturated.status_code == 429

--- a/apps/api/tests/logic/test_run944_trigger_runtime_guardrails.py
+++ b/apps/api/tests/logic/test_run944_trigger_runtime_guardrails.py
@@ -1,0 +1,161 @@
+"""RED tests for RUN-944 WorkflowRunInvoker runtime guardrails."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+
+WORKFLOW_ID = "run944_runtime_guardrails"
+
+
+def _invoker_contract():
+    from runsight_api.logic.services.workflow_run_invoker import (
+        WorkflowRunInvocation,
+        WorkflowRunInvoker,
+    )
+
+    return WorkflowRunInvoker, WorkflowRunInvocation
+
+
+def _direct_api_invocation(**overrides: Any):
+    _, WorkflowRunInvocation = _invoker_contract()
+    payload = {
+        "workflow_id": WORKFLOW_ID,
+        "inputs": {"query": "from api"},
+        "source_correlation_id": "corr-run-944",
+        "source_metadata": {
+            "entry_path": "direct_api",
+            "request_path": f"/api/workflows/{WORKFLOW_ID}/runs",
+        },
+    }
+    payload.update(overrides)
+    return WorkflowRunInvocation.direct_api(**payload)
+
+
+def _value(value: Any) -> Any:
+    return getattr(value, "value", value)
+
+
+def _field(result: Any, name: str) -> Any:
+    if isinstance(result, dict):
+        return result.get(name)
+    return getattr(result, name)
+
+
+@dataclass(frozen=True)
+class _AdmissionDecision:
+    allowed: bool
+    failure_code: str | None = None
+    status_code: int | None = None
+    reason: str | None = None
+
+
+class _RuntimeAdmission:
+    def __init__(self, decision: _AdmissionDecision) -> None:
+        self.decision = decision
+        self.calls: list[Any] = []
+
+    def check_external_invocation(self, invocation: Any) -> _AdmissionDecision:
+        self.calls.append(invocation)
+        return self.decision
+
+
+class _NoCallExecutionService:
+    def resolve_workflow_run_snapshot(self, *args: Any, **kwargs: Any) -> None:
+        raise AssertionError("pre-run admission failure must not resolve workflow snapshots")
+
+    def prepare_run_inputs_from_snapshot(self, *args: Any, **kwargs: Any) -> None:
+        raise AssertionError("pre-run admission failure must not validate inputs")
+
+    async def launch_execution_from_snapshot(self, *args: Any, **kwargs: Any) -> None:
+        raise AssertionError("pre-run admission failure must not launch execution")
+
+
+class _RecordingRunService:
+    def __init__(self) -> None:
+        self.create_calls: list[Any] = []
+
+    def create_run(self, *args: Any, **kwargs: Any) -> None:
+        self.create_calls.append((args, kwargs))
+        raise AssertionError("pre-run admission failure must not create runs")
+
+
+@pytest.mark.asyncio
+async def test_runtime_disabled_returns_typed_503_before_snapshot_or_run_creation() -> None:
+    WorkflowRunInvoker, _ = _invoker_contract()
+    run_service = _RecordingRunService()
+    admission = _RuntimeAdmission(
+        _AdmissionDecision(
+            allowed=False,
+            failure_code="runtime_unavailable",
+            status_code=503,
+            reason="external invocation disabled by runtime config",
+        )
+    )
+    invoker = WorkflowRunInvoker(
+        run_service=run_service,
+        execution_service=_NoCallExecutionService(),
+        runtime_admission=admission,
+    )
+
+    result = await invoker.invoke(_direct_api_invocation())
+
+    assert _field(result, "accepted") is False
+    assert _value(_field(result, "failure_code")) == "runtime_unavailable"
+    assert _field(result, "status_code") == 503
+    assert _field(result, "details") == {"reason": "external invocation disabled by runtime config"}
+    assert admission.calls
+    assert run_service.create_calls == []
+
+
+@pytest.mark.asyncio
+async def test_admission_saturation_returns_typed_429_before_run_creation() -> None:
+    WorkflowRunInvoker, _ = _invoker_contract()
+    run_service = _RecordingRunService()
+    admission = _RuntimeAdmission(
+        _AdmissionDecision(
+            allowed=False,
+            failure_code="admission_saturated",
+            status_code=429,
+            reason="external invocation admission is saturated",
+        )
+    )
+    invoker = WorkflowRunInvoker(
+        run_service=run_service,
+        execution_service=_NoCallExecutionService(),
+        runtime_admission=admission,
+    )
+
+    result = await invoker.invoke(_direct_api_invocation())
+
+    assert _field(result, "accepted") is False
+    assert _value(_field(result, "failure_code")) == "admission_saturated"
+    assert _field(result, "status_code") == 429
+    assert _field(result, "details") == {"reason": "external invocation admission is saturated"}
+    assert admission.calls
+    assert run_service.create_calls == []
+
+
+def test_external_admission_uses_shared_runtime_config_primitives() -> None:
+    from runsight_api.logic.services.trigger_runtime import (
+        ExternalInvocationAdmission,
+        TriggerRuntimeConfig,
+    )
+
+    config = TriggerRuntimeConfig(
+        external_invocation_enabled=False,
+        max_concurrent_runs=1,
+        max_pending_external_invocations=1,
+        body_limit_bytes=1_048_576,
+        public_base_url=None,
+    )
+    admission = ExternalInvocationAdmission(config)
+
+    decision = admission.check_external_invocation(_direct_api_invocation())
+
+    assert decision.allowed is False
+    assert decision.failure_code == "runtime_unavailable"
+    assert decision.status_code == 503

--- a/apps/api/tests/logic/test_run944_trigger_runtime_guardrails.py
+++ b/apps/api/tests/logic/test_run944_trigger_runtime_guardrails.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
+
+from runsight_api.domain.entities.run import RunStatus
 
 
 WORKFLOW_ID = "run944_runtime_guardrails"
@@ -81,6 +85,122 @@ class _RecordingRunService:
     def create_run(self, *args: Any, **kwargs: Any) -> None:
         self.create_calls.append((args, kwargs))
         raise AssertionError("pre-run admission failure must not create runs")
+
+
+@dataclass(frozen=True)
+class _ResolvedWorkflowSnapshot:
+    workflow_id: str
+    branch: str
+    workflow: Any
+    commit_sha: str = "9449449449449449449449449449449449449449"
+
+
+class _SlotRunService:
+    def __init__(self) -> None:
+        self.created_runs: dict[str, Any] = {}
+        self.create_calls: list[dict[str, Any]] = []
+        self.fail_calls: list[dict[str, Any]] = []
+
+    def create_run(
+        self,
+        workflow_id: str,
+        inputs: Any,
+        *,
+        branch: str,
+        source: str,
+        source_correlation_id: str | None = None,
+        source_metadata: dict[str, Any] | None = None,
+        workflow_snapshot: Any | None = None,
+    ) -> Any:
+        run_id = f"run_slot_{len(self.created_runs) + 1}"
+        self.create_calls.append(
+            {
+                "workflow_id": workflow_id,
+                "inputs": inputs,
+                "branch": branch,
+                "source": source,
+                "source_correlation_id": source_correlation_id,
+                "source_metadata": source_metadata,
+                "workflow_snapshot": workflow_snapshot,
+            }
+        )
+        run = SimpleNamespace(
+            id=run_id,
+            workflow_id=workflow_id,
+            status=RunStatus.pending,
+            commit_sha=None,
+        )
+        self.created_runs[run_id] = run
+        return run
+
+    def get_run(self, run_id: str) -> Any | None:
+        return self.created_runs.get(run_id)
+
+    def fail_run(self, run_id: str, error: str) -> Any:
+        self.fail_calls.append({"run_id": run_id, "error": error})
+        run = self.created_runs[run_id]
+        run.status = RunStatus.failed
+        run.error = error
+        return run
+
+
+class _SlotHoldingExecutionService:
+    def __init__(
+        self,
+        *,
+        entered_launch: asyncio.Event | None = None,
+        release_launch: asyncio.Event | None = None,
+        launch_error: Exception | None = None,
+    ) -> None:
+        self.entered_launch = entered_launch
+        self.release_launch = release_launch
+        self.launch_error = launch_error
+        self.resolve_calls: list[dict[str, Any]] = []
+        self.prepare_calls: list[dict[str, Any]] = []
+        self.launch_calls: list[dict[str, Any]] = []
+
+    def resolve_workflow_run_snapshot(
+        self, workflow_id: str, *, branch: str
+    ) -> _ResolvedWorkflowSnapshot:
+        self.resolve_calls.append({"workflow_id": workflow_id, "branch": branch})
+        return _ResolvedWorkflowSnapshot(
+            workflow_id=workflow_id,
+            branch=branch,
+            workflow=SimpleNamespace(name="Committed Main Workflow"),
+        )
+
+    def prepare_run_inputs_from_snapshot(
+        self,
+        snapshot: _ResolvedWorkflowSnapshot,
+        inputs: dict[str, Any],
+    ) -> dict[str, Any]:
+        self.prepare_calls.append(
+            {"workflow_id": snapshot.workflow_id, "branch": snapshot.branch, "inputs": inputs}
+        )
+        return {"normalized_inputs": dict(inputs)}
+
+    async def launch_execution_from_snapshot(
+        self,
+        run_id: str,
+        workflow_id: str,
+        inputs: Any,
+        *,
+        snapshot: _ResolvedWorkflowSnapshot,
+    ) -> None:
+        self.launch_calls.append(
+            {
+                "run_id": run_id,
+                "workflow_id": workflow_id,
+                "inputs": inputs,
+                "branch": snapshot.branch,
+            }
+        )
+        if self.entered_launch is not None:
+            self.entered_launch.set()
+        if self.release_launch is not None:
+            await self.release_launch.wait()
+        if self.launch_error is not None:
+            raise self.launch_error
 
 
 @pytest.mark.asyncio
@@ -216,3 +336,87 @@ def test_external_admission_respects_concurrent_run_capacity() -> None:
     assert saturated.allowed is False
     assert saturated.failure_code == "admission_saturated"
     assert saturated.status_code == 429
+
+
+@pytest.mark.asyncio
+async def test_invoker_uses_external_invocation_slot_for_capacity_and_release() -> None:
+    from runsight_api.logic.services.trigger_runtime import (
+        ExternalInvocationAdmission,
+        TriggerRuntimeConfig,
+    )
+
+    WorkflowRunInvoker, _ = _invoker_contract()
+    config = TriggerRuntimeConfig(
+        external_invocation_enabled=True,
+        max_concurrent_runs=1,
+        max_pending_external_invocations=1,
+        body_limit_bytes=1_048_576,
+        public_base_url=None,
+    )
+    admission = ExternalInvocationAdmission(config)
+    run_service = _SlotRunService()
+    entered_launch = asyncio.Event()
+    release_launch = asyncio.Event()
+    invoker = WorkflowRunInvoker(
+        run_service=run_service,
+        execution_service=_SlotHoldingExecutionService(
+            entered_launch=entered_launch,
+            release_launch=release_launch,
+        ),
+        runtime_admission=admission,
+    )
+
+    first_task = asyncio.create_task(invoker.invoke(_direct_api_invocation()))
+    await asyncio.wait_for(entered_launch.wait(), timeout=1)
+
+    assert admission.pending_external_invocations == 1
+
+    saturated = await invoker.invoke(_direct_api_invocation())
+
+    assert _field(saturated, "accepted") is False
+    assert _value(_field(saturated, "failure_code")) == "admission_saturated"
+    assert _field(saturated, "status_code") == 429
+    assert admission.pending_external_invocations == 1
+    assert len(run_service.create_calls) == 1
+
+    release_launch.set()
+    first = await asyncio.wait_for(first_task, timeout=1)
+
+    assert _field(first, "accepted") is True
+    assert admission.pending_external_invocations == 0
+
+    after_release = await invoker.invoke(_direct_api_invocation())
+
+    assert _field(after_release, "accepted") is True
+    assert admission.pending_external_invocations == 0
+
+
+@pytest.mark.asyncio
+async def test_invoker_releases_external_invocation_slot_after_launch_exception() -> None:
+    from runsight_api.logic.services.trigger_runtime import (
+        ExternalInvocationAdmission,
+        TriggerRuntimeConfig,
+    )
+
+    WorkflowRunInvoker, _ = _invoker_contract()
+    config = TriggerRuntimeConfig(
+        external_invocation_enabled=True,
+        max_concurrent_runs=1,
+        max_pending_external_invocations=1,
+        body_limit_bytes=1_048_576,
+        public_base_url=None,
+    )
+    admission = ExternalInvocationAdmission(config)
+    invoker = WorkflowRunInvoker(
+        run_service=_SlotRunService(),
+        execution_service=_SlotHoldingExecutionService(
+            launch_error=RuntimeError("snapshot launch failed")
+        ),
+        runtime_admission=admission,
+    )
+
+    result = await invoker.invoke(_direct_api_invocation())
+
+    assert _field(result, "accepted") is False
+    assert _value(_field(result, "failure_code")) == "execution_launch_failed"
+    assert admission.pending_external_invocations == 0

--- a/apps/api/tests/logic/test_run944_trigger_runtime_guardrails.py
+++ b/apps/api/tests/logic/test_run944_trigger_runtime_guardrails.py
@@ -186,7 +186,7 @@ class _SlotHoldingExecutionService:
         inputs: Any,
         *,
         snapshot: _ResolvedWorkflowSnapshot,
-    ) -> None:
+    ) -> asyncio.Task[None]:
         self.launch_calls.append(
             {
                 "run_id": run_id,
@@ -201,6 +201,42 @@ class _SlotHoldingExecutionService:
             await self.release_launch.wait()
         if self.launch_error is not None:
             raise self.launch_error
+
+
+class _SchedulingExecutionService(_SlotHoldingExecutionService):
+    def __init__(self) -> None:
+        super().__init__()
+        self.background_started = asyncio.Event()
+        self.background_release = asyncio.Event()
+        self.background_done = asyncio.Event()
+        self.background_tasks: list[asyncio.Task[None]] = []
+
+    async def launch_execution_from_snapshot(
+        self,
+        run_id: str,
+        workflow_id: str,
+        inputs: Any,
+        *,
+        snapshot: _ResolvedWorkflowSnapshot,
+    ) -> None:
+        self.launch_calls.append(
+            {
+                "run_id": run_id,
+                "workflow_id": workflow_id,
+                "inputs": inputs,
+                "branch": snapshot.branch,
+            }
+        )
+        task = asyncio.create_task(self._run_background())
+        self.background_tasks.append(task)
+        return task
+
+    async def _run_background(self) -> None:
+        self.background_started.set()
+        try:
+            await self.background_release.wait()
+        finally:
+            self.background_done.set()
 
 
 @pytest.mark.asyncio
@@ -420,3 +456,53 @@ async def test_invoker_releases_external_invocation_slot_after_launch_exception(
     assert _field(result, "accepted") is False
     assert _value(_field(result, "failure_code")) == "execution_launch_failed"
     assert admission.pending_external_invocations == 0
+
+
+@pytest.mark.asyncio
+async def test_invoker_holds_external_invocation_slot_until_scheduled_execution_finishes() -> None:
+    from runsight_api.logic.services.trigger_runtime import (
+        ExternalInvocationAdmission,
+        TriggerRuntimeConfig,
+    )
+
+    WorkflowRunInvoker, _ = _invoker_contract()
+    admission = ExternalInvocationAdmission(
+        TriggerRuntimeConfig(
+            external_invocation_enabled=True,
+            max_concurrent_runs=1,
+            max_pending_external_invocations=1,
+            body_limit_bytes=1_048_576,
+            public_base_url=None,
+        )
+    )
+    execution = _SchedulingExecutionService()
+    run_service = _SlotRunService()
+    invoker = WorkflowRunInvoker(
+        run_service=run_service,
+        execution_service=execution,
+        runtime_admission=admission,
+    )
+
+    first_task = asyncio.create_task(invoker.invoke(_direct_api_invocation()))
+    await asyncio.wait_for(execution.background_started.wait(), timeout=1)
+
+    assert admission.pending_external_invocations == 1
+
+    saturated = await invoker.invoke(_direct_api_invocation())
+
+    assert _field(saturated, "accepted") is False
+    assert _value(_field(saturated, "failure_code")) == "admission_saturated"
+    assert _field(saturated, "status_code") == 429
+    assert len(run_service.create_calls) == 1
+
+    execution.background_release.set()
+    await asyncio.wait_for(execution.background_done.wait(), timeout=1)
+    first = await asyncio.wait_for(first_task, timeout=1)
+
+    assert _field(first, "accepted") is True
+    assert admission.pending_external_invocations == 0
+
+    after_release = await invoker.invoke(_direct_api_invocation())
+
+    assert _field(after_release, "accepted") is True
+    assert len(run_service.create_calls) == 2

--- a/apps/api/tests/test_run85_docs_contracts.py
+++ b/apps/api/tests/test_run85_docs_contracts.py
@@ -8,3 +8,18 @@ def test_cli_reference_docker_override_preserves_container_host_bind() -> None:
     text = cli_reference.read_text(encoding="utf-8")
 
     assert "runsight --host 0.0.0.0 --port 3000" in text
+
+
+def test_direct_api_docs_require_committed_main_and_enabled_workflows() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    direct_api_reference = (
+        repo_root / "apps/site/src/content/docs/docs/reference/direct-api-invocation.md"
+    )
+    running_workflows = repo_root / "apps/site/src/content/docs/docs/execution/running-workflows.md"
+
+    reference_text = direct_api_reference.read_text(encoding="utf-8")
+    running_text = running_workflows.read_text(encoding="utf-8")
+
+    assert "committed `main` workflow snapshot and requires `enabled: true`" in reference_text
+    assert "Omitting `enabled` is treated the same as `enabled: false`" in reference_text
+    assert "committed on `main` and explicitly enabled with `enabled: true`" in running_text

--- a/apps/api/tests/test_run85_docs_contracts.py
+++ b/apps/api/tests/test_run85_docs_contracts.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+
+def test_cli_reference_docker_override_preserves_container_host_bind() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    cli_reference = repo_root / "apps/site/src/content/docs/docs/reference/cli-reference.md"
+
+    text = cli_reference.read_text(encoding="utf-8")
+
+    assert "runsight --host 0.0.0.0 --port 3000" in text

--- a/apps/api/tests/test_run941_direct_api_integration.py
+++ b/apps/api/tests/test_run941_direct_api_integration.py
@@ -1,0 +1,728 @@
+"""Integration coverage for RUN-941 Direct API workflow invocation.
+
+The versioned asset graph coverage here uses the stable no-network runtime path
+currently available to backend integration tests: committed workflow YAML plus a
+referenced committed child workflow. Provider/soul/custom-tool metadata snapshot
+coverage still needs a stable Direct API fixture that exercises those runtime
+assets without crossing into external model/provider calls.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.exceptions import RequestValidationError
+from sqlalchemy.pool import StaticPool
+from sqlmodel import Session, SQLModel, create_engine, select
+
+from runsight_api.domain.entities.run import Run, RunNode, RunStatus
+
+
+WORKFLOW_ID = "run941-direct"
+PARENT_WORKFLOW_ID = "run941-parent"
+CHILD_WORKFLOW_ID = "run941-child"
+SECRET = "run941-secret-plain-text-must-never-echo"
+IDEMPOTENCY_SECRET = "run941-idempotency-key-not-a-contract"
+DIRTY_MARKER = "run941-dirty-working-tree-marker"
+
+
+DIRECT_WORKFLOW_YAML = """\
+id: run941-direct
+kind: workflow
+version: "1.0"
+inputs:
+  query:
+    type: string
+  api_token:
+    type: string
+    sensitive: true
+  limit:
+    type: number
+    required: false
+    default: 7
+config: {}
+blocks:
+  echo:
+    type: code
+    timeout_seconds: 5
+    inputs:
+      query:
+        from: workflow.query
+      limit:
+        from: workflow.limit
+      token:
+        from: workflow.api_token
+    code: |
+      def main(data):
+          return {
+              "query": data["query"],
+              "limit": data["limit"],
+              "token_echo": data["token"],
+              "asset_marker": "committed-direct",
+          }
+workflow:
+  name: Run941 Committed Direct
+  entry: echo
+  transitions:
+    - from: echo
+      to: null
+"""
+
+
+DIRTY_DIRECT_WORKFLOW_YAML = f"""\
+id: run941-direct
+kind: workflow
+version: "1.0"
+inputs:
+  query:
+    type: number
+  dirty_required:
+    type: string
+config: {{}}
+blocks:
+  echo:
+    type: code
+    code: |
+      def main(data):
+          return {{"asset_marker": "{DIRTY_MARKER}"}}
+workflow:
+  name: Run941 Dirty Direct
+  entry: echo
+  transitions:
+    - from: echo
+      to: null
+"""
+
+
+PARENT_WORKFLOW_YAML = """\
+id: run941-parent
+kind: workflow
+version: "1.0"
+inputs:
+  query:
+    type: string
+  api_token:
+    type: string
+    sensitive: true
+config: {}
+blocks:
+  invoke_child:
+    type: workflow
+    workflow_ref: run941-child
+    inputs:
+      child_query: workflow.query
+      child_token: workflow.api_token
+workflow:
+  name: Run941 Committed Parent
+  entry: invoke_child
+  transitions:
+    - from: invoke_child
+      to: null
+"""
+
+
+CHILD_WORKFLOW_YAML = """\
+id: run941-child
+kind: workflow
+version: "1.0"
+inputs:
+  child_query:
+    type: string
+  child_token:
+    type: string
+    sensitive: true
+config: {}
+blocks:
+  child_echo:
+    type: code
+    timeout_seconds: 5
+    inputs:
+      query:
+        from: workflow.child_query
+      token:
+        from: workflow.child_token
+    code: |
+      def main(data):
+          return {
+              "child_query": data["query"],
+              "child_token_echo": data["token"],
+              "asset_marker": "committed-child",
+          }
+workflow:
+  name: Run941 Committed Child
+  entry: child_echo
+  transitions:
+    - from: child_echo
+      to: null
+"""
+
+
+DIRTY_CHILD_WORKFLOW_YAML = f"""\
+id: run941-child
+kind: workflow
+version: "1.0"
+inputs:
+  child_query:
+    type: number
+  dirty_child_only:
+    type: string
+config: {{}}
+blocks:
+  child_echo:
+    type: code
+    code: |
+      def main(data):
+          return {{"asset_marker": "{DIRTY_MARKER}"}}
+workflow:
+  name: Run941 Dirty Child
+  entry: child_echo
+  transitions:
+    - from: child_echo
+      to: null
+"""
+
+
+def _write_repo_file(repo: Path, relative_path: str, content: str) -> None:
+    path = repo / relative_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _init_git_repo(repo: Path) -> str:
+    subprocess.run(["git", "init", "-b", "main"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "tests@runsight.dev"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Runsight Tests"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "commit run941 assets"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+    return subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+@pytest.fixture
+def repo_root(tmp_path: Path) -> tuple[Path, str]:
+    repo = tmp_path / "repo"
+    _write_repo_file(repo, f"custom/workflows/{WORKFLOW_ID}.yaml", DIRECT_WORKFLOW_YAML)
+    _write_repo_file(repo, f"custom/workflows/{PARENT_WORKFLOW_ID}.yaml", PARENT_WORKFLOW_YAML)
+    _write_repo_file(repo, f"custom/workflows/{CHILD_WORKFLOW_ID}.yaml", CHILD_WORKFLOW_YAML)
+    committed_sha = _init_git_repo(repo)
+    return repo, committed_sha
+
+
+@pytest.fixture
+def db_engine():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SQLModel.metadata.create_all(engine)
+    yield engine
+    SQLModel.metadata.drop_all(engine)
+    engine.dispose()
+
+
+@pytest.fixture
+def direct_api_app(db_engine, repo_root: tuple[Path, str]):
+    from runsight_api.core.secrets import SecretsEnvLoader
+    from runsight_api.data.filesystem.provider_repo import FileSystemProviderRepo
+    from runsight_api.data.filesystem.workflow_repo import WorkflowRepository
+    from runsight_api.data.repositories.run_read_model import RunReadModel
+    from runsight_api.data.repositories.run_repo import RunRepository
+    from runsight_api.domain.errors import RunsightError
+    from runsight_api.logic.services.eval_service import EvalService
+    from runsight_api.logic.services.execution_service import ExecutionService
+    from runsight_api.logic.services.git_service import GitService
+    from runsight_api.logic.services.run_service import RunService
+    from runsight_api.logic.services.trigger_runtime import (
+        ExternalInvocationAdmission,
+        TriggerRuntimeConfig,
+    )
+    from runsight_api.transport.deps import (
+        get_eval_service,
+        get_execution_service,
+        get_external_invocation_admission,
+        get_run_service,
+    )
+    from runsight_api.transport.middleware.body_limit import BodySizeLimitMiddleware
+    from runsight_api.transport.middleware.error_handler import (
+        global_exception_handler,
+        request_validation_exception_handler,
+    )
+    from runsight_api.transport.routers import runs, workflows
+
+    repo, _ = repo_root
+    app = FastAPI()
+    app.add_middleware(BodySizeLimitMiddleware, max_body_bytes=768)
+    app.add_exception_handler(RunsightError, global_exception_handler)
+    app.add_exception_handler(RequestValidationError, request_validation_exception_handler)
+    app.add_exception_handler(Exception, global_exception_handler)
+    app.include_router(runs.router, prefix="/api")
+    app.include_router(workflows.router, prefix="/api")
+
+    workflow_repo = WorkflowRepository(str(repo))
+    execution_session = Session(db_engine)
+    execution_service = ExecutionService(
+        run_repo=RunRepository(execution_session),
+        workflow_repo=workflow_repo,
+        provider_repo=FileSystemProviderRepo(base_path=str(repo)),
+        engine=db_engine,
+        secrets=SecretsEnvLoader(base_path=str(repo)),
+        git_service=GitService(repo),
+    )
+    admission = ExternalInvocationAdmission(
+        TriggerRuntimeConfig(
+            external_invocation_enabled=True,
+            max_concurrent_runs=5,
+            max_pending_external_invocations=5,
+            body_limit_bytes=768,
+            public_base_url=None,
+        )
+    )
+    app.state.execution_service = execution_service
+    app.state.external_invocation_admission = admission
+
+    def _run_service() -> RunService:
+        session = Session(db_engine)
+        return RunService(
+            RunRepository(session),
+            workflow_repo,
+            run_read_model=RunReadModel(session),
+        )
+
+    def _eval_service() -> EvalService:
+        session = Session(db_engine)
+        return EvalService(RunRepository(session), run_read_model=RunReadModel(session))
+
+    app.dependency_overrides[get_run_service] = _run_service
+    app.dependency_overrides[get_execution_service] = lambda: execution_service
+    app.dependency_overrides[get_external_invocation_admission] = lambda: admission
+    app.dependency_overrides[get_eval_service] = _eval_service
+
+    yield app
+
+    app.dependency_overrides.clear()
+    execution_session.close()
+
+
+async def _wait_for_terminal(engine, run_id: str, timeout: float = 5.0) -> Run:
+    terminal = {RunStatus.completed, RunStatus.failed, RunStatus.cancelled}
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        with Session(engine) as session:
+            run = session.get(Run, run_id)
+            if run is not None and run.status in terminal:
+                return run
+        await asyncio.sleep(0.05)
+
+    with Session(engine) as session:
+        run = session.get(Run, run_id)
+    assert run is not None, f"Run {run_id} was not created"
+    return run
+
+
+def _all_runs(engine) -> list[Run]:
+    with Session(engine) as session:
+        return list(session.exec(select(Run).order_by(Run.created_at)).all())
+
+
+def _assert_secret_absent(label: str, value: Any) -> None:
+    rendered = value if isinstance(value, str) else json.dumps(value, default=str, sort_keys=True)
+    assert SECRET not in rendered, f"{label} leaked Direct API secret: {rendered}"
+    assert IDEMPOTENCY_SECRET not in rendered, f"{label} leaked idempotency header: {rendered}"
+
+
+def _assert_sensitive_snapshot(snapshot: dict[str, Any], field: str) -> None:
+    assert snapshot[field]["sensitive"] is True
+    assert snapshot[field]["source"] == "provided"
+    assert "value" not in snapshot[field]
+    assert "redacted" not in snapshot[field]
+
+
+def _assert_schema_field(
+    schema: dict[str, Any],
+    field: str,
+    *,
+    field_type: str,
+    required: bool,
+    sensitive: bool,
+    default: Any = None,
+) -> None:
+    assert schema[field]["type"] == field_type
+    assert schema[field]["required"] is required
+    assert schema[field]["sensitive"] is sensitive
+    if default is not None:
+        assert schema[field]["default"] == default
+
+
+@pytest.mark.asyncio
+async def test_direct_api_uses_committed_main_for_validation_metadata_and_dirty_asset_graph(
+    direct_api_app,
+    db_engine,
+    repo_root: tuple[Path, str],
+) -> None:
+    from httpx import ASGITransport, AsyncClient
+
+    repo, committed_sha = repo_root
+    _write_repo_file(repo, f"custom/workflows/{WORKFLOW_ID}.yaml", DIRTY_DIRECT_WORKFLOW_YAML)
+    _write_repo_file(repo, f"custom/workflows/{CHILD_WORKFLOW_ID}.yaml", DIRTY_CHILD_WORKFLOW_YAML)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=direct_api_app),
+        base_url="http://test",
+    ) as client:
+        create = await client.post(
+            f"/api/workflows/{WORKFLOW_ID}/runs",
+            json={"inputs": {"query": "committed query", "api_token": SECRET}},
+            headers={
+                "x-request-id": "corr-run-941",
+                "x-idempotency-key": IDEMPOTENCY_SECRET,
+            },
+        )
+        assert create.status_code == 200, create.text
+        create_payload = create.json()
+        run = await _wait_for_terminal(db_engine, create_payload["id"])
+        detail = await client.get(f"/api/runs/{run.id}")
+        listing = await client.get("/api/runs", params={"source": "api"})
+
+    assert run.status == RunStatus.completed
+    assert run.source == "api"
+    assert run.branch == "main"
+    assert run.commit_sha == committed_sha
+    assert run.workflow_name == "Run941 Committed Direct"
+    assert run.source_correlation_id == "corr-run-941"
+    assert run.source_metadata == {
+        "entry_path": "direct_api",
+        "request_path": f"/api/workflows/{WORKFLOW_ID}/runs",
+    }
+    assert run.workflow_input_schema is not None
+    assert set(run.workflow_input_schema) == {"query", "api_token", "limit"}
+    assert "dirty_required" not in run.workflow_input_schema
+    _assert_schema_field(
+        run.workflow_input_schema,
+        "query",
+        field_type="string",
+        required=True,
+        sensitive=False,
+    )
+    _assert_schema_field(
+        run.workflow_input_schema,
+        "api_token",
+        field_type="string",
+        required=True,
+        sensitive=True,
+    )
+    _assert_schema_field(
+        run.workflow_input_schema,
+        "limit",
+        field_type="number",
+        required=False,
+        sensitive=False,
+        default=7,
+    )
+    assert run.workflow_inputs is not None
+    assert run.workflow_inputs["query"]["value"] == "committed query"
+    assert run.workflow_inputs["limit"]["source"] == "defaulted"
+    _assert_sensitive_snapshot(run.workflow_inputs, "api_token")
+
+    assert detail.status_code == 200, detail.text
+    assert listing.status_code == 200, listing.text
+    listing_items = {item["id"]: item for item in listing.json()["items"]}
+    for label, payload in {
+        "accepted response": create_payload,
+        "detail response": detail.json(),
+        "list response": listing_items[run.id],
+        "database row": run.model_dump(),
+    }.items():
+        _assert_sensitive_snapshot(payload["workflow_inputs"], "api_token")
+        _assert_secret_absent(label, payload)
+        assert payload["source"] == "api"
+        assert payload["commit_sha"] == committed_sha
+        assert payload["source_metadata"]["entry_path"] == "direct_api"
+        assert "idempotency" not in json.dumps(payload["source_metadata"]).lower()
+
+    assert run.results_json is not None
+    assert "committed-direct" in run.results_json
+    assert DIRTY_MARKER not in run.results_json
+    _assert_secret_absent("run results", run.results_json)
+
+
+@pytest.mark.asyncio
+async def test_direct_api_nested_workflow_execution_uses_committed_child_snapshot(
+    direct_api_app,
+    db_engine,
+    repo_root: tuple[Path, str],
+) -> None:
+    from httpx import ASGITransport, AsyncClient
+
+    repo, committed_sha = repo_root
+    _write_repo_file(repo, f"custom/workflows/{CHILD_WORKFLOW_ID}.yaml", DIRTY_CHILD_WORKFLOW_YAML)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=direct_api_app),
+        base_url="http://test",
+    ) as client:
+        response = await client.post(
+            f"/api/workflows/{PARENT_WORKFLOW_ID}/runs",
+            json={"inputs": {"query": "child committed query", "api_token": SECRET}},
+        )
+        assert response.status_code == 200, response.text
+        parent_run_id = response.json()["id"]
+        parent_run = await _wait_for_terminal(db_engine, parent_run_id)
+
+    with Session(db_engine) as session:
+        parent_node = session.get(RunNode, f"{parent_run_id}:invoke_child")
+        assert parent_node is not None
+        assert parent_node.child_run_id is not None
+        child_run_id = parent_node.child_run_id
+
+    child_run = await _wait_for_terminal(db_engine, child_run_id)
+
+    assert parent_run.status == RunStatus.completed
+    assert parent_run.commit_sha == committed_sha
+    assert child_run.status == RunStatus.completed
+    assert child_run.workflow_id == CHILD_WORKFLOW_ID
+    assert child_run.parent_run_id == parent_run_id
+    assert child_run.workflow_name == "Run941 Committed Child"
+    assert child_run.workflow_input_schema is not None
+    assert set(child_run.workflow_input_schema) == {"child_query", "child_token"}
+    assert "dirty_child_only" not in child_run.workflow_input_schema
+    _assert_schema_field(
+        child_run.workflow_input_schema,
+        "child_query",
+        field_type="string",
+        required=True,
+        sensitive=False,
+    )
+    _assert_schema_field(
+        child_run.workflow_input_schema,
+        "child_token",
+        field_type="string",
+        required=True,
+        sensitive=True,
+    )
+    assert child_run.workflow_inputs is not None
+    assert child_run.workflow_inputs["child_query"]["value"] == "child committed query"
+    _assert_sensitive_snapshot(child_run.workflow_inputs, "child_token")
+    assert child_run.results_json is not None
+    assert "committed-child" in child_run.results_json
+    assert DIRTY_MARKER not in child_run.results_json
+    _assert_secret_absent("child run", child_run.model_dump())
+    _assert_secret_absent("child results", child_run.results_json)
+
+
+@pytest.mark.asyncio
+async def test_direct_api_rejects_privileged_body_fields_before_run_creation(
+    direct_api_app,
+    db_engine,
+) -> None:
+    from httpx import ASGITransport, AsyncClient
+
+    forbidden_fields = [
+        "source",
+        "branch",
+        "commit_sha",
+        "debug",
+        "simulation",
+        "idempotency_key",
+        "trigger",
+        "trigger_id",
+        "delivery",
+        "delivery_id",
+        "provenance",
+        "source_metadata",
+    ]
+
+    async with AsyncClient(
+        transport=ASGITransport(app=direct_api_app),
+        base_url="http://test",
+    ) as client:
+        for field in forbidden_fields:
+            response = await client.post(
+                f"/api/workflows/{WORKFLOW_ID}/runs",
+                json={"inputs": {"query": "ok", "api_token": SECRET}, field: SECRET},
+            )
+            assert response.status_code == 422, (field, response.text)
+            body = response.json()
+            assert body["error_code"] == "WORKFLOW_INPUT_VALIDATION_ERROR"
+            assert body["details"]["fields"][0]["field"] == field
+            assert body["details"]["fields"][0]["code"] == "unknown"
+            _assert_secret_absent(f"rejection for {field}", body)
+
+    assert _all_runs(db_engine) == []
+
+
+@pytest.mark.asyncio
+async def test_direct_api_canonical_input_validation_returns_422_before_run_creation(
+    direct_api_app,
+    db_engine,
+) -> None:
+    from httpx import ASGITransport, AsyncClient
+
+    async with AsyncClient(
+        transport=ASGITransport(app=direct_api_app),
+        base_url="http://test",
+    ) as client:
+        response = await client.post(
+            f"/api/workflows/{WORKFLOW_ID}/runs",
+            json={"inputs": {"query": {"not": "a string"}, "api_token": SECRET}},
+        )
+
+    assert response.status_code == 422, response.text
+    body = response.json()
+    assert body["error_code"] == "WORKFLOW_INPUT_VALIDATION_ERROR"
+    assert body["details"]["workflow_id"] == WORKFLOW_ID
+    assert body["details"]["fields"][0]["field"] == "query"
+    assert body["details"]["fields"][0]["code"] == "type_mismatch"
+    _assert_secret_absent("canonical validation response", body)
+    assert _all_runs(db_engine) == []
+
+
+@pytest.mark.asyncio
+async def test_direct_api_runtime_disabled_and_saturated_fail_before_run_creation(
+    direct_api_app,
+    db_engine,
+) -> None:
+    from httpx import ASGITransport, AsyncClient
+
+    from runsight_api.logic.services.trigger_runtime import (
+        ExternalInvocationAdmission,
+        TriggerRuntimeConfig,
+    )
+    from runsight_api.transport.deps import get_external_invocation_admission
+
+    disabled = ExternalInvocationAdmission(
+        TriggerRuntimeConfig(
+            external_invocation_enabled=False,
+            max_concurrent_runs=1,
+            max_pending_external_invocations=1,
+            body_limit_bytes=768,
+            public_base_url=None,
+        )
+    )
+    saturated = ExternalInvocationAdmission(
+        TriggerRuntimeConfig(
+            external_invocation_enabled=True,
+            max_concurrent_runs=1,
+            max_pending_external_invocations=1,
+            body_limit_bytes=768,
+            public_base_url=None,
+        ),
+        pending_external_invocations=1,
+    )
+
+    async with AsyncClient(
+        transport=ASGITransport(app=direct_api_app),
+        base_url="http://test",
+    ) as client:
+        direct_api_app.dependency_overrides[get_external_invocation_admission] = lambda: disabled
+        unavailable = await client.post(
+            f"/api/workflows/{WORKFLOW_ID}/runs",
+            json={"inputs": {"query": "ok", "api_token": SECRET}},
+        )
+        direct_api_app.dependency_overrides[get_external_invocation_admission] = lambda: saturated
+        too_many = await client.post(
+            f"/api/workflows/{WORKFLOW_ID}/runs",
+            json={"inputs": {"query": "ok", "api_token": SECRET}},
+        )
+
+    assert unavailable.status_code == 503, unavailable.text
+    assert unavailable.json()["error_code"] == "RUNTIME_UNAVAILABLE"
+    assert too_many.status_code == 429, too_many.text
+    assert too_many.json()["error_code"] == "ADMISSION_SATURATED"
+    _assert_secret_absent("runtime unavailable response", unavailable.json())
+    _assert_secret_absent("saturated response", too_many.json())
+    assert _all_runs(db_engine) == []
+
+
+@pytest.mark.asyncio
+async def test_direct_api_body_too_large_returns_413_before_route_parsing_or_storage(
+    direct_api_app,
+    db_engine,
+) -> None:
+    from httpx import ASGITransport, AsyncClient
+
+    async with AsyncClient(
+        transport=ASGITransport(app=direct_api_app),
+        base_url="http://test",
+    ) as client:
+        response = await client.post(
+            f"/api/workflows/{WORKFLOW_ID}/runs",
+            content=b'{"inputs":{"query":"' + (b"x" * 900) + b'"}}',
+            headers={"content-type": "application/json"},
+        )
+
+    assert response.status_code == 413, response.text
+    assert response.json()["error_code"] == "REQUEST_BODY_TOO_LARGE"
+    assert _all_runs(db_engine) == []
+
+
+@pytest.mark.asyncio
+async def test_direct_api_idempotency_headers_are_not_persisted_exposed_or_deduped(
+    direct_api_app,
+    db_engine,
+) -> None:
+    from httpx import ASGITransport, AsyncClient
+
+    async with AsyncClient(
+        transport=ASGITransport(app=direct_api_app),
+        base_url="http://test",
+    ) as client:
+        first = await client.post(
+            f"/api/workflows/{WORKFLOW_ID}/runs",
+            json={"inputs": {"query": "first", "api_token": SECRET}},
+            headers={"x-idempotency-key": IDEMPOTENCY_SECRET},
+        )
+        second = await client.post(
+            f"/api/workflows/{WORKFLOW_ID}/runs",
+            json={"inputs": {"query": "second", "api_token": SECRET}},
+            headers={"x-idempotency-key": IDEMPOTENCY_SECRET},
+        )
+        body_rejection = await client.post(
+            f"/api/workflows/{WORKFLOW_ID}/runs",
+            json={
+                "inputs": {"query": "third", "api_token": SECRET},
+                "idempotency_key": IDEMPOTENCY_SECRET,
+            },
+        )
+
+    assert first.status_code == 200, first.text
+    assert second.status_code == 200, second.text
+    assert first.json()["id"] != second.json()["id"]
+    assert body_rejection.status_code == 422, body_rejection.text
+
+    runs = _all_runs(db_engine)
+    assert [run.id for run in runs] == [first.json()["id"], second.json()["id"]]
+    assert "idempotency" not in Run.model_fields
+    assert "idempotency_key" not in Run.model_fields
+    for run in runs:
+        assert run.source_metadata == {
+            "entry_path": "direct_api",
+            "request_path": f"/api/workflows/{WORKFLOW_ID}/runs",
+        }
+        _assert_secret_absent("idempotency run row", run.model_dump())

--- a/apps/api/tests/test_run941_direct_api_integration.py
+++ b/apps/api/tests/test_run941_direct_api_integration.py
@@ -36,6 +36,7 @@ DIRECT_WORKFLOW_YAML = """\
 id: run941-direct
 kind: workflow
 version: "1.0"
+enabled: true
 inputs:
   query:
     type: string
@@ -104,6 +105,7 @@ PARENT_WORKFLOW_YAML = """\
 id: run941-parent
 kind: workflow
 version: "1.0"
+enabled: true
 inputs:
   query:
     type: string
@@ -131,6 +133,7 @@ CHILD_WORKFLOW_YAML = """\
 id: run941-child
 kind: workflow
 version: "1.0"
+enabled: true
 inputs:
   child_query:
     type: string

--- a/apps/api/tests/test_run944_runtime_config.py
+++ b/apps/api/tests/test_run944_runtime_config.py
@@ -90,9 +90,9 @@ def _compose_port_binding(raw_port: object) -> dict[str, object]:
 def test_docker_compose_and_runtime_defaults_preserve_loopback_port_binding() -> None:
     from runsight_api.core.config import Settings
 
-    compose_text = (Path(__file__).resolve().parents[3] / "docker-compose.yml").read_text(
-        encoding="utf-8"
-    )
+    repo_root = Path(__file__).resolve().parents[3]
+    compose_text = (repo_root / "docker-compose.yml").read_text(encoding="utf-8")
+    dockerfile_text = (repo_root / "Dockerfile").read_text(encoding="utf-8")
     compose: dict[str, Any] = yaml.safe_load(compose_text)
     ports = compose["services"]["runsight"]["ports"]
     bindings = [_compose_port_binding(port) for port in ports]
@@ -106,3 +106,4 @@ def test_docker_compose_and_runtime_defaults_preserve_loopback_port_binding() ->
     assert any(binding["host_ip"] in {"127.0.0.1", "localhost"} for binding in api_bindings)
     assert not any(binding["host_ip"] in {None, "", "0.0.0.0", "::"} for binding in api_bindings)
     assert Settings().host == "127.0.0.1"
+    assert 'CMD ["runsight", "--host", "0.0.0.0"]' in dockerfile_text

--- a/apps/api/tests/test_run944_runtime_config.py
+++ b/apps/api/tests/test_run944_runtime_config.py
@@ -1,0 +1,108 @@
+"""RED tests for RUN-944 trigger runtime exposure configuration."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+def test_settings_defaults_keep_no_auth_runtime_local_first() -> None:
+    from runsight_api.core.config import Settings
+
+    settings = Settings()
+
+    assert settings.host == "127.0.0.1"
+    assert settings.external_invocation_enabled is True
+    assert settings.public_base_url is None
+    assert settings.external_invocation_body_limit_bytes == 1_048_576
+    assert settings.max_concurrent_runs > 0
+    assert settings.max_pending_external_invocations > 0
+
+
+def test_public_base_url_is_absent_by_default_and_explicit_when_configured() -> None:
+    from runsight_api.core.config import Settings
+
+    default_settings = Settings()
+    explicit_settings = Settings(public_base_url="https://runs.example.com")
+
+    assert default_settings.public_base_url is None
+    assert str(explicit_settings.public_base_url).rstrip("/") == "https://runs.example.com"
+
+
+def test_cli_default_host_is_loopback(monkeypatch) -> None:
+    import uvicorn
+    from runsight_api import cli
+
+    captured: dict[str, object] = {}
+
+    def fake_run(app_ref: str, *, host: str, port: int) -> None:
+        captured.update({"app_ref": app_ref, "host": host, "port": port})
+
+    monkeypatch.setattr(sys, "argv", ["runsight"])
+    monkeypatch.setattr(uvicorn, "run", fake_run)
+
+    cli.main()
+
+    assert captured == {
+        "app_ref": "runsight_api.main:app",
+        "host": "127.0.0.1",
+        "port": 8000,
+    }
+
+
+def test_cli_help_documents_loopback_default(monkeypatch, capsys) -> None:
+    from runsight_api import cli
+
+    monkeypatch.setattr(sys, "argv", ["runsight", "--help"])
+
+    try:
+        cli.main()
+    except SystemExit as exc:
+        assert exc.code == 0
+
+    help_text = capsys.readouterr().out
+    assert "default: 127.0.0.1" in help_text
+    assert "default: 0.0.0.0" not in help_text
+
+
+def _compose_port_binding(raw_port: object) -> dict[str, object]:
+    if isinstance(raw_port, dict):
+        return {
+            "host_ip": raw_port.get("host_ip"),
+            "published": str(raw_port.get("published")),
+            "target": str(raw_port.get("target")),
+        }
+    if isinstance(raw_port, str):
+        parts = raw_port.split(":")
+        if len(parts) == 3:
+            host_ip, published, target = parts
+        elif len(parts) == 2:
+            host_ip, published, target = None, parts[0], parts[1]
+        else:
+            host_ip, published, target = None, None, parts[-1]
+        return {"host_ip": host_ip, "published": published, "target": target}
+    raise AssertionError(f"Unsupported Docker Compose port binding: {raw_port!r}")
+
+
+def test_docker_compose_and_runtime_defaults_preserve_loopback_port_binding() -> None:
+    from runsight_api.core.config import Settings
+
+    compose_text = (Path(__file__).resolve().parents[3] / "docker-compose.yml").read_text(
+        encoding="utf-8"
+    )
+    compose: dict[str, Any] = yaml.safe_load(compose_text)
+    ports = compose["services"]["runsight"]["ports"]
+    bindings = [_compose_port_binding(port) for port in ports]
+    api_bindings = [
+        binding
+        for binding in bindings
+        if binding["published"] == "8000" and binding["target"] == "8000"
+    ]
+
+    assert api_bindings, "runsight service must publish container port 8000 for local API use"
+    assert any(binding["host_ip"] in {"127.0.0.1", "localhost"} for binding in api_bindings)
+    assert not any(binding["host_ip"] in {None, "", "0.0.0.0", "::"} for binding in api_bindings)
+    assert Settings().host == "127.0.0.1"

--- a/apps/api/tests/transport/test_run932_direct_api_invocation_route.py
+++ b/apps/api/tests/transport/test_run932_direct_api_invocation_route.py
@@ -1,0 +1,454 @@
+"""RED tests for RUN-932 workflow-scoped Direct API invocation route."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+from fastapi.testclient import TestClient
+from runsight_core.redaction import RunRedactor
+
+from runsight_api.domain.entities.run import RunStatus
+from runsight_api.domain.errors import InputValidationError, WorkflowNotFound
+from runsight_api.logic.services.execution_service import PreparedRunInputs
+from runsight_api.main import app
+from runsight_api.transport.deps import (
+    get_execution_service,
+    get_external_invocation_admission,
+    get_run_service,
+)
+
+
+WORKFLOW_ID = "run932_direct_api"
+COMMITTED_MAIN_SHA = "932" * 13 + "9"
+SECRET_INPUT = "secret-run-932-input"
+SECRET_AUTH = "Bearer secret-run-932-auth"
+
+client = TestClient(app, raise_server_exceptions=False)
+
+
+def teardown_function() -> None:
+    app.dependency_overrides.clear()
+    app.openapi_schema = None
+
+
+@dataclass(frozen=True)
+class _AdmissionDecision:
+    allowed: bool
+    failure_code: str | None = None
+    status_code: int | None = None
+    reason: str | None = None
+
+
+@dataclass(frozen=True)
+class _ResolvedWorkflowSnapshot:
+    workflow: Any
+    branch: str = "main"
+    commit_sha: str = COMMITTED_MAIN_SHA
+
+
+class _RuntimeAdmission:
+    def __init__(self, decision: _AdmissionDecision | None = None) -> None:
+        self.decision = decision or _AdmissionDecision(allowed=True)
+        self.calls: list[Any] = []
+
+    def check_external_invocation(self, invocation: Any) -> _AdmissionDecision:
+        self.calls.append(invocation)
+        return self.decision
+
+
+class _CanonicalExecutionService:
+    def __init__(
+        self,
+        *,
+        prepare_error: Exception | None = None,
+        resolve_error: Exception | None = None,
+    ) -> None:
+        self.prepare_error = prepare_error
+        self.resolve_error = resolve_error
+        self.resolved_snapshot = _ResolvedWorkflowSnapshot(
+            workflow=Mock(
+                name="Committed Main Workflow",
+                warnings=[{"message": "from committed main", "source": "parser", "context": None}],
+            )
+        )
+        self.resolve_calls: list[dict[str, Any]] = []
+        self.prepare_snapshot_calls: list[dict[str, Any]] = []
+        self.launch_snapshot_calls: list[dict[str, Any]] = []
+
+    def resolve_workflow_run_snapshot(
+        self, workflow_id: str, *, branch: str
+    ) -> _ResolvedWorkflowSnapshot:
+        self.resolve_calls.append({"workflow_id": workflow_id, "branch": branch})
+        if self.resolve_error is not None:
+            raise self.resolve_error
+        return self.resolved_snapshot
+
+    def prepare_run_inputs_from_snapshot(
+        self,
+        snapshot: _ResolvedWorkflowSnapshot,
+        inputs: dict[str, object],
+    ) -> PreparedRunInputs:
+        self.prepare_snapshot_calls.append({"snapshot": snapshot, "inputs": dict(inputs)})
+        if self.prepare_error is not None:
+            raise self.prepare_error
+        return PreparedRunInputs(normalized_inputs=dict(inputs), input_redactor=RunRedactor())
+
+    async def launch_execution_from_snapshot(
+        self,
+        run_id: str,
+        workflow_id: str,
+        prepared: PreparedRunInputs,
+        *,
+        snapshot: _ResolvedWorkflowSnapshot,
+    ) -> None:
+        self.launch_snapshot_calls.append(
+            {
+                "run_id": run_id,
+                "workflow_id": workflow_id,
+                "inputs": prepared.normalized_inputs,
+                "branch": snapshot.branch,
+                "commit_sha": snapshot.commit_sha,
+            }
+        )
+
+    def prepare_run_inputs(self, *args: Any, **kwargs: Any) -> None:
+        raise AssertionError("direct API route must not use dirty GUI prepare_run_inputs")
+
+    async def launch_execution(self, *args: Any, **kwargs: Any) -> None:
+        raise AssertionError("direct API route must not use dirty GUI launch_execution")
+
+
+class _RecordingRunService:
+    def __init__(self) -> None:
+        self.created_run = _mock_run()
+        self.create_calls: list[dict[str, Any]] = []
+
+    def create_run(
+        self,
+        workflow_id: str,
+        inputs: PreparedRunInputs,
+        **kwargs: Any,
+    ) -> Mock:
+        self.create_calls.append(
+            {
+                "workflow_id": workflow_id,
+                "inputs": inputs.normalized_inputs,
+                **kwargs,
+            }
+        )
+        self.created_run.workflow_id = workflow_id
+        self.created_run.source = kwargs.get("source")
+        self.created_run.branch = kwargs.get("branch")
+        self.created_run.source_correlation_id = kwargs.get("source_correlation_id")
+        self.created_run.source_metadata = kwargs.get("source_metadata") or {}
+        self.created_run.commit_sha = COMMITTED_MAIN_SHA
+        self.created_run.workflow_name = "Committed Main Workflow"
+        return self.created_run
+
+    def get_run(self, run_id: str) -> Mock | None:
+        return self.created_run if run_id == self.created_run.id else None
+
+    def refresh_run(self, run_id: str) -> Mock | None:
+        return self.get_run(run_id)
+
+    def fail_run(self, run_id: str, error: str) -> Mock:
+        self.created_run.status = RunStatus.failed
+        self.created_run.error = error
+        return self.created_run
+
+
+def _mock_run() -> Mock:
+    run = Mock()
+    run.id = "run_932_api"
+    run.workflow_id = WORKFLOW_ID
+    run.workflow_name = "Committed Main Workflow"
+    run.status = RunStatus.pending
+    run.error = None
+    run.started_at = None
+    run.completed_at = None
+    run.duration_s = None
+    run.total_cost_usd = 0.0
+    run.total_tokens = 0
+    run.created_at = 1711900932.0
+    run.branch = "main"
+    run.source = "api"
+    run.commit_sha = COMMITTED_MAIN_SHA
+    run.source_correlation_id = "corr-run-932"
+    run.source_metadata = {"entry_path": "direct_api"}
+    run.run_number = None
+    run.eval_pass_pct = None
+    run.eval_score_avg = None
+    run.regression_count = 0
+    run.regression_types = []
+    run.warnings_json = [{"message": "from committed main", "source": "parser", "context": None}]
+    run.parent_run_id = None
+    run.root_run_id = None
+    run.depth = 0
+    run.workflow_inputs = None
+    run.workflow_input_schema = {"query": {"type": "string"}}
+    return run
+
+
+def _install_services(
+    *,
+    admission: _RuntimeAdmission | None = None,
+    execution: _CanonicalExecutionService | None = None,
+    run_service: _RecordingRunService | None = None,
+) -> tuple[_RecordingRunService, _CanonicalExecutionService, _RuntimeAdmission]:
+    run_service = run_service or _RecordingRunService()
+    execution = execution or _CanonicalExecutionService()
+    admission = admission or _RuntimeAdmission()
+
+    app.dependency_overrides[get_run_service] = lambda: run_service
+    app.dependency_overrides[get_execution_service] = lambda: execution
+    app.dependency_overrides[get_external_invocation_admission] = lambda: admission
+    return run_service, execution, admission
+
+
+def _assert_sanitized_error_response(response, expected_status: int) -> dict[str, Any]:
+    assert response.status_code == expected_status
+    body = response.json()
+    assert body["status_code"] == expected_status
+    assert isinstance(body.get("error_code"), str)
+    assert "detail" not in body
+    rendered = response.text
+    assert SECRET_INPUT not in rendered
+    assert SECRET_AUTH not in rendered
+    return body
+
+
+def _validation_error() -> InputValidationError:
+    return InputValidationError(
+        "Workflow input validation failed",
+        error_code="WORKFLOW_INPUT_VALIDATION_ERROR",
+        status_code=422,
+        details={
+            "kind": "workflow_input_validation",
+            "workflow_id": WORKFLOW_ID,
+            "fields": [
+                {
+                    "field": "query",
+                    "code": "type_mismatch",
+                    "message": "Input 'query' is invalid.",
+                    "input_path": ["inputs", "query"],
+                    "expected_type": "string",
+                    "actual_type": "number",
+                }
+            ],
+        },
+    )
+
+
+def test_direct_api_route_invokes_committed_main_snapshot_not_gui_run_contract() -> None:
+    run_service, execution, admission = _install_services()
+
+    response = client.post(
+        f"/api/workflows/{WORKFLOW_ID}/runs",
+        json={"inputs": {"query": "from api", "api_token": SECRET_INPUT}},
+        headers={"x-request-id": "corr-run-932", "authorization": SECRET_AUTH},
+    )
+
+    assert response.status_code in {200, 202}
+    body = response.json()
+    assert body["id"] == "run_932_api"
+    assert body["status"] == "pending"
+    assert body["source"] == "api"
+    assert body["branch"] == "main"
+    assert body["commit_sha"] == COMMITTED_MAIN_SHA
+    assert body["source_correlation_id"] == "corr-run-932"
+    assert body["source_metadata"]["entry_path"] == "direct_api"
+    assert body["workflow_name"] == "Committed Main Workflow"
+    assert SECRET_INPUT not in response.text
+
+    assert admission.calls
+    assert execution.resolve_calls == [{"workflow_id": WORKFLOW_ID, "branch": "main"}]
+    assert execution.prepare_snapshot_calls[0]["inputs"] == {
+        "query": "from api",
+        "api_token": SECRET_INPUT,
+    }
+    assert execution.launch_snapshot_calls == [
+        {
+            "run_id": "run_932_api",
+            "workflow_id": WORKFLOW_ID,
+            "inputs": {"query": "from api", "api_token": SECRET_INPUT},
+            "branch": "main",
+            "commit_sha": COMMITTED_MAIN_SHA,
+        }
+    ]
+    assert len(run_service.create_calls) == 1
+    create_call = run_service.create_calls[0]
+    assert create_call["workflow_id"] == WORKFLOW_ID
+    assert create_call["inputs"] == {"query": "from api", "api_token": SECRET_INPUT}
+    assert create_call["branch"] == "main"
+    assert create_call["source"] == "api"
+    assert create_call["source_correlation_id"] == "corr-run-932"
+    assert create_call["source_metadata"]["entry_path"] == "direct_api"
+    assert create_call["source_metadata"]["request_path"] == f"/api/workflows/{WORKFLOW_ID}/runs"
+    assert SECRET_INPUT not in str(create_call["source_metadata"])
+    assert create_call["workflow_snapshot"] is execution.resolved_snapshot.workflow
+
+
+@pytest.mark.parametrize(
+    "extra_field",
+    [
+        "source",
+        "branch",
+        "commit_sha",
+        "trigger_id",
+        "delivery_id",
+        "debug",
+        "simulation",
+        "simulation_id",
+        "simulation_branch",
+        "idempotency_key",
+        "idempotency_token",
+        "caller",
+        "source_metadata",
+        "source_correlation_id",
+        "provenance",
+    ],
+)
+def test_direct_api_body_rejects_privileged_and_idempotency_fields(extra_field: str) -> None:
+    run_service, execution, _ = _install_services()
+
+    response = client.post(
+        f"/api/workflows/{WORKFLOW_ID}/runs",
+        json={"inputs": {"query": "from api"}, extra_field: SECRET_INPUT},
+        headers={"authorization": SECRET_AUTH},
+    )
+
+    body = _assert_sanitized_error_response(response, 422)
+    assert body["details"]["kind"] == "workflow_input_validation"
+    assert body["details"]["fields"][0]["field"] == extra_field
+    assert body["details"]["fields"][0]["code"] in {"unknown", "extra_forbidden"}
+    assert run_service.create_calls == []
+    assert execution.resolve_calls == []
+    assert execution.launch_snapshot_calls == []
+
+
+def test_direct_api_runtime_unavailable_returns_503_before_run_creation() -> None:
+    run_service, execution, _ = _install_services(
+        admission=_RuntimeAdmission(
+            _AdmissionDecision(
+                allowed=False,
+                failure_code="runtime_unavailable",
+                status_code=503,
+                reason="external invocation disabled by runtime config",
+            )
+        )
+    )
+
+    response = client.post(
+        f"/api/workflows/{WORKFLOW_ID}/runs",
+        json={"inputs": {"query": SECRET_INPUT}},
+        headers={"authorization": SECRET_AUTH},
+    )
+
+    body = _assert_sanitized_error_response(response, 503)
+    assert body["error_code"] == "RUNTIME_UNAVAILABLE"
+    assert run_service.create_calls == []
+    assert execution.resolve_calls == []
+    assert execution.launch_snapshot_calls == []
+
+
+def test_direct_api_admission_saturation_returns_429_before_run_creation() -> None:
+    run_service, execution, _ = _install_services(
+        admission=_RuntimeAdmission(
+            _AdmissionDecision(
+                allowed=False,
+                failure_code="admission_saturated",
+                status_code=429,
+                reason="external invocation admission is saturated",
+            )
+        )
+    )
+
+    response = client.post(
+        f"/api/workflows/{WORKFLOW_ID}/runs",
+        json={"inputs": {"query": SECRET_INPUT}},
+        headers={"authorization": SECRET_AUTH},
+    )
+
+    body = _assert_sanitized_error_response(response, 429)
+    assert body["error_code"] == "ADMISSION_SATURATED"
+    assert run_service.create_calls == []
+    assert execution.resolve_calls == []
+    assert execution.launch_snapshot_calls == []
+
+
+def test_direct_api_workflow_missing_on_saved_main_returns_404_without_run_creation() -> None:
+    run_service, execution, _ = _install_services(
+        execution=_CanonicalExecutionService(
+            resolve_error=WorkflowNotFound(f"Workflow {WORKFLOW_ID!r} not found on main")
+        )
+    )
+
+    response = client.post(
+        f"/api/workflows/{WORKFLOW_ID}/runs",
+        json={"inputs": {"query": SECRET_INPUT}},
+        headers={"authorization": SECRET_AUTH},
+    )
+
+    body = _assert_sanitized_error_response(response, 404)
+    assert body["error_code"] == "WORKFLOW_NOT_FOUND"
+    assert execution.resolve_calls == [{"workflow_id": WORKFLOW_ID, "branch": "main"}]
+    assert run_service.create_calls == []
+    assert execution.launch_snapshot_calls == []
+
+
+def test_direct_api_canonical_input_validation_returns_422_without_run_creation() -> None:
+    run_service, execution, _ = _install_services(
+        execution=_CanonicalExecutionService(prepare_error=_validation_error())
+    )
+
+    response = client.post(
+        f"/api/workflows/{WORKFLOW_ID}/runs",
+        json={"inputs": {"query": 932, "api_token": SECRET_INPUT}},
+        headers={"authorization": SECRET_AUTH},
+    )
+
+    body = _assert_sanitized_error_response(response, 422)
+    assert body["error_code"] == "WORKFLOW_INPUT_VALIDATION_ERROR"
+    assert body["details"]["fields"][0]["code"] == "type_mismatch"
+    assert run_service.create_calls == []
+    assert execution.launch_snapshot_calls == []
+
+
+def test_direct_api_body_too_large_returns_413_before_route_parsing_or_storage() -> None:
+    run_service, execution, _ = _install_services()
+
+    response = client.post(
+        f"/api/workflows/{WORKFLOW_ID}/runs",
+        content=b'{"inputs":{"query":"' + (b"x" * 1_100_000) + b'"}}',
+        headers={"content-type": "application/json", "authorization": SECRET_AUTH},
+    )
+
+    body = _assert_sanitized_error_response(response, 413)
+    assert body["error_code"] == "REQUEST_BODY_TOO_LARGE"
+    assert run_service.create_calls == []
+    assert execution.resolve_calls == []
+    assert execution.launch_snapshot_calls == []
+
+
+def test_openapi_exposes_distinct_direct_api_invocation_schema() -> None:
+    app.openapi_schema = None
+    spec = app.openapi()
+
+    operation = spec["paths"]["/api/workflows/{workflow_id}/runs"]["post"]
+    request_schema = operation["requestBody"]["content"]["application/json"]["schema"]
+    schema_ref = request_schema.get("$ref", "")
+    assert not schema_ref.endswith("/RunCreate")
+
+    schema_name = schema_ref.rsplit("/", 1)[-1]
+    assert schema_name != "RunCreate"
+    schema = spec["components"]["schemas"][schema_name]
+    assert set(schema["properties"]) == {"inputs"}
+    assert "workflow_id" not in schema["properties"]
+    assert "source" not in schema["properties"]
+    assert "branch" not in schema["properties"]
+    assert "idempotency_key" not in schema["properties"]
+    assert "source_metadata" not in schema["properties"]
+    assert {"404", "422", "429", "503"}.issubset(operation["responses"])

--- a/apps/api/tests/transport/test_run932_direct_api_invocation_route.py
+++ b/apps/api/tests/transport/test_run932_direct_api_invocation_route.py
@@ -12,6 +12,7 @@ from runsight_core.redaction import RunRedactor
 
 from runsight_api.domain.entities.run import RunStatus
 from runsight_api.domain.errors import InputValidationError, WorkflowNotFound
+from runsight_api.domain.value_objects import WorkflowEntity
 from runsight_api.logic.services.execution_service import PreparedRunInputs
 from runsight_api.main import app
 from runsight_api.transport.deps import (
@@ -399,6 +400,30 @@ def test_direct_api_workflow_missing_on_saved_main_returns_404_without_run_creat
     assert execution.launch_snapshot_calls == []
 
 
+def test_direct_api_disabled_saved_main_snapshot_returns_404_without_run_creation() -> None:
+    run_service, execution, _ = _install_services()
+    execution.resolved_snapshot = _ResolvedWorkflowSnapshot(
+        workflow=WorkflowEntity(
+            kind="workflow",
+            id=WORKFLOW_ID,
+            name="Disabled Main Workflow",
+            enabled=False,
+        )
+    )
+
+    response = client.post(
+        f"/api/workflows/{WORKFLOW_ID}/runs",
+        json={"inputs": {"query": SECRET_INPUT}},
+        headers={"authorization": SECRET_AUTH},
+    )
+
+    body = _assert_sanitized_error_response(response, 404)
+    assert body["error_code"] == "WORKFLOW_NOT_FOUND"
+    assert execution.resolve_calls == [{"workflow_id": WORKFLOW_ID, "branch": "main"}]
+    assert run_service.create_calls == []
+    assert execution.launch_snapshot_calls == []
+
+
 def test_direct_api_canonical_input_validation_returns_422_without_run_creation() -> None:
     run_service, execution, _ = _install_services(
         execution=_CanonicalExecutionService(prepare_error=_validation_error())
@@ -452,3 +477,14 @@ def test_openapi_exposes_distinct_direct_api_invocation_schema() -> None:
     assert "idempotency_key" not in schema["properties"]
     assert "source_metadata" not in schema["properties"]
     assert {"404", "422", "429", "503"}.issubset(operation["responses"])
+
+
+@pytest.mark.parametrize("status", ["404", "429", "503", "413"])
+def test_openapi_models_direct_api_error_responses_as_json(status: str) -> None:
+    app.openapi_schema = None
+    spec = app.openapi()
+
+    operation = spec["paths"]["/api/workflows/{workflow_id}/runs"]["post"]
+    response = operation["responses"][status]
+
+    assert response["content"]["application/json"]["schema"]

--- a/apps/api/tests/transport/test_run932_direct_api_invocation_route.py
+++ b/apps/api/tests/transport/test_run932_direct_api_invocation_route.py
@@ -424,6 +424,31 @@ def test_direct_api_disabled_saved_main_snapshot_returns_404_without_run_creatio
     assert execution.launch_snapshot_calls == []
 
 
+def test_direct_api_omitted_enabled_saved_main_snapshot_returns_404_without_run_creation() -> None:
+    run_service, execution, _ = _install_services()
+    execution.resolved_snapshot = _ResolvedWorkflowSnapshot(
+        workflow=WorkflowEntity(
+            kind="workflow",
+            id=WORKFLOW_ID,
+            name="Omitted Enabled Main Workflow",
+            yaml="id: run932_direct_api\nkind: workflow\nworkflow:\n  name: Omitted Enabled Main Workflow\n",
+        )
+    )
+
+    response = client.post(
+        f"/api/workflows/{WORKFLOW_ID}/runs",
+        json={"inputs": {"query": SECRET_INPUT}},
+        headers={"authorization": SECRET_AUTH},
+    )
+
+    body = _assert_sanitized_error_response(response, 404)
+    assert body["error_code"] == "WORKFLOW_NOT_FOUND"
+    assert execution.resolve_calls == [{"workflow_id": WORKFLOW_ID, "branch": "main"}]
+    assert execution.prepare_snapshot_calls == []
+    assert run_service.create_calls == []
+    assert execution.launch_snapshot_calls == []
+
+
 def test_direct_api_canonical_input_validation_returns_422_without_run_creation() -> None:
     run_service, execution, _ = _install_services(
         execution=_CanonicalExecutionService(prepare_error=_validation_error())

--- a/apps/api/tests/transport/test_run934_api_run_provenance_responses.py
+++ b/apps/api/tests/transport/test_run934_api_run_provenance_responses.py
@@ -1,0 +1,226 @@
+"""RED tests for RUN-934 API run provenance response surfaces."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import Mock
+
+from fastapi.testclient import TestClient
+
+from runsight_api.domain.entities.run import RunStatus
+from runsight_api.main import app
+from runsight_api.transport.deps import get_api_run_service, get_eval_service, get_run_service
+
+
+COMMITTED_MAIN_SHA = "934" * 13 + "a"
+SECRET_INPUT = "secret-run-934-input"
+SECRET_AUTH = "Bearer secret-run-934-auth"
+SECRET_IDEMPOTENCY = "idem-secret-run-934"
+
+client = TestClient(app, raise_server_exceptions=False)
+
+
+def teardown_function() -> None:
+    app.dependency_overrides.clear()
+
+
+def _summary() -> dict[str, Any]:
+    return {
+        "total_cost_usd": 0.0,
+        "total_tokens": 0,
+        "nodes_count": 0,
+        "total": 0,
+        "completed": 0,
+        "running": 0,
+        "pending": 0,
+        "failed": 0,
+    }
+
+
+def _run(
+    run_id: str,
+    *,
+    source: str,
+    status: RunStatus | str = RunStatus.pending,
+    branch: str = "main",
+    commit_sha: str | None = None,
+    source_correlation_id: str | None = None,
+    source_metadata: dict[str, Any] | None = None,
+) -> Mock:
+    run = Mock()
+    run.id = run_id
+    run.workflow_id = "wf_run934"
+    run.workflow_name = "RUN-934 Workflow"
+    run.status = status
+    run.error = None
+    run.started_at = None
+    run.completed_at = None
+    run.duration_s = None
+    run.total_cost_usd = 0.0
+    run.total_tokens = 0
+    run.created_at = 1711900934.0
+    run.branch = branch
+    run.source = source
+    run.commit_sha = commit_sha
+    run.source_correlation_id = source_correlation_id
+    run.source_metadata = source_metadata if source_metadata is not None else {}
+    run.run_number = None
+    run.eval_pass_pct = None
+    run.eval_score_avg = None
+    run.regression_count = 0
+    run.regression_types = []
+    run.warnings_json = []
+    run.parent_run_id = None
+    run.root_run_id = None
+    run.depth = 0
+    run.workflow_inputs = None
+    run.workflow_input_schema = None
+    return run
+
+
+def _eval_service() -> Mock:
+    service = Mock()
+    service.get_run_regressions.return_value = {"count": 0, "issues": []}
+    return service
+
+
+def _install_run_service(*runs: Mock) -> Mock:
+    service = Mock()
+    by_id = {run.id: run for run in runs}
+    service.list_runs_paginated.return_value = (list(runs), len(runs))
+    service.get_run.side_effect = lambda run_id: by_id.get(run_id)
+    service.get_node_summary.return_value = _summary()
+    service.get_node_summaries_batch.return_value = {run.id: _summary() for run in runs}
+    app.dependency_overrides[get_run_service] = lambda: service
+    app.dependency_overrides[get_eval_service] = lambda: _eval_service()
+    return service
+
+
+def test_list_and_detail_responses_expose_api_provenance_without_mislabeling_sources() -> None:
+    api_run = _run(
+        "run_934_api",
+        source="api",
+        commit_sha=COMMITTED_MAIN_SHA,
+        source_correlation_id="corr-run-934",
+        source_metadata={
+            "entry_path": "direct_api",
+            "request_path": "/api/workflows/wf_run934/runs",
+        },
+    )
+    manual_run = _run("run_934_manual", source="manual")
+    simulation_run = _run("run_934_simulation", source="simulation", branch="sim/run-934")
+    legacy_unknown_run = _run("run_934_legacy", source="legacy-runner")
+    _install_run_service(api_run, manual_run, simulation_run, legacy_unknown_run)
+
+    list_response = client.get("/api/runs")
+    detail_response = client.get("/api/runs/run_934_api")
+
+    assert list_response.status_code == 200
+    items = {item["id"]: item for item in list_response.json()["items"]}
+    assert items["run_934_api"]["source"] == "api"
+    assert items["run_934_api"]["commit_sha"] == COMMITTED_MAIN_SHA
+    assert items["run_934_api"]["source_correlation_id"] == "corr-run-934"
+    assert items["run_934_api"]["source_metadata"] == {
+        "entry_path": "direct_api",
+        "request_path": "/api/workflows/wf_run934/runs",
+    }
+    assert items["run_934_manual"]["source"] == "manual"
+    assert items["run_934_simulation"]["source"] == "simulation"
+    assert items["run_934_legacy"]["source"] == "legacy-runner"
+    assert items["run_934_legacy"]["source"] != "api"
+
+    assert detail_response.status_code == 200
+    detail = detail_response.json()
+    assert detail["source"] == "api"
+    assert detail["commit_sha"] == COMMITTED_MAIN_SHA
+    assert detail["source_correlation_id"] == "corr-run-934"
+    assert detail["source_metadata"]["entry_path"] == "direct_api"
+
+
+def test_old_run_detail_and_list_responses_do_not_leak_unsafe_source_metadata() -> None:
+    unsafe_api_run = _run(
+        "run_934_unsafe_api",
+        source="api",
+        commit_sha=COMMITTED_MAIN_SHA,
+        source_correlation_id="corr-run-934",
+        source_metadata={
+            "entry_path": "direct_api",
+            "request_path": "/api/workflows/wf_run934/runs",
+            "headers": {
+                "authorization": SECRET_AUTH,
+                "x-api-key": "secret-run-934-api-key",
+            },
+            "raw_body": {"inputs": {"api_token": SECRET_INPUT}},
+            "idempotency_key": SECRET_IDEMPOTENCY,
+            "nested": [{"token": "nested-secret-run-934"}],
+        },
+    )
+    _install_run_service(unsafe_api_run)
+
+    list_response = client.get("/api/runs")
+    detail_response = client.get("/api/runs/run_934_unsafe_api")
+
+    assert list_response.status_code == 200
+    assert detail_response.status_code == 200
+    for response in (list_response, detail_response):
+        rendered = response.text
+        body = response.json()
+        run_payload = body["items"][0] if "items" in body else body
+        assert run_payload["source"] == "api"
+        assert run_payload["source_metadata"]["entry_path"] == "direct_api"
+        assert run_payload["source_metadata"]["request_path"] == "/api/workflows/wf_run934/runs"
+        assert "headers" not in run_payload["source_metadata"]
+        assert "raw_body" not in run_payload["source_metadata"]
+        assert "idempotency_key" not in run_payload["source_metadata"]
+        assert SECRET_AUTH not in rendered
+        assert SECRET_INPUT not in rendered
+        assert SECRET_IDEMPOTENCY not in rendered
+        assert "authorization" not in rendered.lower()
+        assert "api_token" not in rendered
+        assert "nested-secret-run-934" not in rendered
+
+
+async def _created_run(
+    *,
+    workflow_id: str,
+    inputs: dict[str, Any],
+    source_correlation_id: str | None,
+    source_metadata: dict[str, Any],
+) -> Mock:
+    return _run(
+        "run_934_direct_api",
+        source="api",
+        status=RunStatus.running,
+        commit_sha=COMMITTED_MAIN_SHA,
+        source_correlation_id=source_correlation_id,
+        source_metadata=dict(source_metadata),
+    )
+
+
+def test_direct_api_accepted_response_reports_current_nonterminal_status_and_safe_provenance() -> (
+    None
+):
+    service = Mock()
+    service.create_direct_api_run.side_effect = _created_run
+    app.dependency_overrides[get_api_run_service] = lambda: service
+
+    response = client.post(
+        "/api/workflows/wf_run934/runs",
+        json={"inputs": {"query": "from api", "api_token": SECRET_INPUT}},
+        headers={"x-request-id": "corr-run-934", "authorization": SECRET_AUTH},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == "run_934_direct_api"
+    assert body["source"] == "api"
+    assert body["status"] == "running"
+    assert body["status"] not in {"completed", "success", "succeeded"}
+    assert body["commit_sha"] == COMMITTED_MAIN_SHA
+    assert body["source_correlation_id"] == "corr-run-934"
+    assert body["source_metadata"] == {
+        "entry_path": "direct_api",
+        "request_path": "/api/workflows/wf_run934/runs",
+    }
+    assert SECRET_INPUT not in response.text
+    assert SECRET_AUTH not in response.text

--- a/apps/api/tests/transport/test_run944_trigger_transport_guardrails.py
+++ b/apps/api/tests/transport/test_run944_trigger_transport_guardrails.py
@@ -78,6 +78,22 @@ def test_external_invocation_log_context_redacts_auth_headers_raw_body_and_input
     assert context["inputs"]["query"] == "safe"
 
 
+def test_external_invocation_log_context_redacts_sensitive_keys_inside_input_lists() -> None:
+    from runsight_api.logic.services.trigger_runtime import redact_external_invocation_log_context
+
+    context = redact_external_invocation_log_context(
+        method="POST",
+        path="/api/workflows/wf_944/runs",
+        headers={},
+        body=None,
+        inputs={"records": [{"token": "secret-list-token", "query": "safe"}]},
+    )
+
+    rendered = json.dumps(context, sort_keys=True)
+    assert "secret-list-token" not in rendered
+    assert context["inputs"]["records"] == [{"token": "[redacted]", "query": "safe"}]
+
+
 @pytest.mark.parametrize(
     "raw_body",
     [

--- a/apps/api/tests/transport/test_run944_trigger_transport_guardrails.py
+++ b/apps/api/tests/transport/test_run944_trigger_transport_guardrails.py
@@ -1,0 +1,101 @@
+"""RED tests for RUN-944 external invocation transport guardrails."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+
+def _assert_runsight_error_shape(response, expected_status: int) -> dict:
+    assert response.status_code == expected_status
+    body = response.json()
+    assert body["status_code"] == expected_status
+    assert "error" in body
+    assert "error_code" in body
+    assert "detail" not in body
+    return body
+
+
+def test_body_limit_rejects_oversized_payload_before_json_parsing_or_storage() -> None:
+    from runsight_api.transport.middleware.body_limit import BodySizeLimitMiddleware
+
+    handler_calls: list[str] = []
+    app = FastAPI()
+    app.add_middleware(BodySizeLimitMiddleware, max_body_bytes=32)
+
+    @app.post("/api/workflows/{workflow_id}/runs")
+    async def direct_api_run(workflow_id: str, request: Request):
+        handler_calls.append(workflow_id)
+        await request.json()
+        return {"ok": True}
+
+    response = TestClient(app).post(
+        "/api/workflows/wf_944/runs",
+        content=b'{"inputs":{"query":"' + (b"x" * 128),
+        headers={
+            "content-type": "application/json",
+            "authorization": "Bearer secret-run-944",
+        },
+    )
+
+    body = _assert_runsight_error_shape(response, 413)
+    assert body["error_code"] == "REQUEST_BODY_TOO_LARGE"
+    assert handler_calls == []
+
+
+def test_external_invocation_log_context_redacts_auth_headers_raw_body_and_inputs() -> None:
+    from runsight_api.logic.services.trigger_runtime import redact_external_invocation_log_context
+
+    context = redact_external_invocation_log_context(
+        method="POST",
+        path="/api/workflows/wf_944/runs",
+        headers={
+            "authorization": "Bearer secret-token-944",
+            "x-api-key": "secret-api-key-944",
+            "content-type": "application/json",
+        },
+        body=b'{"inputs":{"api_token":"secret-input-944","query":"safe"}}',
+        inputs={
+            "api_token": "secret-input-944",
+            "password": "secret-password-944",
+            "query": "safe",
+        },
+    )
+
+    rendered = json.dumps(context, sort_keys=True)
+    assert "secret-token-944" not in rendered
+    assert "secret-api-key-944" not in rendered
+    assert "secret-input-944" not in rendered
+    assert "secret-password-944" not in rendered
+    assert context["headers"]["authorization"] == "[redacted]"
+    assert context["headers"]["x-api-key"] == "[redacted]"
+    assert context["raw_body"] == "[redacted]"
+    assert context["inputs"]["api_token"] == "[redacted]"
+    assert context["inputs"]["password"] == "[redacted]"
+    assert context["inputs"]["query"] == "safe"
+
+
+@pytest.mark.parametrize(
+    "raw_body",
+    [
+        b'{"inputs":{"token":"secret-from-truncated-json"',
+        b"x" * 2048,
+    ],
+)
+def test_redaction_handles_malformed_or_huge_body_without_leaking(raw_body: bytes) -> None:
+    from runsight_api.logic.services.trigger_runtime import redact_external_invocation_log_context
+
+    context = redact_external_invocation_log_context(
+        method="POST",
+        path="/api/workflows/wf_944/runs",
+        headers={"authorization": "Bearer secret-token-944"},
+        body=raw_body,
+        inputs=None,
+    )
+
+    rendered = json.dumps(context, sort_keys=True)
+    assert "secret" not in rendered.lower()
+    assert context["raw_body"] == "[redacted]"

--- a/apps/api/tests/transport/test_runs_router.py
+++ b/apps/api/tests/transport/test_runs_router.py
@@ -415,6 +415,42 @@ def test_runs_post_passes_source_and_branch_to_services():
     app.dependency_overrides.clear()
 
 
+def test_runs_post_rejects_reserved_api_source_before_create_or_launch():
+    mock_service = Mock()
+    mock_run = _make_mock_run("run_forged_api_source", branch=TEST_BRANCH)
+    mock_run.source = "api"
+    mock_service.create_run.return_value = mock_run
+    mock_service.refresh_run.return_value = mock_run
+    mock_exec_service = Mock()
+    mock_exec_service.prepare_run_inputs.return_value = _prepared_inputs({"instruction": "go"})
+    mock_exec_service.launch_execution = AsyncMock()
+    app.dependency_overrides[get_run_service] = lambda: mock_service
+    app.dependency_overrides[get_execution_service] = lambda: mock_exec_service
+
+    try:
+        response = client.post(
+            "/api/runs",
+            json={
+                "workflow_id": "wf_1",
+                "inputs": {"instruction": "go"},
+                "source": "api",
+                "branch": TEST_BRANCH,
+            },
+        )
+
+        assert response.status_code == 422
+        body = response.json()
+        assert body["error_code"] == "WORKFLOW_INPUT_VALIDATION_ERROR"
+        assert body["status_code"] == 422
+        assert body["details"]["kind"] == "workflow_input_validation"
+        assert body["details"]["fields"][0]["field"] == "source"
+        mock_exec_service.prepare_run_inputs.assert_not_called()
+        mock_service.create_run.assert_not_called()
+        mock_exec_service.launch_execution.assert_not_called()
+    finally:
+        app.dependency_overrides.clear()
+
+
 def test_runs_post_allows_omitted_branch_and_persists_main():
     """POST /api/runs should use the working tree when branch is omitted."""
     mock_service = Mock()
@@ -452,6 +488,20 @@ def test_runs_post_allows_omitted_branch_and_persists_main():
         branch=None,
     )
     app.dependency_overrides.clear()
+
+
+def test_runs_post_large_unrelated_body_is_not_rejected_by_direct_api_body_limit():
+    response = client.post(
+        "/api/runs",
+        content=b'{"workflow_id":123,"inputs":{"blob":"' + (b"x" * 1_100_000) + b'"}}',
+        headers={"content-type": "application/json"},
+    )
+
+    assert response.status_code == 422
+    body = response.json()
+    assert body["error_code"] == "WORKFLOW_INPUT_VALIDATION_ERROR"
+    assert body["status_code"] == 422
+    assert body["error_code"] != "REQUEST_BODY_TOO_LARGE"
 
 
 def test_runs_post_422():

--- a/apps/gui/src/features/dashboard/__tests__/activeRunsSection.test.ts
+++ b/apps/gui/src/features/dashboard/__tests__/activeRunsSection.test.ts
@@ -215,6 +215,24 @@ function buildRunList(items: RunResponse[]): RunListResponse {
   };
 }
 
+function getRequestedSources(params: unknown): string[] {
+  if (params instanceof URLSearchParams) {
+    return params.getAll("source").sort();
+  }
+
+  if (params && typeof params === "object") {
+    const source = (params as { source?: unknown }).source;
+    if (Array.isArray(source)) {
+      return source.filter((value): value is string => typeof value === "string").sort();
+    }
+    if (typeof source === "string") {
+      return [source];
+    }
+  }
+
+  return [];
+}
+
 function rootRun(overrides: Partial<RunResponse> = {}): RunResponse {
   return makeRun(overrides);
 }
@@ -301,6 +319,34 @@ describe("RUN-974 active runs dashboard behavior", () => {
     expect(eventSources.map((source) => source.url).sort()).toEqual([
       "/api/runs/run_root/stream",
       "/api/runs/run_root_2/stream",
+    ]);
+  });
+
+  it("treats api main root runs as production active runs", async () => {
+    activeRunsData = [
+      rootRun({
+        id: "run_api_active",
+        workflow_name: "API Active Flow",
+        source: "api",
+      }),
+    ];
+
+    renderDashboard();
+
+    await waitFor(() => {
+      expect(harness.listRuns).toHaveBeenCalled();
+    });
+
+    expect(getRequestedSources(harness.listRuns.mock.calls[0]?.[0])).toEqual([
+      "api",
+      "manual",
+      "schedule",
+      "webhook",
+    ]);
+
+    await waitForInitialActiveRunsLoad(["API Active Flow"]);
+    expect(eventSources.map((source) => source.url)).toEqual([
+      "/api/runs/run_api_active/stream",
     ]);
   });
 

--- a/apps/gui/src/features/runs/RunRow.tsx
+++ b/apps/gui/src/features/runs/RunRow.tsx
@@ -20,7 +20,7 @@ import { AlertTriangle, Info } from "lucide-react";
 import { RegressionTooltipBody } from "@/components/shared/RegressionTooltipBody";
 import { WarningTooltipBody } from "@/components/shared/WarningTooltipBody";
 import { useRunRegressions } from "@/queries/runs";
-import { formatCommit, formatCost, formatDuration, getSourceVariant, getTimeAgo } from "@/utils/formatting";
+import { formatCommit, formatCost, formatDuration, formatRunSource, getSourceVariant, getTimeAgo } from "@/utils/formatting";
 import { formatRegressionTooltip } from "../workflows/regressionBadge.utils";
 import {
   formatWarningTooltip,
@@ -56,7 +56,7 @@ function formatStartedAt(startedAt: number | null | undefined) {
 }
 
 function SourceBadge({ source }: { source: RunResponse["source"] }) {
-  return <Badge variant={getSourceVariant(source)}>{source}</Badge>;
+  return <Badge variant={getSourceVariant(source)}>{formatRunSource(source)}</Badge>;
 }
 
 function EvalCell({

--- a/apps/gui/src/features/runs/RunsTab.tsx
+++ b/apps/gui/src/features/runs/RunsTab.tsx
@@ -208,6 +208,9 @@ export function RunsTab({
     );
   }, [attentionOnly, runs, searchQuery, sortColumn, sortDirection]);
 
+  const hasLocalFilters = sourceFilter !== "all" || searchQuery.trim() !== "";
+  const hasAnyFilters = Boolean(workflowFilter) || activeOnly || attentionOnly || hasLocalFilters;
+
   const handleSort = (column: SortColumn) => {
     if (column === sortColumn) {
       setSortDirection((current) =>
@@ -225,6 +228,12 @@ export function RunsTab({
 
   const openRun = (runId: string) => {
     navigate(`/runs/${runId}`);
+  };
+
+  const handleClearFilters = () => {
+    setSearchQuery("");
+    setSourceFilter("all");
+    onClearFilters();
   };
 
   return (
@@ -316,7 +325,7 @@ export function RunsTab({
               Retry
             </Button>
           </section>
-        ) : runs.length === 0 && !workflowFilter && !activeOnly ? (
+        ) : runs.length === 0 && !hasAnyFilters ? (
           <EmptyState
             icon={Play}
             title="No runs yet"
@@ -340,7 +349,7 @@ export function RunsTab({
                   ? "No runs are currently in progress."
                   : "Try adjusting your filters."
             }
-            action={{ label: "Clear filters", onClick: onClearFilters }}
+            action={{ label: "Clear filters", onClick: handleClearFilters }}
           />
         ) : (
           <div className={RUN_TABLE_CONTAINER_CLASS}>

--- a/apps/gui/src/features/runs/RunsTab.tsx
+++ b/apps/gui/src/features/runs/RunsTab.tsx
@@ -45,7 +45,7 @@ type SortColumn =
 type SortDirection = "ascending" | "descending";
 type SourceFilter = "production" | "all";
 
-const PRODUCTION_RUN_SOURCES = ["manual", "webhook", "schedule"] as const;
+const PRODUCTION_RUN_SOURCES = ["manual", "webhook", "schedule", "api"] as const;
 const SOURCE_FILTER_LABELS: Record<SourceFilter, string> = {
   production: "Production runs",
   all: "All runs",

--- a/apps/gui/src/features/runs/__tests__/run940ApiSourceUi.test.tsx
+++ b/apps/gui/src/features/runs/__tests__/run940ApiSourceUi.test.tsx
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   onOpen: vi.fn(),
   runsQueryCalls: [] as unknown[],
   refetchRuns: vi.fn(),
+  runs: [] as RunResponse[],
 }));
 
 function normalizeSources(params: unknown): string[] {
@@ -42,9 +43,14 @@ function buildRunList(items: RunResponse[]) {
 vi.mock("@/queries/runs", () => ({
   useRuns: (params?: unknown) => {
     mocks.runsQueryCalls.push(params);
+    const requestedSources = normalizeSources(params);
+    const runs =
+      requestedSources.length === 0
+        ? mocks.runs
+        : mocks.runs.filter((run) => requestedSources.includes(run.source));
 
     return {
-      data: buildRunList([]),
+      data: buildRunList(runs),
       isLoading: false,
       error: null,
       refetch: mocks.refetchRuns,
@@ -144,6 +150,7 @@ beforeEach(() => {
   mocks.onOpen.mockReset();
   mocks.runsQueryCalls.length = 0;
   mocks.refetchRuns.mockReset();
+  mocks.runs = [];
 });
 
 afterEach(() => {
@@ -217,5 +224,42 @@ describe("RUN-940 api run source UI", () => {
         "webhook",
       ]);
     });
+  });
+
+  it("shows filtered-empty copy instead of first-run copy when source filtering hides runs", async () => {
+    const user = userEvent.setup();
+    mocks.runs = [makeRun({ id: "run_simulation_only", source: "simulation" })];
+    renderRunsTab();
+
+    await user.click(screen.getByLabelText("Filter runs by source"));
+    await screen.findByText("Production runs");
+    await user.click(findSourceSelectOption("Production runs"));
+
+    expect(await screen.findByText("No matching runs")).toBeTruthy();
+    expect(screen.queryByText("No runs yet")).toBeNull();
+  });
+
+  it("clears local source and search filters from the RunsTab empty state", async () => {
+    const user = userEvent.setup();
+    mocks.runs = [makeRun({ id: "run_clear_filters", workflow_name: "Visible After Clear" })];
+    renderRunsTab();
+
+    await user.click(screen.getByLabelText("Filter runs by source"));
+    await screen.findByText("Production runs");
+    await user.click(findSourceSelectOption("Production runs"));
+    await user.type(screen.getByRole("searchbox", { name: "Search runs" }), "missing");
+
+    expect(await screen.findByText("No matching runs")).toBeTruthy();
+
+    await user.click(screen.getByRole("button", { name: "Clear filters" }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Filter runs by source").textContent).toContain("All runs");
+    });
+    expect((screen.getByRole("searchbox", { name: "Search runs" }) as HTMLInputElement).value).toBe(
+      "",
+    );
+    expect(screen.getByText("Visible After Clear")).toBeTruthy();
+    expect(normalizeSources(mocks.runsQueryCalls.at(-1))).toEqual([]);
   });
 });

--- a/apps/gui/src/features/runs/__tests__/run940ApiSourceUi.test.tsx
+++ b/apps/gui/src/features/runs/__tests__/run940ApiSourceUi.test.tsx
@@ -1,0 +1,221 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router";
+import type { RunResponse } from "@runsight/shared/zod";
+
+const mocks = vi.hoisted(() => ({
+  onOpen: vi.fn(),
+  runsQueryCalls: [] as unknown[],
+  refetchRuns: vi.fn(),
+}));
+
+function normalizeSources(params: unknown): string[] {
+  if (params instanceof URLSearchParams) {
+    return params.getAll("source").sort();
+  }
+
+  if (
+    params &&
+    typeof params === "object" &&
+    "source" in params &&
+    Array.isArray((params as { source?: unknown }).source)
+  ) {
+    return [...((params as { source: string[] }).source)].sort();
+  }
+
+  return [];
+}
+
+function buildRunList(items: RunResponse[]) {
+  return {
+    items,
+    total: items.length,
+    offset: 0,
+    limit: 20,
+  };
+}
+
+vi.mock("@/queries/runs", () => ({
+  useRuns: (params?: unknown) => {
+    mocks.runsQueryCalls.push(params);
+
+    return {
+      data: buildRunList([]),
+      isLoading: false,
+      error: null,
+      refetch: mocks.refetchRuns,
+    };
+  },
+  useRunRegressions: () => ({
+    data: undefined,
+  }),
+}));
+
+vi.mock("@/queries/workflows", () => ({
+  useWorkflows: () => ({
+    data: { items: [] },
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+import { RunRow } from "../RunRow";
+import { RunsTab } from "../RunsTab";
+
+function makeRun(overrides: Partial<RunResponse> = {}): RunResponse {
+  return {
+    id: "run_940",
+    workflow_id: "wf_940",
+    workflow_name: "RUN-940 Flow",
+    status: "completed",
+    started_at: 1_774_414_400,
+    completed_at: 1_774_414_412,
+    duration_seconds: 12,
+    total_cost_usd: 0.04,
+    total_tokens: 1200,
+    created_at: 1_774_414_399,
+    branch: "main",
+    source: "manual",
+    commit_sha: "f078f13deadbeef",
+    run_number: 7,
+    eval_pass_pct: 92,
+    eval_score_avg: null,
+    regression_count: 0,
+    regression_types: [],
+    warnings: [],
+    node_summary: null,
+    parent_run_id: null,
+    root_run_id: null,
+    depth: 0,
+    workflow_inputs: null,
+    workflow_input_schema: null,
+    ...overrides,
+  };
+}
+
+function renderRows(runs: RunResponse[]) {
+  render(
+    <table>
+      <tbody>
+        {runs.map((run) => (
+          <RunRow key={run.id} run={run} onOpen={mocks.onOpen} />
+        ))}
+      </tbody>
+    </table>,
+  );
+}
+
+function getSourceCell(row: HTMLElement): HTMLElement {
+  const cell = within(row).getAllByRole("cell")[4];
+  expect(cell).toBeTruthy();
+  return cell;
+}
+
+function renderRunsTab() {
+  render(
+    <MemoryRouter>
+      <RunsTab
+        RowComponent={RunRow}
+        workflowFilter={null}
+        attentionOnly={false}
+        activeOnly={false}
+        onWorkflowFilterChange={vi.fn()}
+        onAttentionFilterChange={vi.fn()}
+        onActiveFilterChange={vi.fn()}
+        onClearFilters={vi.fn()}
+      />
+    </MemoryRouter>,
+  );
+}
+
+function findSourceSelectOption(label: "All runs" | "Production runs") {
+  return (
+    screen.queryByRole("option", { name: label }) ??
+    screen.queryByRole("menuitemradio", { name: label }) ??
+    screen.getByText(label)
+  );
+}
+
+beforeEach(() => {
+  mocks.onOpen.mockReset();
+  mocks.runsQueryCalls.length = 0;
+  mocks.refetchRuns.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("RUN-940 api run source UI", () => {
+  it("renders api source runs as API without leaking request provenance metadata", () => {
+    renderRows([
+      makeRun({
+        id: "run_api_940",
+        workflow_name: "API Intake",
+        source: "api",
+        source_correlation_id: "req-run-940",
+        source_metadata: {
+          authorization: "Bearer secret-run-940",
+          idempotency_key: "idem-key-run-940",
+        },
+      } as Partial<RunResponse>),
+    ]);
+
+    const row = screen.getByRole("row");
+    const sourceCell = getSourceCell(row);
+    const apiBadge = within(sourceCell).getByText("API");
+
+    expect(sourceCell.textContent).toBe("API");
+    expect(apiBadge.className).toContain("whitespace-nowrap");
+
+    const renderedText = row.textContent ?? "";
+    expect(renderedText).not.toContain("req-run-940");
+    expect(renderedText).not.toContain("idem-key-run-940");
+    expect(renderedText).not.toContain("Bearer");
+    expect(renderedText).not.toContain("secret-run-940");
+  });
+
+  it("keeps existing manual and simulation source labels unchanged", () => {
+    renderRows([
+      makeRun({ id: "run_manual", source: "manual" }),
+      makeRun({ id: "run_simulation", source: "simulation" }),
+    ]);
+
+    const [manualRow, simulationRow] = screen.getAllByRole("row");
+    expect(getSourceCell(manualRow).textContent).toBe("manual");
+    expect(getSourceCell(simulationRow).textContent).toBe("simulation");
+  });
+
+  it("keeps unknown source values visible on the safe fallback path", () => {
+    renderRows([
+      makeRun({
+        id: "run_partner_unknown",
+        source: "partner_console",
+      }),
+    ]);
+
+    expect(getSourceCell(screen.getByRole("row")).textContent).toBe("partner_console");
+  });
+
+  it("includes api in the Production runs source filter", async () => {
+    const user = userEvent.setup();
+    renderRunsTab();
+
+    await user.click(screen.getByLabelText("Filter runs by source"));
+    await screen.findByText("Production runs");
+    await user.click(findSourceSelectOption("Production runs"));
+
+    await waitFor(() => {
+      expect(normalizeSources(mocks.runsQueryCalls.at(-1))).toEqual([
+        "api",
+        "manual",
+        "schedule",
+        "webhook",
+      ]);
+    });
+  });
+});

--- a/apps/gui/src/features/runs/__tests__/runsPageContract.test.ts
+++ b/apps/gui/src/features/runs/__tests__/runsPageContract.test.ts
@@ -301,6 +301,7 @@ describe("RUN-487 canonical /runs page", () => {
 
     await waitFor(() => {
       expect(normalizeSources(mocks.runsQueryCalls.at(-1))).toEqual([
+        "api",
         "manual",
         "schedule",
         "webhook",
@@ -321,6 +322,7 @@ describe("RUN-487 canonical /runs page", () => {
 
     await waitFor(() => {
       expect(normalizeSources(mocks.runsQueryCalls.at(-1))).toEqual([
+        "api",
         "manual",
         "schedule",
         "webhook",
@@ -333,6 +335,7 @@ describe("RUN-487 canonical /runs page", () => {
     const finalRequest = mocks.runsQueryCalls.at(-1);
 
     expect(normalizeSources(finalRequest)).toEqual([
+      "api",
       "manual",
       "schedule",
       "webhook",

--- a/apps/gui/src/features/surface/SurfaceRunRow.tsx
+++ b/apps/gui/src/features/surface/SurfaceRunRow.tsx
@@ -15,7 +15,7 @@ import { AlertTriangle, Info } from "lucide-react";
 import { RegressionTooltipBody } from "@/components/shared/RegressionTooltipBody";
 import { WarningTooltipBody } from "@/components/shared/WarningTooltipBody";
 import { useRunRegressions } from "@/queries/runs";
-import { formatCost, formatDuration, getSourceVariant, getTimeAgo } from "@/utils/formatting";
+import { formatCost, formatDuration, formatRunSource, getSourceVariant, getTimeAgo } from "@/utils/formatting";
 import { formatRegressionTooltip } from "../workflows/regressionBadge.utils";
 import {
   formatWarningTooltip,
@@ -138,7 +138,7 @@ export function SurfaceRunRow({
         {run.run_number != null ? `#${run.run_number}` : "—"}
       </TableCell>
       <TableCell data-type="data" className={RUN_TABLE_CELL_CLASS}>
-        <Badge variant={getSourceVariant(run.source)}>{run.source}</Badge>
+        <Badge variant={getSourceVariant(run.source)}>{formatRunSource(run.source)}</Badge>
       </TableCell>
       <TableCell data-type="timestamp" className={cn(RUN_TABLE_CELL_CLASS, "text-muted")}>
         {run.started_at ? getTimeAgo(new Date(run.started_at * 1000).toISOString()) : "—"}

--- a/apps/gui/src/features/surface/__tests__/run924SurfaceRunInputsHistory.test.tsx
+++ b/apps/gui/src/features/surface/__tests__/run924SurfaceRunInputsHistory.test.tsx
@@ -94,6 +94,18 @@ function getDataRow() {
   return row;
 }
 
+function getCellByColumn(row: HTMLElement, columnName: string): HTMLElement {
+  const headerIndex = screen
+    .getAllByRole("columnheader")
+    .findIndex((header) => header.textContent?.trim() === columnName);
+
+  expect(headerIndex).toBeGreaterThanOrEqual(0);
+  const cell = within(row).getAllByRole("cell")[headerIndex];
+  expect(cell).toBeTruthy();
+
+  return cell;
+}
+
 beforeEach(() => {
   mocks.onRowClick.mockReset();
   mocks.clipboardWriteText.mockReset();
@@ -106,6 +118,33 @@ beforeEach(() => {
 });
 
 describe("RUN-924 surface run input history", () => {
+  it("renders api run history source as API without displaying request provenance metadata", () => {
+    renderSurfaceRunsTable(
+      makeRun({
+        id: "run_api_940",
+        source: "api",
+        source_correlation_id: "req-surface-940",
+        source_metadata: {
+          authorization: "Bearer surface-secret-940",
+          idempotency_key: "idem-surface-940",
+        },
+      } as Partial<RunResponse>),
+    );
+
+    const row = getDataRow();
+    const sourceCell = getCellByColumn(row, "Source");
+    const apiBadge = within(sourceCell).getByText("API");
+
+    expect(sourceCell.textContent).toBe("API");
+    expect(apiBadge.className).toContain("whitespace-nowrap");
+
+    const renderedText = row.textContent ?? "";
+    expect(renderedText).not.toContain("req-surface-940");
+    expect(renderedText).not.toContain("idem-surface-940");
+    expect(renderedText).not.toContain("Bearer");
+    expect(renderedText).not.toContain("surface-secret-940");
+  });
+
   it("shows the stored snapshot preview and ignores later workflow schema defaults", () => {
     renderSurfaceRunsTable(
       makeRun({

--- a/apps/gui/src/queries/runs.ts
+++ b/apps/gui/src/queries/runs.ts
@@ -10,7 +10,7 @@ import { runsApi, type RunContextAuditParams, type RunQueryParams } from "../api
 import { useContextAuditStore } from "../store/contextAudit";
 import { queryKeys } from "./keys";
 
-const PRODUCTION_RUN_SOURCES = new Set(["manual", "webhook", "schedule"]);
+const PRODUCTION_RUN_SOURCES = new Set(["manual", "webhook", "schedule", "api"]);
 
 function hasSameRunMembership(currentRuns: RunResponse[], nextRuns: RunResponse[]) {
   if (currentRuns.length !== nextRuns.length) {
@@ -189,7 +189,7 @@ export function useActiveRuns() {
       ...queryKeys.runs.all,
       {
         status: ["running", "pending"],
-        source: ["manual", "webhook", "schedule"],
+        source: ["manual", "webhook", "schedule", "api"],
         branch: "main",
       },
     ],
@@ -200,6 +200,7 @@ export function useActiveRuns() {
       params.append("source", "manual");
       params.append("source", "webhook");
       params.append("source", "schedule");
+      params.append("source", "api");
       params.append("branch", "main");
       return runsApi.listRuns(params);
     },

--- a/apps/gui/src/utils/__tests__/formatting.test.ts
+++ b/apps/gui/src/utils/__tests__/formatting.test.ts
@@ -5,6 +5,7 @@ import {
   formatTimestamp,
   formatCost,
   getTimeAgo,
+  getSourceVariant,
 } from "../formatting";
 
 // ---------------------------------------------------------------------------
@@ -185,6 +186,19 @@ describe("formatCost", () => {
 
   it("formats sub-milli-cent cost values with more precision", () => {
     expect(formatCost(0.0001132)).toBe("$0.000113");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getSourceVariant
+// ---------------------------------------------------------------------------
+describe("getSourceVariant", () => {
+  it("treats api as a known production source instead of the unknown fallback", () => {
+    expect(getSourceVariant("api")).not.toBe(getSourceVariant("unknown-run-source"));
+  });
+
+  it("keeps unknown run sources on the neutral fallback variant", () => {
+    expect(getSourceVariant("unknown-run-source")).toBe("neutral");
   });
 });
 

--- a/apps/gui/src/utils/formatting.ts
+++ b/apps/gui/src/utils/formatting.ts
@@ -73,6 +73,7 @@ export function getSourceVariant(
   switch (source) {
     case "manual":
       return "neutral";
+    case "api":
     case "webhook":
       return "info";
     case "schedule":
@@ -82,6 +83,11 @@ export function getSourceVariant(
     default:
       return "neutral";
   }
+}
+
+export function formatRunSource(source: string | null | undefined): string {
+  if (!source) return "\u2014";
+  return source === "api" ? "API" : source;
 }
 
 // ── Relative time ───────────────────────────────────────────────────────────

--- a/apps/site/astro.config.mjs
+++ b/apps/site/astro.config.mjs
@@ -122,6 +122,7 @@ export default defineConfig({
 						{ label: 'YAML Schema Reference', slug: 'docs/reference/yaml-schema-reference' },
 						{ label: 'Block Type Reference', slug: 'docs/reference/block-type-reference' },
 						{ label: 'Assertion Reference', slug: 'docs/reference/assertion-reference' },
+						{ label: 'Direct API Invocation', slug: 'docs/reference/direct-api-invocation' },
 						{ label: 'CLI Reference', slug: 'docs/reference/cli-reference' },
 						{ label: 'Unified Entity Identity', slug: 'docs/reference/unified-entity-identity' },
 						{ label: 'Identity ADR', slug: 'docs/reference/unified-entity-identity-adr' },

--- a/apps/site/src/content/docs/docs/evaluation/regressions.md
+++ b/apps/site/src/content/docs/docs/evaluation/regressions.md
@@ -16,7 +16,7 @@ The `EvalService._detect_node_regressions` method compares two matching nodes (s
 | `quality_drop` | `eval_score` dropped by more than 0.1 | `{score_delta: <negative number>}` |
 
 :::note
-Only **production runs** are compared -- runs on the `main` branch with a source of `manual`, `webhook`, or `schedule`. Simulation branches are excluded.
+Only **production runs** are compared -- runs on the `main` branch with a source of `manual`, `api`, `webhook`, or `schedule`. Direct API runs use the shipped `api` source. Webhook and schedule sources are reserved and are not part of RUN-85. Simulation branches are excluded.
 :::
 
 ## How eval_score and eval_passed work
@@ -88,4 +88,4 @@ The regression response schema on the frontend validates three regression types:
 
 The `EvalService.get_attention_items` method scans production runs from the last 24 hours and surfaces regressions as attention items on the dashboard. It flags the same three conditions as the regression endpoints, plus a `new_baseline` info item for the first production run of a soul version. Items are sorted by severity (warnings before info) and recency.
 
-<!-- Linear: RUN-555, RUN-558, RUN-769, RUN-801 -- last verified against codebase 2026-04-10 -->
+<!-- Linear: RUN-555, RUN-558, RUN-769, RUN-801, RUN-943 -- last verified against codebase 2026-04-26 -->

--- a/apps/site/src/content/docs/docs/execution/running-workflows.md
+++ b/apps/site/src/content/docs/docs/execution/running-workflows.md
@@ -3,7 +3,7 @@ title: Running Workflows
 description: Production runs vs simulation runs — how Runsight executes workflows and tracks run history.
 ---
 
-Runsight has two execution modes: **production runs** on the main branch and **simulation runs** on disposable branches. Every run is persisted as a database record with per-block node tracking, parent-child linkage for sub-workflows, and a commit SHA tying the run back to the exact YAML that executed.
+Runsight has two execution modes: **production runs** on the main branch and **simulation runs** on disposable branches. Every run is persisted as a database record with per-block node tracking, parent-child linkage for sub-workflows, and a commit SHA tying the run back to the workflow YAML that executed.
 
 ## Run lifecycle
 
@@ -24,24 +24,22 @@ Terminal states (`completed`, `failed`, `cancelled`) are final --- no further tr
 
 ## Production runs
 
-A production run executes the workflow YAML as committed on the **main branch**. When you click **Run** in the GUI with no unsaved changes, or call the API with `branch: "main"`:
+A production run executes the workflow YAML as committed on the **main branch**.
 
-1. The API reads the workflow YAML from `git show main:custom/workflows/{id}.yaml`.
+Production runs can be started from the GUI when there are no unsaved workflow changes, or through the external Direct API. Direct API invocation uses `POST /api/workflows/{workflow_id}/runs`, always records `source: "api"`, and always resolves `branch: "main"`. Callers cannot supply `source`, `branch`, provenance, delivery, simulation, or idempotency fields in the request body.
+
+When a production run starts:
+
+1. The API resolves the committed `main` workflow YAML for the requested workflow.
 2. A `Run` record is created with `status: pending` and `branch: "main"`.
 3. The execution service acquires a concurrency slot (default: 5 concurrent runs), then transitions the run to `running`.
 4. The engine parses the YAML, builds the workflow graph, and wraps every LLM block in an `IsolatedBlockWrapper` with a `SubprocessHarness`.
 5. Each block executes sequentially through the transition graph. LLM blocks (linear, gate, synthesize, dispatch) run in isolated subprocesses --- the subprocess has no API keys and communicates with the engine over a Unix socket IPC channel. A `RunNode` record is created per block.
 6. On completion, the observer writes `status: completed` with final cost and token totals.
 
-```bash title="API — create a production run"
-curl -X POST http://localhost:8321/api/runs \
-  -H "Content-Type: application/json" \
-  -d '{
-    "workflow_id": "research-pipeline",
-    "inputs": { "topic": "quantum computing trends" },
-    "branch": "main"
-  }'
-```
+Direct API runs ignore dirty working tree edits to workflow YAML and nested workflow YAML. Referenced workflow blocks are resolved through the same committed snapshot. Parser and discovery paths receive the resolved git ref for snapshot-capable workflow assets, while provider settings, server settings, and API keys remain live runtime configuration from the running server environment.
+
+For the exact external HTTP contract, request body, success response, and error codes, see [Direct API Invocation](/docs/reference/direct-api-invocation).
 
 ## Simulation runs
 
@@ -49,7 +47,7 @@ When the workflow has **unsaved changes** (the canvas shows an uncommitted badge
 
 1. The GUI calls `POST /api/git/sim-branch` with the current YAML draft.
 2. A simulation branch is created with the naming convention `sim/{workflow-slug}/{YYYYMMDD}/{short-id}` (e.g., `sim/research-pipeline/20260407/a3f1b`).
-3. The run is created with `branch: "sim/research-pipeline/20260407/a3f1b"` and `source: "manual"`.
+3. The run is created with `branch: "sim/research-pipeline/20260407/a3f1b"` and `source: "simulation"`.
 4. Execution proceeds identically to a production run, but reads the YAML from the sim branch snapshot.
 
 Simulation branches are disposable --- they capture the exact state of the workflow at the time of the run, including any unsaved edits. See [Git Integration](/docs/execution/git-integration) for details on how sim branches work.
@@ -65,7 +63,7 @@ Each run is stored as a `Run` row in the SQLite database with these fields:
 | `workflow_name` | `str` | Human-readable workflow name |
 | `status` | `RunStatus` | Current state (`pending` / `running` / `completed` / `failed` / `cancelled`) |
 | `branch` | `str` | Git branch this run executed against (default: `"main"`) |
-| `source` | `str` | How the run was triggered (default: `"manual"`) |
+| `source` | `str` | How the run was triggered, such as `manual`, `simulation`, or `api` |
 | `commit_sha` | `str?` | Git commit SHA of the YAML that executed |
 | `total_cost_usd` | `float` | Accumulated LLM cost |
 | `total_tokens` | `int` | Accumulated token count |
@@ -98,7 +96,7 @@ Each block execution within a run creates a `RunNode` record:
 When a workflow contains a `workflow` block, the child workflow executes as a nested run. The parent `RunNode` records the `child_run_id`, and the child `Run` stores `parent_run_id`, `root_run_id`, and `depth`. This creates a tree of runs that you can query via the API:
 
 ```bash title="API — list child runs"
-curl http://localhost:8321/api/runs/{parent_run_id}/children
+curl http://localhost:8000/api/runs/{parent_run_id}/children
 ```
 
 The child run response includes `parent_run_id`, `root_run_id`, and `depth` fields so you can reconstruct the full execution tree.
@@ -111,15 +109,17 @@ If the server restarts while runs are in `running` status, those runs become "gh
 
 | Method | How |
 |--------|-----|
-| **GUI** | Click the **Run** button on the canvas topbar. Enter an instruction in the run dialog. |
-| **API** | `POST /api/runs` with `workflow_id`, optional `inputs` (arbitrary JSON), optional `branch` and `source`. |
+| **GUI** | Click the **Run** button on the canvas topbar. Committed clean workflows run on `main`; dirty workflows create a simulation branch. |
+| **Direct API** | `POST /api/workflows/{workflow_id}/runs` with a required body containing only `inputs`. Direct API runs use `source: "api"` and `branch: "main"`. |
 
 :::note
-There is no cron or webhook trigger yet. All runs are currently triggered manually through the GUI or API.
+Webhook and schedule triggers are not part of RUN-85. Runs can be triggered manually through the GUI or externally through the Direct API.
 :::
+
+See [Direct API Invocation](/docs/reference/direct-api-invocation) for the copyable curl example and full request reference.
 
 ## Process isolation
 
 Every LLM block runs in an isolated subprocess. API keys stay in the engine process --- the subprocess proxies all LLM calls through the IPC channel, where budget interceptors enforce cost caps and observer interceptors record traces. This is transparent: workflow YAML and block behavior are unchanged. See [Process Isolation](/docs/execution/process-isolation) for the full architecture.
 
-<!-- Linear: RUN-554, RUN-590, RUN-607, RUN-717, RUN-391 — last verified against codebase 2026-04-11 -->
+<!-- Linear: RUN-554, RUN-590, RUN-607, RUN-717, RUN-391, RUN-943 — last verified against codebase 2026-04-26 -->

--- a/apps/site/src/content/docs/docs/execution/running-workflows.md
+++ b/apps/site/src/content/docs/docs/execution/running-workflows.md
@@ -26,18 +26,18 @@ Terminal states (`completed`, `failed`, `cancelled`) are final --- no further tr
 
 A production run executes the workflow YAML as committed on the **main branch**.
 
-Production runs can be started from the GUI when there are no unsaved workflow changes, or through the external Direct API. Direct API invocation uses `POST /api/workflows/{workflow_id}/runs`, always records `source: "api"`, and always resolves `branch: "main"`. Callers cannot supply `source`, `branch`, provenance, delivery, simulation, or idempotency fields in the request body.
+Production runs can be started from the GUI when there are no unsaved workflow changes, or through the external Direct API. Direct API invocation uses `POST /api/workflows/{workflow_id}/runs`, always records `source: "api"`, always resolves `branch: "main"`, and only runs workflows committed on `main` and explicitly enabled with `enabled: true`. Callers cannot supply `source`, `branch`, provenance, delivery, simulation, or idempotency fields in the request body.
 
 When a production run starts:
 
-1. The API resolves the committed `main` workflow YAML for the requested workflow.
+1. The API resolves the committed `main` workflow YAML for the requested workflow and verifies that the committed snapshot has `enabled: true`.
 2. A `Run` record is created with `status: pending` and `branch: "main"`.
 3. The execution service acquires a concurrency slot (default: 5 concurrent runs), then transitions the run to `running`.
 4. The engine parses the YAML, builds the workflow graph, and wraps every LLM block in an `IsolatedBlockWrapper` with a `SubprocessHarness`.
 5. Each block executes sequentially through the transition graph. LLM blocks (linear, gate, synthesize, dispatch) run in isolated subprocesses --- the subprocess has no API keys and communicates with the engine over a Unix socket IPC channel. A `RunNode` record is created per block.
 6. On completion, the observer writes `status: completed` with final cost and token totals.
 
-Direct API runs ignore dirty working tree edits to workflow YAML and nested workflow YAML. Referenced workflow blocks are resolved through the same committed snapshot. Parser and discovery paths receive the resolved git ref for snapshot-capable workflow assets, while provider settings, server settings, and API keys remain live runtime configuration from the running server environment.
+Direct API runs ignore dirty working tree edits to workflow YAML and nested workflow YAML. Referenced workflow blocks are resolved through the same committed snapshot. Parser and discovery paths receive the resolved git ref for snapshot-capable workflow assets, while provider settings, server settings, and API keys remain live runtime configuration from the running server environment. Omitted `enabled` is treated as disabled for Direct API invocation.
 
 For the exact external HTTP contract, request body, success response, and error codes, see [Direct API Invocation](/docs/reference/direct-api-invocation).
 
@@ -110,7 +110,7 @@ If the server restarts while runs are in `running` status, those runs become "gh
 | Method | How |
 |--------|-----|
 | **GUI** | Click the **Run** button on the canvas topbar. Committed clean workflows run on `main`; dirty workflows create a simulation branch. |
-| **Direct API** | `POST /api/workflows/{workflow_id}/runs` with a required body containing only `inputs`. Direct API runs use `source: "api"` and `branch: "main"`. |
+| **Direct API** | `POST /api/workflows/{workflow_id}/runs` with a required body containing only `inputs`. Direct API runs require a committed `main` workflow with `enabled: true`, and use `source: "api"` and `branch: "main"`. |
 
 :::note
 Webhook and schedule triggers are not part of RUN-85. Runs can be triggered manually through the GUI or externally through the Direct API.

--- a/apps/site/src/content/docs/docs/getting-started/installation.md
+++ b/apps/site/src/content/docs/docs/getting-started/installation.md
@@ -4,10 +4,10 @@ description: Install Runsight via uvx, Docker, or from source for development.
 ---
 
 :::caution
-Runsight's self-hosted API is unauthenticated today. For `uvx runsight`, use
-`--host 127.0.0.1` for local-only access instead of the default `0.0.0.0`. For
-Docker, keep host port publishing on loopback, for example
-`-p 127.0.0.1:8000:8000`, unless you add your own proxy and auth controls.
+Runsight's self-hosted API is unauthenticated today. By default, `uvx runsight`
+binds to `127.0.0.1` for local-only access. For Docker, keep host port
+publishing on loopback, for example `-p 127.0.0.1:8000:8000`, unless you add
+your own proxy and auth controls.
 :::
 
 ## uvx (recommended)
@@ -20,7 +20,7 @@ uvx runsight
 
 This downloads and runs the `runsight` package in an isolated environment. Open [http://localhost:8000](http://localhost:8000).
 
-For loopback-only local use:
+To bind loopback explicitly:
 
 ```bash
 uvx runsight --host 127.0.0.1
@@ -40,7 +40,7 @@ runsight [--host HOST] [--port PORT]
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `--host` | `0.0.0.0` | Bind address |
+| `--host` | `127.0.0.1` | Bind address |
 | `--port` | `8000` | Bind port |
 
 ## Docker
@@ -62,6 +62,10 @@ workspace in the named volume `workspace_data`, and adds a healthcheck at `/heal
 If you want your current directory to be the workspace instead, use the `docker run`
 command above or edit `docker-compose.yml` to replace the named volume with a bind
 mount.
+
+The Dockerfile may bind to `0.0.0.0` inside the container. Host port publishing
+should still use `127.0.0.1` unless the service is intentionally exposed behind
+your own network and authentication controls.
 
 ### What the container does
 
@@ -169,4 +173,4 @@ tied to commit SHAs.
 If git is not available, the API server will start but git-dependent features (save,
 commit, simulation branches, fork recovery) will fail.
 
-<!-- Linear: RUN-821, RUN-847, RUN-848, RUN-944 — last verified against codebase 2026-04-26 -->
+<!-- Linear: RUN-821, RUN-847, RUN-848, RUN-944, RUN-943 — last verified against codebase 2026-04-26 -->

--- a/apps/site/src/content/docs/docs/reference/cli-reference.md
+++ b/apps/site/src/content/docs/docs/reference/cli-reference.md
@@ -96,7 +96,7 @@ unless you add your own proxy or authentication controls.
 The default Docker `CMD` is `["runsight"]`. Override it to pass flags:
 
 ```bash
-docker run -p 127.0.0.1:3000:3000 runsight runsight --port 3000
+docker run -p 127.0.0.1:3000:3000 runsight runsight --host 0.0.0.0 --port 3000
 ```
 
 <!-- Linear: RUN-821, RUN-847, RUN-848, RUN-944, RUN-943 — last verified against codebase 2026-04-26 -->

--- a/apps/site/src/content/docs/docs/reference/cli-reference.md
+++ b/apps/site/src/content/docs/docs/reference/cli-reference.md
@@ -32,7 +32,7 @@ runsight [--host HOST] [--port PORT]
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
-| `--host` | `str` | `0.0.0.0` | Bind address for the server |
+| `--host` | `str` | `127.0.0.1` | Bind address for the server |
 | `--port` | `int` | `8000` | Bind port for the server |
 | `--help`, `-h` | -- | -- | Print usage information and exit |
 
@@ -41,7 +41,7 @@ Unknown arguments cause the CLI to print an error and exit with code 1.
 ## Examples
 
 ```bash
-# Start with defaults (0.0.0.0:8000)
+# Start with defaults (127.0.0.1:8000)
 uvx runsight
 
 # Custom port
@@ -49,6 +49,9 @@ uvx runsight --port 3000
 
 # Bind to localhost only
 uvx runsight --host 127.0.0.1 --port 9000
+
+# Bind to all interfaces only when protected by your own network and auth controls
+uvx runsight --host 0.0.0.0 --port 8000
 ```
 
 On startup, the CLI prints:
@@ -96,7 +99,7 @@ The default Docker `CMD` is `["runsight"]`. Override it to pass flags:
 docker run -p 127.0.0.1:3000:3000 runsight runsight --port 3000
 ```
 
-<!-- Linear: RUN-821, RUN-847, RUN-848, RUN-944 — last verified against codebase 2026-04-26 -->
+<!-- Linear: RUN-821, RUN-847, RUN-848, RUN-944, RUN-943 — last verified against codebase 2026-04-26 -->
 
 ## Requirements
 

--- a/apps/site/src/content/docs/docs/reference/direct-api-invocation.md
+++ b/apps/site/src/content/docs/docs/reference/direct-api-invocation.md
@@ -4,6 +4,8 @@ description: Reference for invoking Runsight workflows through the external Dire
 ---
 
 Direct API invocation creates a production workflow run through an external HTTP request.
+The requested workflow must exist in the committed `main` workflow snapshot and requires `enabled: true`.
+Omitting `enabled` is treated the same as `enabled: false`, so a user must explicitly enable the workflow before it is externally invokable.
 
 ## Endpoint
 
@@ -13,7 +15,7 @@ POST /api/workflows/{workflow_id}/runs
 
 | Path parameter | Type | Required | Description |
 |----------------|------|----------|-------------|
-| `workflow_id` | string | Yes | Workflow ID to run. The server resolves the committed `main` workflow snapshot for this workflow. |
+| `workflow_id` | string | Yes | Workflow ID to run. The server resolves the committed `main` workflow snapshot for this workflow and only invokes it when the snapshot has `enabled: true`. |
 
 ## Request body
 
@@ -110,11 +112,11 @@ Runsight reads correlation IDs from request headers.
 
 ## Workflow snapshot resolution
 
-Direct API always resolves the committed `main` workflow snapshot.
+Direct API always resolves the committed `main` workflow snapshot and requires that snapshot to be enabled.
 
 | Runtime asset | Resolution behavior |
 |---------------|---------------------|
-| Workflow YAML | Committed `main` snapshot |
+| Workflow YAML | Committed `main` snapshot with `enabled: true` |
 | Nested workflow YAML | Committed `main` snapshot through the resolved git ref |
 | Snapshot-capable workflow asset discovery | Receives the resolved git ref from the execution runtime |
 | Provider settings | Live server runtime configuration |
@@ -156,7 +158,7 @@ The Dockerfile command may bind to `0.0.0.0` inside the container. Host publishi
 
 | Status | Code | Description |
 |--------|------|-------------|
-| `404` | `WORKFLOW_NOT_FOUND` | The workflow ID does not resolve to a workflow. |
+| `404` | `WORKFLOW_NOT_FOUND` | The workflow ID does not resolve to a workflow, or the committed `main` workflow snapshot is not enabled. |
 | `413` | `REQUEST_BODY_TOO_LARGE` | The request body exceeds `RUNSIGHT_EXTERNAL_INVOCATION_BODY_LIMIT_BYTES`. |
 | `422` | `WORKFLOW_INPUT_VALIDATION_ERROR` | The body shape is invalid, privileged fields are present, required inputs are missing, or input types do not match. |
 | `429` | `ADMISSION_SATURATED` | Runtime admission limits are saturated. |

--- a/apps/site/src/content/docs/docs/reference/direct-api-invocation.md
+++ b/apps/site/src/content/docs/docs/reference/direct-api-invocation.md
@@ -1,0 +1,193 @@
+---
+title: Direct API Invocation
+description: Reference for invoking Runsight workflows through the external Direct API.
+---
+
+Direct API invocation creates a production workflow run through an external HTTP request.
+
+## Endpoint
+
+```http
+POST /api/workflows/{workflow_id}/runs
+```
+
+| Path parameter | Type | Required | Description |
+|----------------|------|----------|-------------|
+| `workflow_id` | string | Yes | Workflow ID to run. The server resolves the committed `main` workflow snapshot for this workflow. |
+
+## Request body
+
+The request body is required and strict. It must contain only `inputs`.
+
+```json
+{
+  "inputs": {
+    "topic": "quantum computing trends"
+  }
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `inputs` | object | Yes | Workflow input values. May be empty when the workflow has no required inputs. |
+
+No other request body fields are accepted.
+
+## Example request
+
+```bash title="Invoke a workflow through the Direct API"
+curl -X POST http://localhost:8000/api/workflows/research-pipeline/runs \
+  -H "Content-Type: application/json" \
+  -H "x-request-id: req_01HTZK7V9QK4K4Z8Z9J4Z4Z4Z4" \
+  -d '{
+    "inputs": {
+      "topic": "quantum computing trends"
+    }
+  }'
+```
+
+The `x-request-id` header is optional. When present, Runsight records it as the run source correlation ID.
+
+## Rejected request body fields
+
+Direct API callers must not send privileged execution, provenance, delivery, simulation, or idempotency fields in the JSON body.
+
+Examples of rejected fields:
+
+| Field |
+|-------|
+| `workflow_id` |
+| `source` |
+| `branch` |
+| `commit_sha` |
+| `debug` |
+| `simulation` |
+| `simulation_id` |
+| `simulation_branch` |
+| `idempotency_key` |
+| `idempotency_token` |
+| `trigger` |
+| `trigger_id` |
+| `delivery` |
+| `delivery_id` |
+| `provenance` |
+| `source_metadata` |
+| `source_correlation_id` |
+| `caller` |
+
+Unsupported or privileged request body fields are rejected with `422 WORKFLOW_INPUT_VALIDATION_ERROR`.
+
+## Success response
+
+A successful Direct API invocation returns `200` with a `RunResponse`.
+
+`200` means run creation or launch was accepted. Workflow execution continues in the background, and the run may later be pending, running, failed, or completed.
+
+The response uses the server run response schema and includes the created run details, including server-authored values such as `source: "api"` and `branch: "main"`.
+
+## Server-authored fields
+
+Direct API always sets these run properties on the server.
+
+| Property | Value | Caller-controlled |
+|----------|-------|-------------------|
+| `source` | `api` | No |
+| `branch` | `main` | No |
+| `source_metadata.entry_path` | `direct_api` | No |
+| `source_metadata.request_path` | Request path | No |
+| `source_correlation_id` | From request headers | Headers only |
+
+## Correlation headers
+
+Runsight reads correlation IDs from request headers.
+
+| Header | Description |
+|--------|-------------|
+| `x-request-id` | Request correlation ID |
+| `x-correlation-id` | Alternate request correlation ID |
+
+`source_correlation_id` cannot be supplied in the request body.
+
+## Workflow snapshot resolution
+
+Direct API always resolves the committed `main` workflow snapshot.
+
+| Runtime asset | Resolution behavior |
+|---------------|---------------------|
+| Workflow YAML | Committed `main` snapshot |
+| Nested workflow YAML | Committed `main` snapshot through the resolved git ref |
+| Snapshot-capable workflow asset discovery | Receives the resolved git ref from the execution runtime |
+| Provider settings | Live server runtime configuration |
+| Server settings | Live server runtime configuration |
+| API keys and credentials | Live server environment or configuration |
+
+Dirty working tree edits to workflow YAML and nested workflow YAML are ignored by Direct API runs. Do not rely on dirty working tree edits for Direct API workflow definitions.
+
+## Configuration
+
+Environment variables use the `RUNSIGHT_` prefix.
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `RUNSIGHT_EXTERNAL_INVOCATION_ENABLED` | `true` | Enables external Direct API invocation. |
+| `RUNSIGHT_PUBLIC_BASE_URL` | unset | Optional public base URL for external invocation contexts. |
+| `RUNSIGHT_EXTERNAL_INVOCATION_BODY_LIMIT_BYTES` | `1048576` | Maximum Direct API request body size in bytes. |
+| `RUNSIGHT_MAX_CONCURRENT_RUNS` | `5` | Maximum concurrent workflow runs. |
+| `RUNSIGHT_MAX_PENDING_EXTERNAL_INVOCATIONS` | `32` | Maximum queued pending external invocations. |
+
+## Host binding defaults
+
+The default host is `127.0.0.1`.
+
+:::caution
+Runsight's self-hosted API is unauthenticated today. Keep host binding and Docker port publishing on loopback unless you intentionally expose the service behind your own proxy and authentication controls.
+:::
+
+Docker compose publishes the API on host loopback:
+
+```yaml title="docker-compose.yml"
+ports:
+  - "127.0.0.1:8000:8000"
+```
+
+The Dockerfile command may bind to `0.0.0.0` inside the container. Host publishing examples should still bind to loopback unless you intentionally expose the service.
+
+## Error responses
+
+| Status | Code | Description |
+|--------|------|-------------|
+| `404` | `WORKFLOW_NOT_FOUND` | The workflow ID does not resolve to a workflow. |
+| `413` | `REQUEST_BODY_TOO_LARGE` | The request body exceeds `RUNSIGHT_EXTERNAL_INVOCATION_BODY_LIMIT_BYTES`. |
+| `422` | `WORKFLOW_INPUT_VALIDATION_ERROR` | The body shape is invalid, privileged fields are present, required inputs are missing, or input types do not match. |
+| `429` | `ADMISSION_SATURATED` | Runtime admission limits are saturated. |
+| `503` | `RUNTIME_UNAVAILABLE` | The workflow runtime is unavailable or external invocation is disabled. |
+
+Direct API request and workflow input validation failures use `422`, not `400`.
+
+## Idempotency
+
+Direct API invocation in RUN-85 does not provide idempotency support.
+
+| Input | Behavior |
+|-------|----------|
+| `x-idempotency-key` header | Not persisted, exposed, or used for deduplication |
+| Request body idempotency fields | Rejected with `422 WORKFLOW_INPUT_VALIDATION_ERROR` |
+
+## Redaction and metadata filtering
+
+Runsight redacts sensitive workflow input values by omitting the value from stored and returned `workflow_inputs` payloads.
+
+`source_metadata` is server-authored for Direct API runs. Unsafe metadata keys are rejected or dropped. Accepted responses, detail responses, list responses, and stored payloads must not leak authorization data, raw sensitive input values, or unsupported idempotency fields.
+
+## Availability of other external sources
+
+Webhook and schedule invocation are not part of RUN-85.
+
+| Source | Availability |
+|--------|--------------|
+| `api` | Shipped production source |
+| `manual` | Shipped production source |
+| `webhook` | Not part of RUN-85 |
+| `schedule` | Not part of RUN-85 |
+
+<!-- Linear: RUN-943 — last verified against codebase 2026-04-26 -->

--- a/openapi.json
+++ b/openapi.json
@@ -1059,6 +1059,67 @@
         }
       }
     },
+    "/api/workflows/{workflow_id}/runs": {
+      "post": {
+        "tags": [
+          "Workflows"
+        ],
+        "summary": "Create Direct Api Run",
+        "operationId": "create_direct_api_run_api_workflows__workflow_id__runs_post",
+        "parameters": [
+          {
+            "name": "workflow_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Workflow Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DirectApiRunCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RunResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Workflow not found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowInputValidationErrorResponse"
+                }
+              }
+            },
+            "description": "Unprocessable Content"
+          },
+          "429": {
+            "description": "External invocation admission is saturated"
+          },
+          "503": {
+            "description": "Execution runtime is unavailable"
+          }
+        }
+      }
+    },
     "/api/workflows/{id}/regressions": {
       "get": {
         "tags": [
@@ -2857,6 +2918,21 @@
         ],
         "title": "DiffResponse"
       },
+      "DirectApiRunCreate": {
+        "properties": {
+          "inputs": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Inputs"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "inputs"
+        ],
+        "title": "DirectApiRunCreate"
+      },
       "EvalDelta": {
         "properties": {
           "cost_pct": {
@@ -3473,15 +3549,22 @@
             "default": "manual"
           },
           "branch": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Branch"
           }
         },
         "additionalProperties": false,
         "type": "object",
         "required": [
-          "workflow_id",
-          "branch"
+          "workflow_id"
         ],
         "title": "RunCreate"
       },
@@ -3888,6 +3971,22 @@
               }
             ],
             "title": "Commit Sha"
+          },
+          "source_correlation_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Correlation Id"
+          },
+          "source_metadata": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Source Metadata"
           },
           "run_number": {
             "anyOf": [

--- a/openapi.json
+++ b/openapi.json
@@ -1099,7 +1099,14 @@
             }
           },
           "404": {
-            "description": "Workflow not found"
+            "description": "Workflow not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           },
           "422": {
             "content": {
@@ -1112,10 +1119,34 @@
             "description": "Unprocessable Content"
           },
           "429": {
-            "description": "External invocation admission is saturated"
+            "description": "External invocation admission is saturated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           },
           "503": {
-            "description": "Execution runtime is unavailable"
+            "description": "Execution runtime is unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "Request body too large",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       }
@@ -2932,6 +2963,41 @@
           "inputs"
         ],
         "title": "DirectApiRunCreate"
+      },
+      "ErrorResponse": {
+        "properties": {
+          "error": {
+            "type": "string",
+            "title": "Error"
+          },
+          "error_code": {
+            "type": "string",
+            "title": "Error Code"
+          },
+          "status_code": {
+            "type": "integer",
+            "title": "Status Code"
+          },
+          "details": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Details"
+          }
+        },
+        "type": "object",
+        "required": [
+          "error",
+          "error_code",
+          "status_code"
+        ],
+        "title": "ErrorResponse"
       },
       "EvalDelta": {
         "properties": {

--- a/packages/core/src/runsight_core/yaml/parser.py
+++ b/packages/core/src/runsight_core/yaml/parser.py
@@ -454,7 +454,7 @@ def _validate_declared_tool_definitions(
             continue
 
         expected_file = Path(base_dir) / "custom" / "tools" / f"{tool_id}.yaml"
-        if expected_file.exists():
+        if git_ref is None and expected_file.exists():
             result.add_error(
                 (
                     f"reserved builtin tool id '{tool_id}' collides with custom tool metadata at "

--- a/packages/shared/src/__tests__/run901_workflow_input_contracts.test.ts
+++ b/packages/shared/src/__tests__/run901_workflow_input_contracts.test.ts
@@ -56,13 +56,13 @@ function extractComponentBlock(
 }
 
 describe("RUN-901 shared workflow input contracts", () => {
-  it("RunCreateSchema requires branch and defaults omitted inputs to an empty object", () => {
+  it("RunCreateSchema accepts branch when provided and defaults omitted inputs to an empty object", () => {
     const schema = getSchema("RunCreateSchema");
 
     const parsed = schema.parse({
       workflow_id: "wf_901",
       branch: "main",
-    }) as { workflow_id: string; branch: string; inputs?: Record<string, unknown> };
+    }) as { workflow_id: string; branch?: string | null; inputs?: Record<string, unknown> };
 
     expect(parsed.workflow_id).toBe("wf_901");
     expect(parsed.branch).toBe("main");
@@ -216,12 +216,12 @@ describe("RUN-901 shared workflow input contracts", () => {
     expect(workflowResponseFields).toEqual(expect.arrayContaining(["input_schema"]));
   });
 
-  it("generated OpenAPI TS keeps only defaulted RunCreate fields optional for callers", () => {
+  it("generated OpenAPI TS keeps defaulted and nullable RunCreate fields optional for callers", () => {
     const runCreateBlock = extractComponentBlock(apiSource, "RunCreate", "RunEvalResponse");
 
     expect(runCreateBlock).toMatch(/\binputs\?:/);
     expect(runCreateBlock).toMatch(/\bsource\?:/);
-    expect(runCreateBlock).toMatch(/\bbranch:/);
+    expect(runCreateBlock).toMatch(/\bbranch\?: string \| null;/);
   });
 
   it("committed OpenAPI includes a workflow input validation error schema with structured fields", () => {

--- a/packages/shared/src/__tests__/run935_direct_api_contracts.test.ts
+++ b/packages/shared/src/__tests__/run935_direct_api_contracts.test.ts
@@ -89,6 +89,17 @@ function extractOperationBlock(source: string, operationName: string): string {
   return match?.[0] ?? "";
 }
 
+function extractResponseStatusBlock(operationBlock: string, status: string): string {
+  const pattern = new RegExp(
+    `\\n\\s{12}${status}: \\{[\\s\\S]*?(?=\\n\\s{12}\\d{3}: \\{|\\n\\s{8}\\};)`,
+  );
+  const match = operationBlock.match(pattern);
+
+  expect(match, `Expected generated Direct API operation to include ${status}`).not.toBeNull();
+
+  return match?.[0] ?? "";
+}
+
 function assertOnlyInputs(fields: string[]): void {
   expect(fields.sort()).toEqual(["inputs"]);
   for (const field of FORBIDDEN_EXTERNAL_FIELDS) {
@@ -125,6 +136,26 @@ describe("RUN-935 generated Direct API shared contracts", () => {
     expect(operation?.post?.responses).toHaveProperty("503");
   });
 
+  it("committed OpenAPI snapshot models Direct API errors as structured JSON", () => {
+    const operation = openapi.paths?.[DIRECT_API_PATH] as {
+      post?: {
+        responses?: Record<
+          string,
+          { content?: { "application/json"?: { schema?: unknown } } }
+        >;
+      };
+    } | undefined;
+
+    for (const status of ["404", "429", "503", "413"]) {
+      const jsonContent = operation?.post?.responses?.[status]?.content?.["application/json"];
+
+      expect(
+        jsonContent?.schema,
+        `Expected ${status} on POST ${DIRECT_API_PATH} to declare application/json content`,
+      ).toBeDefined();
+    }
+  });
+
   it("committed OpenAPI snapshot keeps the external Direct API body to inputs only", () => {
     const schema = openapi.components?.schemas?.DirectApiRunCreate;
     expect(schema, "Expected committed openapi.json to include DirectApiRunCreate").toBeDefined();
@@ -148,6 +179,20 @@ describe("RUN-935 generated Direct API shared contracts", () => {
     );
     expect(operationBlock).toContain('"application/json": components["schemas"]["RunResponse"]');
     expect(operationBlock).not.toContain('"application/json": components["schemas"]["RunCreate"]');
+  });
+
+  it("generated api.ts exposes structured JSON for Direct API error responses", () => {
+    const pathBlock = extractPathBlock(apiSource, DIRECT_API_PATH);
+    const operationName = pathBlock.match(/post: operations\["([^"]+)"\]/)?.[1];
+    const operationBlock = extractOperationBlock(apiSource, operationName ?? "");
+
+    for (const status of ["404", "429", "503", "413"]) {
+      const responseBlock = extractResponseStatusBlock(operationBlock, status);
+
+      expect(responseBlock).toContain("content: {");
+      expect(responseBlock).toContain('"application/json":');
+      expect(responseBlock).not.toContain("content?: never");
+    }
   });
 
   it("generated api.ts declares DirectApiRunCreate as inputs only and keeps RunCreate distinct", () => {

--- a/packages/shared/src/__tests__/run935_direct_api_contracts.test.ts
+++ b/packages/shared/src/__tests__/run935_direct_api_contracts.test.ts
@@ -1,0 +1,228 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import * as sharedZod from "@runsight/shared/zod";
+import { describe, expect, it } from "vitest";
+
+const SHARED_SRC = resolve(__dirname, "..");
+const REPO_ROOT = resolve(__dirname, "..", "..", "..", "..");
+const DIRECT_API_PATH = "/api/workflows/{workflow_id}/runs";
+const FORBIDDEN_EXTERNAL_FIELDS = [
+  "source",
+  "branch",
+  "commit_sha",
+  "debug",
+  "simulation",
+  "simulation_id",
+  "simulation_branch",
+  "trigger_id",
+  "delivery_id",
+  "idempotency_key",
+  "idempotency_token",
+  "caller",
+  "source_correlation_id",
+  "source_metadata",
+  "provenance",
+];
+
+const apiSource = readFileSync(resolve(SHARED_SRC, "api.ts"), "utf8");
+const openapi = JSON.parse(readFileSync(resolve(REPO_ROOT, "openapi.json"), "utf8")) as {
+  paths?: Record<string, unknown>;
+  components?: { schemas?: Record<string, Record<string, unknown>> };
+};
+
+type ParseableSchema = {
+  parse: (input: unknown) => unknown;
+  safeParse: (input: unknown) => { success: boolean };
+  shape: Record<string, unknown>;
+};
+
+function getSchema(name: string): ParseableSchema {
+  const schema = (sharedZod as Record<string, unknown>)[name];
+
+  expect(
+    schema && typeof (schema as { parse?: unknown }).parse === "function",
+    `Expected ${name} to be exported from @runsight/shared/zod`,
+  ).toBe(true);
+
+  return schema as ParseableSchema;
+}
+
+function extractComponentFieldNames(source: string, componentName: string): string[] {
+  const pattern = new RegExp(
+    `\\/\\*\\* ${componentName} \\*\\/\\s*${componentName}: \\{([\\s\\S]*?)\\n\\s+\\};`,
+  );
+  const match = source.match(pattern);
+
+  expect(match, `Expected generated api.ts to declare ${componentName}`).not.toBeNull();
+
+  return (match?.[1] ?? "")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const fieldMatch = line.match(/^([A-Za-z0-9_]+)\??:/);
+      return fieldMatch?.[1] ?? null;
+    })
+    .filter((field): field is string => field !== null);
+}
+
+function extractPathBlock(source: string, path: string): string {
+  const startMarker = `    "${path}": {`;
+  const start = source.indexOf(startMarker);
+  expect(start, `Expected generated api.ts paths to include ${path}`).toBeGreaterThanOrEqual(
+    0,
+  );
+
+  const nextPath = source.indexOf('\n    "', start + startMarker.length);
+  const end = nextPath === -1 ? source.indexOf("\nexport type", start) : nextPath;
+  return source.slice(start, end);
+}
+
+function extractOperationBlock(source: string, operationName: string): string {
+  const pattern = new RegExp(
+    `\\n\\s{4}${operationName}: \\{[\\s\\S]*?(?=\\n\\s{4}[A-Za-z0-9_]+: \\{|\\n\\};)`,
+  );
+  const match = source.match(pattern);
+
+  expect(match, `Expected generated api.ts operations to include ${operationName}`).not.toBeNull();
+
+  return match?.[0] ?? "";
+}
+
+function assertOnlyInputs(fields: string[]): void {
+  expect(fields.sort()).toEqual(["inputs"]);
+  for (const field of FORBIDDEN_EXTERNAL_FIELDS) {
+    expect(fields).not.toContain(field);
+  }
+}
+
+function assertSourceEnumIfModeled(sourceProperty: unknown): void {
+  const enumValues = (sourceProperty as { enum?: unknown[] } | undefined)?.enum;
+  if (Array.isArray(enumValues)) {
+    expect(enumValues).toEqual(expect.arrayContaining(["manual", "simulation", "api"]));
+  }
+}
+
+describe("RUN-935 generated Direct API shared contracts", () => {
+  it("committed OpenAPI snapshot includes the workflow-scoped Direct API route", () => {
+    const operation = openapi.paths?.[DIRECT_API_PATH] as {
+      post?: {
+        requestBody?: { content?: { "application/json"?: { schema?: { $ref?: string } } } };
+        responses?: Record<string, unknown>;
+      };
+    } | undefined;
+
+    expect(
+      operation?.post,
+      `Expected committed openapi.json to include POST ${DIRECT_API_PATH}`,
+    ).toBeDefined();
+
+    const schemaRef = operation?.post?.requestBody?.content?.["application/json"]?.schema?.$ref;
+    expect(schemaRef).toBe("#/components/schemas/DirectApiRunCreate");
+    expect(operation?.post?.responses).toHaveProperty("200");
+    expect(operation?.post?.responses).toHaveProperty("422");
+    expect(operation?.post?.responses).toHaveProperty("429");
+    expect(operation?.post?.responses).toHaveProperty("503");
+  });
+
+  it("committed OpenAPI snapshot keeps the external Direct API body to inputs only", () => {
+    const schema = openapi.components?.schemas?.DirectApiRunCreate;
+    expect(schema, "Expected committed openapi.json to include DirectApiRunCreate").toBeDefined();
+
+    const properties = (schema?.properties ?? {}) as Record<string, unknown>;
+    assertOnlyInputs(Object.keys(properties));
+    expect(schema?.additionalProperties).toBe(false);
+  });
+
+  it("generated api.ts exposes the Direct API path with a distinct request component", () => {
+    const pathBlock = extractPathBlock(apiSource, DIRECT_API_PATH);
+    const operationName = pathBlock.match(/post: operations\["([^"]+)"\]/)?.[1];
+    expect(
+      operationName,
+      `Expected generated path ${DIRECT_API_PATH} to expose a post operation`,
+    ).toBeDefined();
+
+    const operationBlock = extractOperationBlock(apiSource, operationName ?? "");
+    expect(operationBlock).toContain(
+      '"application/json": components["schemas"]["DirectApiRunCreate"]',
+    );
+    expect(operationBlock).toContain('"application/json": components["schemas"]["RunResponse"]');
+    expect(operationBlock).not.toContain('"application/json": components["schemas"]["RunCreate"]');
+  });
+
+  it("generated api.ts declares DirectApiRunCreate as inputs only and keeps RunCreate distinct", () => {
+    const directApiFields = extractComponentFieldNames(apiSource, "DirectApiRunCreate");
+    const manualRunFields = extractComponentFieldNames(apiSource, "RunCreate");
+
+    assertOnlyInputs(directApiFields);
+    expect(manualRunFields).toEqual(
+      expect.arrayContaining(["workflow_id", "inputs", "source", "branch"]),
+    );
+  });
+
+  it("generated Zod exports validate the external Direct API DTO as inputs only", () => {
+    const schema = getSchema("DirectApiRunCreateSchema");
+
+    expect(Object.keys(schema.shape).sort()).toEqual(["inputs"]);
+    expect(schema.parse({ inputs: { query: "from api" } })).toEqual({
+      inputs: { query: "from api" },
+    });
+
+    for (const field of FORBIDDEN_EXTERNAL_FIELDS) {
+      expect(
+        schema.safeParse({ inputs: { query: "from api" }, [field]: "caller-owned" }).success,
+        `DirectApiRunCreateSchema must reject caller-owned field ${field}`,
+      ).toBe(false);
+    }
+  });
+
+  it("generated RunResponse contracts expose sanitized provenance fields", () => {
+    const apiFields = extractComponentFieldNames(apiSource, "RunResponse");
+    const schema = getSchema("RunResponseSchema");
+    const openapiRunResponse = openapi.components?.schemas?.RunResponse;
+    const openapiProperties = (openapiRunResponse?.properties ?? {}) as Record<string, unknown>;
+    const provenanceFields = [
+      "source",
+      "commit_sha",
+      "source_correlation_id",
+      "source_metadata",
+    ];
+
+    expect(apiFields).toEqual(expect.arrayContaining(provenanceFields));
+    expect(Object.keys(schema.shape)).toEqual(expect.arrayContaining(provenanceFields));
+    expect(Object.keys(openapiProperties)).toEqual(expect.arrayContaining(provenanceFields));
+    assertSourceEnumIfModeled(openapiProperties.source);
+
+    const parsed = schema.parse({
+      id: "run_935",
+      workflow_id: "wf_935",
+      workflow_name: "Direct API contract",
+      status: "pending",
+      started_at: null,
+      completed_at: null,
+      duration_seconds: null,
+      total_cost_usd: 0,
+      total_tokens: 0,
+      created_at: 1711900935,
+      branch: "main",
+      source: "api",
+      commit_sha: "9359359359359359359359359359359359359359",
+      source_correlation_id: "request-run-935",
+      source_metadata: { entry_path: "direct_api" },
+    }) as {
+      source: string;
+      commit_sha?: string | null;
+      source_correlation_id?: string | null;
+      source_metadata?: Record<string, unknown>;
+    };
+
+    expect(parsed.source).toBe("api");
+    expect(parsed.commit_sha).toBe("9359359359359359359359359359359359359359");
+    expect(parsed.source_correlation_id).toBe("request-run-935");
+    expect(parsed.source_metadata).toEqual({ entry_path: "direct_api" });
+  });
+
+  it("does not recreate generated GUI contracts under the product app", () => {
+    expect(existsSync(resolve(REPO_ROOT, "apps", "gui", "src", "types", "generated"))).toBe(false);
+  });
+});

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -264,6 +264,23 @@ export interface paths {
         patch: operations["patch_workflow_enabled_api_workflows__id__enabled_patch"];
         trace?: never;
     };
+    "/api/workflows/{workflow_id}/runs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create Direct Api Run */
+        post: operations["create_direct_api_run_api_workflows__workflow_id__runs_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/workflows/{id}/regressions": {
         parameters: {
             query?: never;
@@ -930,6 +947,13 @@ export interface components {
             /** Diff */
             diff: string;
         };
+        /** DirectApiRunCreate */
+        DirectApiRunCreate: {
+            /** Inputs */
+            inputs: {
+                [key: string]: unknown;
+            };
+        };
         /** EvalDelta */
         EvalDelta: {
             /** Cost Pct */
@@ -1131,16 +1155,14 @@ export interface components {
              * Inputs
              * @default {}
              */
-            inputs?: {
-                [key: string]: unknown;
-            };
+            inputs?: Record<string, unknown>;
             /**
              * Source
              * @default manual
              */
             source?: string | null;
             /** Branch */
-            branch: string;
+            branch?: string | null;
         };
         /** RunEvalResponse */
         RunEvalResponse: {
@@ -1265,6 +1287,10 @@ export interface components {
             source: string;
             /** Commit Sha */
             commit_sha?: string | null;
+            /** Source Correlation Id */
+            source_correlation_id?: string | null;
+            /** Source Metadata */
+            source_metadata?: Record<string, unknown>;
             /** Run Number */
             run_number?: number | null;
             /** Eval Pass Pct */
@@ -1294,13 +1320,9 @@ export interface components {
              */
             depth: number;
             /** Workflow Inputs */
-            workflow_inputs?: {
-                [key: string]: unknown;
-            } | null;
+            workflow_inputs?: Record<string, unknown> | null;
             /** Workflow Input Schema */
-            workflow_input_schema?: {
-                [key: string]: unknown;
-            } | null;
+            workflow_input_schema?: Record<string, unknown> | null;
         };
         /** SettingsFallbackListResponse */
         SettingsFallbackListResponse: {
@@ -2528,6 +2550,62 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
                 };
+            };
+        };
+    };
+    create_direct_api_run_api_workflows__workflow_id__runs_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workflow_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["DirectApiRunCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RunResponse"];
+                };
+            };
+            /** @description Workflow not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unprocessable Content */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WorkflowInputValidationErrorResponse"];
+                };
+            };
+            /** @description External invocation admission is saturated */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Execution runtime is unavailable */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -954,6 +954,19 @@ export interface components {
                 [key: string]: unknown;
             };
         };
+        /** ErrorResponse */
+        ErrorResponse: {
+            /** Error */
+            error: string;
+            /** Error Code */
+            error_code: string;
+            /** Status Code */
+            status_code: number;
+            /** Details */
+            details?: {
+                [key: string]: unknown;
+            } | null;
+        };
         /** EvalDelta */
         EvalDelta: {
             /** Cost Pct */
@@ -2582,7 +2595,18 @@ export interface operations {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Request body too large */
+            413: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
             };
             /** @description Unprocessable Content */
             422: {
@@ -2598,14 +2622,18 @@ export interface operations {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
             };
             /** @description Execution runtime is unavailable */
             503: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
             };
         };
     };

--- a/packages/shared/src/zod.ts
+++ b/packages/shared/src/zod.ts
@@ -137,6 +137,14 @@ export const DirectApiRunCreateSchema = z.object({
 }).strict();
 export type DirectApiRunCreate = z.infer<typeof DirectApiRunCreateSchema>;
 
+export const ErrorResponseSchema = z.object({
+  error: z.string(),
+  error_code: z.string(),
+  status_code: z.number(),
+  details: z.record(z.string(), z.unknown()).nullable().optional(),
+});
+export type ErrorResponse = z.infer<typeof ErrorResponseSchema>;
+
 export const EvalDeltaSchema = z.object({
   cost_pct: z.number(),
   tokens_pct: z.number(),

--- a/packages/shared/src/zod.ts
+++ b/packages/shared/src/zod.ts
@@ -132,6 +132,11 @@ export const DiffResponseSchema = z.object({
 });
 export type DiffResponse = z.infer<typeof DiffResponseSchema>;
 
+export const DirectApiRunCreateSchema = z.object({
+  inputs: z.record(z.string(), z.unknown()),
+}).strict();
+export type DirectApiRunCreate = z.infer<typeof DirectApiRunCreateSchema>;
+
 export const EvalDeltaSchema = z.object({
   cost_pct: z.number(),
   tokens_pct: z.number(),
@@ -274,7 +279,7 @@ export const RunCreateSchema = z.object({
   workflow_id: z.string(),
   inputs: z.record(z.string(), z.unknown()).optional().default({}),
   source: z.string().nullable().optional().default("manual"),
-  branch: z.string(),
+  branch: z.string().nullable().optional(),
 }).strict();
 export type RunCreate = z.infer<typeof RunCreateSchema>;
 
@@ -308,6 +313,8 @@ export const RunResponseSchema = z.object({
   branch: z.string(),
   source: z.string().optional().default("manual"),
   commit_sha: z.string().nullable().optional(),
+  source_correlation_id: z.string().nullable().optional(),
+  source_metadata: z.record(z.string(), z.unknown()).optional(),
   run_number: z.number().nullable().optional(),
   eval_pass_pct: z.number().nullable().optional(),
   eval_score_avg: z.number().nullable().optional(),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runsight-workspace"
-version = "0.4.26"
+version = "0.5.0"
 requires-python = ">=3.11"
 dependencies = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runsight-workspace"
-version = "0.4.19"
+version = "0.4.20"
 requires-python = ">=3.11"
 dependencies = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runsight-workspace"
-version = "0.4.25"
+version = "0.4.26"
 requires-python = ">=3.11"
 dependencies = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runsight-workspace"
-version = "0.4.24"
+version = "0.4.25"
 requires-python = ">=3.11"
 dependencies = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runsight-workspace"
-version = "0.4.21"
+version = "0.4.22"
 requires-python = ">=3.11"
 dependencies = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runsight-workspace"
-version = "0.4.23"
+version = "0.4.24"
 requires-python = ">=3.11"
 dependencies = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runsight-workspace"
-version = "0.4.22"
+version = "0.4.23"
 requires-python = ">=3.11"
 dependencies = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runsight-workspace"
-version = "0.4.20"
+version = "0.4.21"
 requires-python = ">=3.11"
 dependencies = []
 

--- a/tools/generate-types.sh
+++ b/tools/generate-types.sh
@@ -45,6 +45,43 @@ for old, new in replacements.items():
     if old not in block:
         raise SystemExit(f"RunCreate generated contract missing expected field: {old}")
     block = block.replace(old, new, 1)
+inputs_record = """            inputs?: {
+                [key: string]: unknown;
+            };"""
+if inputs_record not in block:
+    raise SystemExit("RunCreate generated contract missing expected inputs record shape")
+block = block.replace(inputs_record, "            inputs?: Record<string, unknown>;", 1)
+path.write_text(source[:start] + block + source[end:])
+PY
+
+# Keep generated response map fields compact so component field extraction in
+# contract tests can see fields that follow them.
+uv run python - "$GENERATED_DIR/api.ts" << 'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+source = path.read_text()
+start_marker = "        /** RunResponse */\n        RunResponse: {"
+end_marker = "        /** SettingsFallbackListResponse */"
+start = source.index(start_marker)
+end = source.index(end_marker, start)
+block = source[start:end]
+replacements = {
+    """            source_metadata?: {
+                [key: string]: unknown;
+            };""": "            source_metadata?: Record<string, unknown>;",
+    """            workflow_inputs?: {
+                [key: string]: unknown;
+            } | null;""": "            workflow_inputs?: Record<string, unknown> | null;",
+    """            workflow_input_schema?: {
+                [key: string]: unknown;
+            } | null;""": "            workflow_input_schema?: Record<string, unknown> | null;",
+}
+for old, new in replacements.items():
+    if old not in block:
+        raise SystemExit(f"RunResponse generated contract missing expected map field: {old}")
+    block = block.replace(old, new, 1)
 path.write_text(source[:start] + block + source[end:])
 PY
 

--- a/uv.lock
+++ b/uv.lock
@@ -2088,7 +2088,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "runsight-workspace"
-version = "0.4.25"
+version = "0.4.26"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -2088,7 +2088,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "runsight-workspace"
-version = "0.4.16"
+version = "0.4.22"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -2088,7 +2088,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "runsight-workspace"
-version = "0.4.23"
+version = "0.4.24"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -2088,7 +2088,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "runsight-workspace"
-version = "0.4.22"
+version = "0.4.23"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -2088,7 +2088,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "runsight-workspace"
-version = "0.4.26"
+version = "0.5.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -2088,7 +2088,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "runsight-workspace"
-version = "0.4.24"
+version = "0.4.25"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- Adds workflow-scoped Direct API invocation via `POST /api/workflows/{workflow_id}/runs` with strict `{ inputs }` request body.
- Server-authors API provenance (`source="api"`, `branch="main"`, correlation metadata), committed-main snapshot execution, explicit enabled-workflow gating, route-scoped body limits, admission guardrails, and structured sanitized errors.
- Wires `api` as a production run source across backend read models, GUI filters/badges, generated shared contracts, OpenAPI, and docs.
- Bumps root workspace version to `0.5.0`.

## Related
- Linear: RUN-85, RUN-930, RUN-931, RUN-932, RUN-934, RUN-935, RUN-940, RUN-941, RUN-943, RUN-944
- GitHub issues: no matching RUN-85 / Direct API issue found in `runsight-ai/runsight`.

## Verification
- `uv run pytest -q apps/api/tests/test_run941_direct_api_integration.py apps/api/tests/transport/test_run932_direct_api_invocation_route.py` -> 35 passed
- `uv run pytest -q apps/api/tests/logic/test_run931_workflow_run_invoker.py apps/api/tests/logic/test_run944_trigger_runtime_guardrails.py apps/api/tests/transport/test_runs_router.py apps/api/tests/test_run85_docs_contracts.py` -> 51 passed
- `uv run pytest -q apps/api/tests/domain/test_run930_run_provenance_foundation.py apps/api/tests/data/test_run930_run_provenance_read_model.py apps/api/tests/data/test_run934_api_provenance_read_model.py apps/api/tests/transport/test_run934_api_run_provenance_responses.py apps/api/tests/transport/test_run944_trigger_transport_guardrails.py apps/api/tests/test_run944_runtime_config.py` -> 27 passed
- `pnpm -C apps/gui test:unit src/features/runs/__tests__/run940ApiSourceUi.test.tsx` -> 6 passed
- `pnpm -C packages/shared test:unit src/__tests__/run935_direct_api_contracts.test.ts` -> 9 passed
- Related GUI tests rerun solo -> 70 passed
- `uv run ruff check apps/api packages/core` -> passed
- `pnpm -C apps/gui run lint` -> passed
- `pnpm -C packages/shared run lint` -> passed
- `pnpm -C packages/shared run typecheck` -> passed
- `pnpm -C packages/shared run check:types-fresh` -> passed
- `git diff --check` -> passed

## Post-Epic Gates
- Amber: CLEAN
- Crimson: PASS (no Critical/High findings; one LOW accepted deployment exposure note for unauthenticated invocation when enabled on non-loopback deployments)
- Final Blue: APPROVE
- Final Yellow: ALIGNED

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds workflow-scoped Direct API invocation (RUN-85) via POST /api/workflows/{workflow_id}/runs with strict { inputs }, production provenance, and strong guardrails. Enforces committed main snapshot (enabled workflows), validates the snapshot workflow ID against YAML, and hardens legacy SQLite backfill to safely add provenance indexes.

- New Features
  - Endpoint: POST /api/workflows/{workflow_id}/runs accepts only { inputs }. Requires enabled committed main snapshot and pins commit_sha.
  - Provenance: source="api" on main with source_correlation_id and sanitized, size-capped source_metadata (secrets redacted). Reserved-source checks prevent forging.
  - Guardrails: admission limits (max concurrent + pending), route-scoped body size limit, structured errors, and background task release on completion.
  - Surfaces: GUI treats api as a production source (badges, filters); hides sensitive provenance. Eval/dashboard include api.
  - Contracts/Docs: adds DirectApiRunCreate and ErrorResponse to OpenAPI and `packages/shared`; new Direct API reference docs.

- Migration
  - Database: Alembic migration 004 adds run provenance columns and indexes; legacy SQLite backfill guards missing columns and creates safe provenance indexes when supported.
  - Settings (env prefix RUNSIGHT_): external_invocation_enabled, public_base_url, external_invocation_body_limit_bytes, max_concurrent_runs, max_pending_external_invocations.
  - Defaults: CLI binds to 127.0.0.1 by default; Docker CMD binds 0.0.0.0.
  - Version: workspace bumped to 0.5.0.

<sup>Written for commit 4dee094ac7e998e6a94a94df2e37a0746266ee54. Summary will update on new commits. <a href="https://cubic.dev/pr/runsight-ai/runsight/pull/76?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

