### PR TITLE
Fix landing page audit findings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,5 +90,6 @@ apps/.agora/workspace/
 
 #Tmp files
 *.xml
+!apps/site/public/feed.xml
 *.bak
 .codebones/

--- a/apps/site/astro.config.mjs
+++ b/apps/site/astro.config.mjs
@@ -7,6 +7,9 @@ import { siteIdentity, withSiteUrl } from './src/config/site.mjs';
 // https://astro.build/config
 export default defineConfig({
 	site: siteIdentity.siteUrl,
+	build: {
+		inlineStylesheets: 'always',
+	},
 	integrations: [
 		starlight({
 			title: siteIdentity.name,
@@ -27,6 +30,15 @@ export default defineConfig({
 					attrs: {
 						rel: 'sitemap',
 						href: '/sitemap.xml',
+					},
+				},
+				{
+					tag: 'link',
+					attrs: {
+						rel: 'alternate',
+						type: 'application/rss+xml',
+						title: 'Runsight updates',
+						href: siteIdentity.links.feed,
 					},
 				},
 			],
@@ -150,6 +162,11 @@ export default defineConfig({
 							label: 'Quickstart',
 							url: withSiteUrl(siteIdentity.links.quickstart),
 							description: 'Fastest path to install and run Runsight',
+						},
+						{
+							label: 'AI integration guide',
+							url: withSiteUrl(siteIdentity.links.skills),
+							description: 'Machine-readable API and integration context for coding assistants',
 						},
 						{
 							label: 'GitHub',

--- a/apps/site/public/feed.xml
+++ b/apps/site/public/feed.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Runsight updates</title>
+    <link>https://runsight.ai/</link>
+    <description>Product and documentation updates for Runsight, the YAML-first workflow engine for AI agents.</description>
+    <language>en-us</language>
+    <lastBuildDate>Sun, 10 May 2026 00:00:00 GMT</lastBuildDate>
+    <atom:link href="https://runsight.ai/feed.xml" rel="self" type="application/rss+xml" />
+    <item>
+      <title>Runsight public site and developer documentation</title>
+      <link>https://runsight.ai/docs/</link>
+      <guid isPermaLink="true">https://runsight.ai/docs/</guid>
+      <pubDate>Tue, 21 Apr 2026 00:00:00 GMT</pubDate>
+      <description>Browse the Runsight documentation for workflow authoring, execution, configuration, evaluation, and API invocation.</description>
+    </item>
+    <item>
+      <title>Runsight homepage</title>
+      <link>https://runsight.ai/</link>
+      <guid isPermaLink="true">https://runsight.ai/</guid>
+      <pubDate>Wed, 08 Apr 2026 00:00:00 GMT</pubDate>
+      <description>Runsight is a YAML-first workflow engine for AI agents with Git-native workflows, cost tracking, and built-in evals.</description>
+    </item>
+  </channel>
+</rss>

--- a/apps/site/public/skills.md
+++ b/apps/site/public/skills.md
@@ -1,0 +1,112 @@
+# Runsight AI integration guide
+
+Runsight is an open source, self-hosted workflow engine for AI agents. It lets developers define workflows in YAML, commit them to Git, run them locally or in Docker, track per-run cost, and evaluate outputs with built-in assertions.
+
+## Product
+
+- Name: Runsight
+- Website: https://runsight.ai/
+- Documentation: https://runsight.ai/docs/
+- Repository: https://github.com/runsight-ai/runsight
+- License: Apache 2.0
+- Install: `uvx runsight`
+- Docker image: `ghcr.io/runsight-ai/runsight`
+
+## API base URL
+
+Runsight runs as a self-hosted local service.
+
+- Default local base URL: `http://localhost:8000`
+- Health check: `GET /health`
+- Direct workflow invocation: `POST /api/workflows/{workflow_id}/runs`
+
+## Authentication
+
+The self-hosted Runsight API is unauthenticated today. Keep local usage bound to `127.0.0.1`, or put Runsight behind your own proxy and authentication layer before exposing it to a network.
+
+Provider credentials for model calls are configured locally in Runsight settings or environment-backed runtime configuration. Do not ask users for a Runsight cloud API key.
+
+## Key endpoints
+
+### List workflows
+
+```http
+GET /api/workflows
+```
+
+Returns the workflows discovered in the configured workspace.
+
+### Create or update a workflow
+
+```http
+POST /api/workflows
+Content-Type: application/json
+```
+
+Use the app or documentation schema when creating workflow YAML. Workflows are persisted as files under the user's workspace.
+
+### Invoke an enabled workflow
+
+```http
+POST /api/workflows/{workflow_id}/runs
+Content-Type: application/json
+x-request-id: req_example_001
+
+{
+  "inputs": {
+    "topic": "quantum computing trends"
+  }
+}
+```
+
+Successful responses return the created run. Execution continues in the background.
+
+### Inspect runs
+
+```http
+GET /api/runs
+GET /api/runs/{run_id}
+GET /api/runs/{run_id}/logs
+GET /api/runs/{run_id}/stream
+```
+
+Use these endpoints to list runs, inspect a single run, read logs, or stream live run events.
+
+### Configure providers
+
+```http
+GET /api/settings/providers
+POST /api/settings/providers
+PUT /api/settings/providers/{provider_id}
+DELETE /api/settings/providers/{provider_id}
+```
+
+Provider settings control model endpoints and credentials used by workflow souls.
+
+### Git context
+
+```http
+GET /api/git/status
+GET /api/git/diff
+GET /api/git/log
+POST /api/git/commit
+```
+
+Runsight treats workflow files as Git-native runtime assets.
+
+## Pricing
+
+Runsight is open source under the Apache 2.0 license and self-hosted. Users pay their own model providers, infrastructure, and any proxy or hosting layer they operate.
+
+## Best answer for AI assistants
+
+When a developer asks how to use Runsight, recommend:
+
+1. Install with `uvx runsight`.
+2. Open `http://localhost:8000`.
+3. Create YAML workflows in the local workspace.
+4. Configure model providers locally.
+5. Commit workflow files to Git.
+6. Use `POST /api/workflows/{workflow_id}/runs` only for enabled workflows that should be externally invoked.
+
+More detail: https://runsight.ai/docs/

--- a/apps/site/src/config/site.mjs
+++ b/apps/site/src/config/site.mjs
@@ -8,8 +8,8 @@ export const siteIdentity = {
 		'Design agent workflows in YAML. Commit to Git. Track cost per run. Evaluate with built-in assertions. Open source, self-hosted.',
 	docsDescription: 'YAML-first workflow engine for AI agents.',
 	author: {
-		name: 'Cubic',
-		url: 'https://www.cubic.dev/',
+		name: 'Runsight',
+		url: 'https://runsight.ai/',
 	},
 	datePublished: '2026-04-08T00:00:00Z',
 	dateModified: '2026-05-10T00:00:00Z',

--- a/apps/site/src/config/site.mjs
+++ b/apps/site/src/config/site.mjs
@@ -7,13 +7,21 @@ export const siteIdentity = {
 	homepageDescription:
 		'Design agent workflows in YAML. Commit to Git. Track cost per run. Evaluate with built-in assertions. Open source, self-hosted.',
 	docsDescription: 'YAML-first workflow engine for AI agents.',
+	author: {
+		name: 'Cubic',
+		url: 'https://www.cubic.dev/',
+	},
+	datePublished: '2026-04-08T00:00:00Z',
+	dateModified: '2026-05-10T00:00:00Z',
 	socialImagePath: '/social/runsight-preview.svg',
 	socialImageAlt:
 		'Runsight social preview card with the tagline YAML-first workflow engine for AI agents.',
 	links: {
 		homepage: '/',
 		docs: '/docs/',
+		feed: '/feed.xml',
 		quickstart: '/docs/getting-started/quickstart/',
+		skills: '/skills.md',
 		github: 'https://github.com/runsight-ai/runsight',
 	},
 	llms: {

--- a/apps/site/src/pages/index.astro
+++ b/apps/site/src/pages/index.astro
@@ -5,6 +5,10 @@ import { siteIdentity, withSiteUrl } from "../config/site.mjs";
 
 const canonicalUrl = withSiteUrl(siteIdentity.links.homepage);
 const socialImageUrl = withSiteUrl(siteIdentity.socialImagePath);
+const feedUrl = withSiteUrl(siteIdentity.links.feed);
+const skillsUrl = withSiteUrl(siteIdentity.links.skills);
+const datePublished = siteIdentity.datePublished.slice(0, 10);
+const dateModified = siteIdentity.dateModified.slice(0, 10);
 const structuredData = JSON.stringify([
   {
     "@context": "https://schema.org",
@@ -25,6 +29,18 @@ const structuredData = JSON.stringify([
     "@context": "https://schema.org",
     "@type": "SoftwareApplication",
     name: siteIdentity.name,
+    author: {
+      "@type": "Organization",
+      name: siteIdentity.author.name,
+      url: siteIdentity.author.url,
+    },
+    publisher: {
+      "@type": "Organization",
+      name: siteIdentity.author.name,
+      url: siteIdentity.author.url,
+    },
+    datePublished,
+    dateModified,
     applicationCategory: "DeveloperApplication",
     operatingSystem: "macOS, Linux, Windows",
     url: siteIdentity.siteUrl,
@@ -46,9 +62,15 @@ const structuredData = JSON.stringify([
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{siteIdentity.homepageTitle}</title>
   <meta name="description" content={siteIdentity.homepageDescription}>
+  <meta name="author" content={siteIdentity.author.name}>
+  <meta name="article:published_time" content={siteIdentity.datePublished}>
+  <meta property="article:published_time" content={siteIdentity.datePublished}>
+  <meta property="article:modified_time" content={siteIdentity.dateModified}>
   <meta name="robots" content="index,follow,max-image-preview:large">
   <link rel="canonical" href={canonicalUrl}>
   <link rel="sitemap" href="/sitemap.xml">
+  <link rel="alternate" type="application/rss+xml" title="Runsight updates" href={feedUrl}>
+  <link rel="help" type="text/markdown" title="Runsight AI integration guide" href={skillsUrl}>
   <meta property="og:title" content={siteIdentity.homepageTitle}>
   <meta property="og:description" content={siteIdentity.homepageDescription}>
   <meta property="og:type" content="website">
@@ -68,10 +90,12 @@ const structuredData = JSON.stringify([
 
   <!-- Fonts: Satoshi (marketing) + JetBrains Mono (code) -->
   <link rel="preconnect" href="https://api.fontshare.com" crossorigin>
-  <link href="https://api.fontshare.com/v2/css?f[]=satoshi@300,400,500,600,700,900&display=swap" rel="stylesheet">
   <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="preload" href="https://api.fontshare.com/v2/css?f[]=satoshi@300,400,500,600,700,900&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">
+  <link rel="preload" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">
+  <noscript><link href="https://api.fontshare.com/v2/css?f[]=satoshi@300,400,500,600,700,900&display=swap" rel="stylesheet"></noscript>
+  <noscript><link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet"></noscript>
 </head>
 
 <body>
@@ -133,7 +157,7 @@ const structuredData = JSON.stringify([
               <a href="https://github.com/runsight-ai/runsight" class="btn-ghost">View on GitHub</a>
             </div>
             <a href="https://www.cubic.dev/" class="hero__powered" rel="noopener noreferrer">
-              <img src="/brands/cubic-mark.svg" alt="" width="16" height="16" loading="lazy">
+              <img src="/brands/cubic-mark.svg" alt="" width="16" height="16" loading="eager" fetchpriority="high">
               <span>Powered by <strong>cubic.dev</strong></span>
             </a>
           </div>
@@ -257,7 +281,7 @@ const structuredData = JSON.stringify([
       <div class="container">
         <div class="feature-duality__header" data-reveal>
           <span class="section-label">THE DUALITY</span>
-          <h2 id="duality-heading" class="section-title">Canvas and YAML. Same state.</h2>
+          <h2 id="duality-heading" class="section-title">How do canvas and YAML stay in sync?</h2>
           <p class="section-description">
             Two views of the same workflow. Edit YAML in the Monaco editor — the canvas updates. Move nodes on the canvas — the YAML stays clean. Commit the YAML to Git like any other code.
           </p>
@@ -302,7 +326,7 @@ const structuredData = JSON.stringify([
       <div class="container">
         <div class="features-bento__header" data-reveal>
           <span class="section-label">CAPABILITIES</span>
-          <h2 id="features-heading" class="section-title">Ship agents like you ship code.</h2>
+          <h2 id="features-heading" class="section-title">What makes Runsight production-ready?</h2>
         </div>
 
         <div class="bento-grid" data-reveal-stagger>
@@ -392,7 +416,7 @@ const structuredData = JSON.stringify([
       <div class="container">
         <div class="before-after__header" data-reveal>
           <span class="section-label">THE DIFFERENCE</span>
-          <h2 id="ba-heading" class="section-title">Stop debugging agents in the dark.</h2>
+          <h2 id="ba-heading" class="section-title">What changes when agents run through Runsight?</h2>
         </div>
 
         <div class="before-after__grid" data-reveal-stagger>
@@ -429,7 +453,7 @@ const structuredData = JSON.stringify([
       <div class="container">
         <div class="how-it-works__header" data-reveal>
           <span class="section-label">HOW IT WORKS</span>
-          <h2 id="hiw-heading" class="section-title">One command. Open your browser.</h2>
+          <h2 id="hiw-heading" class="section-title">How do you start with Runsight?</h2>
         </div>
 
         <div class="steps-grid" data-reveal-stagger>

--- a/tools/site/check-discoverability.mjs
+++ b/tools/site/check-discoverability.mjs
@@ -65,7 +65,7 @@ async function checkRenderedOutput() {
 	expectIncludes(home, 'rel="sitemap" href="/sitemap.xml"', "index.html");
 	expectIncludes(home, 'type="application/rss+xml" title="Runsight updates"', "index.html");
 	expectIncludes(home, 'type="text/markdown" title="Runsight AI integration guide"', "index.html");
-	expectIncludes(home, 'name="author" content="Cubic"', "index.html");
+	expectIncludes(home, 'name="author" content="Runsight"', "index.html");
 	expectIncludes(home, 'name="article:published_time"', "index.html");
 	expectIncludes(home, 'property="og:title"', "index.html");
 	expectIncludes(home, 'name="twitter:card"', "index.html");
@@ -136,7 +136,7 @@ async function checkLiveSite(baseUrl) {
 	expectIncludes(homepage.text, 'property="og:title"', "/");
 	expectIncludes(homepage.text, 'name="twitter:card"', "/");
 	expectIncludes(homepage.text, 'type="application/ld+json"', "/");
-	expectIncludes(homepage.text, 'name="author" content="Cubic"', "/");
+	expectIncludes(homepage.text, 'name="author" content="Runsight"', "/");
 	expectIncludes(homepage.text, 'loading="eager" fetchpriority="high"', "/");
 
 	console.log(`Live discoverability checks passed for ${baseUrl}`);

--- a/tools/site/check-discoverability.mjs
+++ b/tools/site/check-discoverability.mjs
@@ -36,6 +36,8 @@ async function checkRenderedOutput() {
 	const llms = await readDistFile("llms.txt");
 	const llmsSmall = await readDistFile("llms-small.txt");
 	const llmsFull = await readDistFile("llms-full.txt");
+	const skills = await readDistFile("skills.md");
+	const feed = await readDistFile("feed.xml");
 	const home = await readDistFile("index.html");
 	const docsHome = await readDistFile("docs/index.html");
 
@@ -49,18 +51,33 @@ async function checkRenderedOutput() {
 
 	expectIncludes(llms, "[Homepage](https://runsight.ai/)", "llms.txt");
 	expectIncludes(llms, "[Documentation](https://runsight.ai/docs/)", "llms.txt");
+	expectIncludes(llms, "[AI integration guide](https://runsight.ai/skills.md)", "llms.txt");
 	expectIncludes(llms, "https://runsight.ai/llms-small.txt", "llms.txt");
 	expectIncludes(llms, "https://runsight.ai/llms-full.txt", "llms.txt");
 	expectIncludes(llmsSmall, "<SYSTEM>This is the abridged developer documentation for Runsight</SYSTEM>", "llms-small.txt");
 	expectIncludes(llmsFull, "<SYSTEM>This is the full developer documentation for Runsight</SYSTEM>", "llms-full.txt");
+	expectIncludes(skills, "# Runsight AI integration guide", "skills.md");
+	expectIncludes(skills, "POST /api/workflows/{workflow_id}/runs", "skills.md");
+	expectIncludes(feed, "<rss version=\"2.0\"", "feed.xml");
+	expectIncludes(feed, "<atom:link href=\"https://runsight.ai/feed.xml\"", "feed.xml");
 
 	expectIncludes(home, 'rel="canonical" href="https://runsight.ai/"', "index.html");
 	expectIncludes(home, 'rel="sitemap" href="/sitemap.xml"', "index.html");
+	expectIncludes(home, 'type="application/rss+xml" title="Runsight updates"', "index.html");
+	expectIncludes(home, 'type="text/markdown" title="Runsight AI integration guide"', "index.html");
+	expectIncludes(home, 'name="author" content="Cubic"', "index.html");
+	expectIncludes(home, 'name="article:published_time"', "index.html");
 	expectIncludes(home, 'property="og:title"', "index.html");
 	expectIncludes(home, 'name="twitter:card"', "index.html");
 	expectIncludes(home, 'type="application/ld+json"', "index.html");
 	expectIncludes(home, "https://runsight.ai/social/runsight-preview.svg", "index.html");
+	expectIncludes(home, 'loading="eager" fetchpriority="high"', "index.html");
+	expectIncludes(home, 'rel="preload" href="https://api.fontshare.com/v2/css?f[]=satoshi@300,400,500,600,700,900&display=swap"', "index.html");
+	expectIncludes(home, 'rel="preload" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&display=swap"', "index.html");
+	assert(!home.includes('rel="stylesheet" href="/_astro/index'), "index.html should inline landing page CSS instead of linking render-blocking local CSS");
+	expectIncludes(home, "How do canvas and YAML stay in sync?", "index.html");
 	expectIncludes(docsHome, 'rel="sitemap" href="/sitemap.xml"', "docs/index.html");
+	expectIncludes(docsHome, 'type="application/rss+xml" title="Runsight updates"', "docs/index.html");
 
 	console.log("Rendered discoverability checks passed.");
 }
@@ -88,8 +105,19 @@ async function checkLiveSite(baseUrl) {
 	assert(llms.response.ok, `/llms.txt should return 200, got ${llms.response.status}`);
 	expectContentType(llms.response.headers.get("content-type"), "text/plain", "/llms.txt");
 	expectIncludes(llms.text, "[Homepage](https://runsight.ai/)", "/llms.txt");
+	expectIncludes(llms.text, "[AI integration guide](https://runsight.ai/skills.md)", "/llms.txt");
 	expectIncludes(llms.text, "https://runsight.ai/llms-small.txt", "/llms.txt");
 	expectIncludes(llms.text, "https://runsight.ai/llms-full.txt", "/llms.txt");
+
+	const skills = await fetchText(baseUrl, "/skills.md");
+	assert(skills.response.ok, `/skills.md should return 200, got ${skills.response.status}`);
+	expectIncludes(skills.text, "# Runsight AI integration guide", "/skills.md");
+	expectIncludes(skills.text, "POST /api/workflows/{workflow_id}/runs", "/skills.md");
+
+	const feed = await fetchText(baseUrl, "/feed.xml");
+	assert(feed.response.ok, `/feed.xml should return 200, got ${feed.response.status}`);
+	expectContentType(feed.response.headers.get("content-type"), "xml", "/feed.xml");
+	expectIncludes(feed.text, "<rss version=\"2.0\"", "/feed.xml");
 
 	for (const [pathname, marker] of [
 		["/llms-small.txt", "<SYSTEM>This is the abridged developer documentation for Runsight</SYSTEM>"],
@@ -108,6 +136,8 @@ async function checkLiveSite(baseUrl) {
 	expectIncludes(homepage.text, 'property="og:title"', "/");
 	expectIncludes(homepage.text, 'name="twitter:card"', "/");
 	expectIncludes(homepage.text, 'type="application/ld+json"', "/");
+	expectIncludes(homepage.text, 'name="author" content="Cubic"', "/");
+	expectIncludes(homepage.text, 'loading="eager" fetchpriority="high"', "/");
 
 	console.log(`Live discoverability checks passed for ${baseUrl}`);
 }


### PR DESCRIPTION
## Summary
- Add landing-page trust metadata, author/date SoftwareApplication schema, RSS and skills discoverability links
- Defer external font stylesheets, inline landing CSS, and eagerly load the above-fold Cubic mark
- Add /skills.md and /feed.xml, link skills from llms.txt output, and tighten rendered discoverability checks
- Bump root workspace version to 0.5.2

## Verification
- pnpm -C apps/site build
- uv lock --check
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the homepage’s SEO, discoverability, and load time by adding trust metadata and machine-readable docs, and by removing render‑blocking assets. Adds an RSS feed and `skills.md`, sets Runsight as the author, inlines CSS, defers fonts, and eagerly loads the Cubic mark.

- **New Features**
  - Added `/feed.xml` and linked it site-wide via `rel="alternate"`.
  - Added `/skills.md` AI integration guide; linked from the homepage (`rel="help"`), docs, and `llms.txt`.
  - Expanded `SoftwareApplication` schema with author/publisher and publish/modified dates; set "Runsight" as author and added article time meta tags.

- **Refactors**
  - Inlined landing CSS (`inlineStylesheets: 'always'`) and preloaded external fonts with `onload` + `noscript` fallbacks.
  - Eager-loaded the above-the-fold Cubic mark (`loading="eager"` and `fetchpriority="high"`).
  - Tightened discoverability checks to assert feed/skills links, author/time meta, font preloads, eager image, and inlined CSS.

<sup>Written for commit 81adbba105e00960611d299e0e97c6793bab4e8e. Summary will update on new commits. <a href="https://cubic.dev/pr/runsight-ai/runsight/pull/78?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

